### PR TITLE
shoot: #337 Actions 版本升級 + #346 auto-shoot 流程修正

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,11 +43,11 @@ jobs:
     steps:
       # ── 1. Checkout 原始碼 ──────────────────────────────────
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # ── 2. 設定 Node.js 環境 ────────────────────────────────
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -73,7 +73,7 @@ jobs:
 
       # ── 6. 上傳測試結果 Artifact ───────────────────────────
       - name: Upload Playwright test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         # 無論測試成功或失敗，均上傳報告（方便排查問題）
         if: always()
         with:
@@ -83,7 +83,7 @@ jobs:
 
       # ── 7. 上傳 Playwright traces（失敗時）────────────────
       - name: Upload test traces on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-traces-${{ github.ref_name }}

--- a/.github/workflows/new-issue-intake.yml
+++ b/.github/workflows/new-issue-intake.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install unzip (no sudo)
         run: |

--- a/.github/workflows/sprint-dispatch.yml
+++ b/.github/workflows/sprint-dispatch.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       # Step 1：checkout 目標 repo
       - name: Checkout target repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.target_repo }}
           token: ${{ secrets.GH_TOKEN }}

--- a/skills/cruise/SKILL.md
+++ b/skills/cruise/SKILL.md
@@ -399,8 +399,9 @@ for each issue in issues:
     SPRINT_CANDIDATES += issue.number
     log action: "sprint-candidate #<issue.number>"
 
-# 回傳結果
-# actionable_issues: 供主 loop auto-shoot 派遣
+# 回傳結果（#346：close 與 auto-shoot 分開回傳）
+# close_issues: PO 已直接 close 的 Issue（不走 shoot）
+# actionable_issues: 供主 loop invoke shikigami:shoot 派遣（必須走完整 shoot 流程）
 # sprint_candidates: 供主 loop Sprint Planning 觸發判斷
 ```
 
@@ -427,11 +428,24 @@ SHOOT_FLAG **只防併發，不防連續**。shoot 完成後立即檢查下一�
 
 ```bash
 # 偽碼：shoot 完成後立即 re-check（在主 loop 內）
+#
+# 重要（#346）：auto-shoot 與 close 的區分
+#   - auto-shoot（有程式碼修改）→ 必須 invoke shikigami:shoot（完整 QA gates）
+#   - close（已修復結案）→ 直接 gh issue close，不走 shoot
+#   - 禁止直接派 Developer Agent 跳過 shoot 流程
+
+# Step 1：先處理 close 處置（不走 shoot，直接關閉）
+for ISSUE in CLOSE_ISSUES:
+  gh issue close ${ISSUE} -R ${OWNER_REPO} --comment "<結案理由>"
+  log: "close #${ISSUE}"
+
+# Step 2：連續 auto-shoot（走完整 /shoot 流程）
 while ACTIONABLE_ISSUES is not empty:
   if SHOOT_FLAG 不存在:
     ISSUE = ACTIONABLE_ISSUES.shift()  # 取出第一個
     echo "$ISSUE" > SHOOT_FLAG
-    派遣 shoot agent（/shoot #${ISSUE}）
+    # !! 必須 invoke shikigami:shoot，不是派 Developer Agent !!
+    invoke shikigami:shoot with args=#${ISSUE}  # 完整 QA + Architect + PR + CI Gate
     等待 shoot 完成
     if shoot 成功:
       rm -f SHOOT_FLAG


### PR DESCRIPTION
## Summary

Closes #337, Closes #346

### #337: GitHub Actions 版本升級
- `actions/checkout` v4 → v6（3 個 workflow）
- `actions/setup-node` v4 → v6（e2e.yml）
- `actions/upload-artifact` v4 → v7（e2e.yml）

### #346: auto-shoot 流程修正
- auto-shoot 偽碼明確使用 `invoke shikigami:shoot`（完整 QA gates）
- close 處置與 auto-shoot 處置分開（close 不走 shoot）
- 禁止直接派 Developer Agent 跳過 shoot 流程

## QA 審查
- CI/CD 雙審查 Gate: PASS（QA regression + SRE infra）
- 向後相容性確認：所有 action 參數無 breaking change

## Test plan
- [ ] new-issue-intake workflow 正常觸發（actions/checkout@v6）
- [ ] sprint-dispatch workflow 正常 checkout（actions/checkout@v6）
- [ ] e2e workflow 正常執行（setup-node@v6 + upload-artifact@v7）

🤖 Generated with [Claude Code](https://claude.com/claude-code)