### PR TITLE
fix: #350 回退 actions v6/v7 → v4（node24 不相容迴歸）

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,11 +43,11 @@ jobs:
     steps:
       # ── 1. Checkout 原始碼 ──────────────────────────────────
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       # ── 2. 設定 Node.js 環境 ────────────────────────────────
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
@@ -73,7 +73,7 @@ jobs:
 
       # ── 6. 上傳測試結果 Artifact ───────────────────────────
       - name: Upload Playwright test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         # 無論測試成功或失敗，均上傳報告（方便排查問題）
         if: always()
         with:
@@ -83,7 +83,7 @@ jobs:
 
       # ── 7. 上傳 Playwright traces（失敗時）────────────────
       - name: Upload test traces on failure
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-traces-${{ github.ref_name }}

--- a/.github/workflows/new-issue-intake.yml
+++ b/.github/workflows/new-issue-intake.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install unzip (no sudo)
         run: |

--- a/.github/workflows/sprint-dispatch.yml
+++ b/.github/workflows/sprint-dispatch.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       # Step 1：checkout 目標 repo
       - name: Checkout target repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.target_repo }}
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #350

#337 升級 actions/checkout@v6 造成 CI 全紅 — self-hosted runner (v2.322.0) 僅支援 node20，v6 需要 node24。回退所有 actions 至 v4。

## Changes
- actions/checkout v6 → v4（3 個 workflow）
- actions/setup-node v6 → v4（e2e.yml）
- actions/upload-artifact v7 → v4（e2e.yml）

## Test plan
- [ ] CI run 恢復正常（不再 ArgumentOutOfRangeException）

🤖 Generated with [Claude Code](https://claude.com/claude-code)