### PR TITLE
feat: Sprint 118 #376 #374 #375 — Epic 防護 + Cruise/OAuth 可配置化

### DIFF
--- a/.claude/shikigami.local.md
+++ b/.claude/shikigami.local.md
@@ -13,6 +13,10 @@ shikigami:
   feedback_routing:
     default: kctw-dev/shikigami       # 預設回報目標
     # Future: pattern-based routing（尚未實作，目前僅使用 default）
+  cruise:
+    progress_fallback_window: 30m     # 背景 Agent 進度偵測 fallback 視窗（預設 30m，支援 Nm / Nh）
+  oauth:
+    warn_threshold_hours: 24          # OAuth Token 過期告警門檻（預設 24 小時）
 ---
 
 # Shikigami 專案配置

--- a/hooks/oauth-token-watchdog.sh
+++ b/hooks/oauth-token-watchdog.sh
@@ -3,7 +3,7 @@
 #
 # 行為：
 #   - 讀取 ~/.claude/.credentials.json
-#   - 檢查 claudeAiOauth.expiresAt 是否距現在 < 24 小時
+#   - 檢查 claudeAiOauth.expiresAt 是否距現在 < warn_threshold_hours（預設 24 小時）
 #   - 即將過期 → 輸出 [OAUTH-WARN] 告警（提示執行 claude auth login）
 #   - 檔案不存在 / 欄位缺失 / 解析失敗 → 靜默跳過（不阻塞 session）
 #
@@ -12,7 +12,17 @@
 #   - 靜默跳過：任何讀取或解析錯誤均不影響 session 啟動
 
 CREDENTIALS_FILE="${HOME}/.claude/.credentials.json"
-WARN_THRESHOLD_SECONDS=$((24 * 3600))   # 告警門檻：24 小時
+
+# 告警門檻：從 .claude/shikigami.local.md 讀取 oauth.warn_threshold_hours（預設 24）
+_LOCAL_CONFIG="$(git rev-parse --show-toplevel 2>/dev/null)/.claude/shikigami.local.md"
+_THRESHOLD_HOURS=24
+if [[ -f "$_LOCAL_CONFIG" ]]; then
+  _RAW=$(grep 'warn_threshold_hours:' "$_LOCAL_CONFIG" 2>/dev/null | awk '{print $2}' | head -1)
+  if [[ "$_RAW" =~ ^[0-9]+$ ]]; then
+    _THRESHOLD_HOURS="$_RAW"
+  fi
+fi
+WARN_THRESHOLD_SECONDS=$(( _THRESHOLD_HOURS * 3600 ))
 
 # 檔案不存在 → 靜默跳過
 if [[ ! -f "$CREDENTIALS_FILE" ]]; then

--- a/skills/cruise/SKILL.md
+++ b/skills/cruise/SKILL.md
@@ -625,12 +625,25 @@ PO 巡邏在每個 cycle 偵測 subagent 是否有新產出，避免背景工作
 
 ```bash
 # ── 背景 Agent 進度偵測 ──
-# 上次巡邏時間：從 JSONL log 讀取，取最近一筆 timestamp；首次 cycle 用 30 分鐘前
+# fallback 視窗：從 .claude/shikigami.local.md 讀取 cruise.progress_fallback_window（預設 30m）
+LOCAL_CONFIG="${REPO_PATH}/.claude/shikigami.local.md"
+FALLBACK_WINDOW_RAW=$(grep 'progress_fallback_window:' "${LOCAL_CONFIG}" 2>/dev/null | awk '{print $2}' | head -1)
+FALLBACK_MINUTES=30
+if [[ -n "$FALLBACK_WINDOW_RAW" ]]; then
+  # 支援 30m / 60m / 1h 格式
+  if [[ "$FALLBACK_WINDOW_RAW" =~ ^([0-9]+)h$ ]]; then
+    FALLBACK_MINUTES=$(( ${BASH_REMATCH[1]} * 60 ))
+  elif [[ "$FALLBACK_WINDOW_RAW" =~ ^([0-9]+)m$ ]]; then
+    FALLBACK_MINUTES="${BASH_REMATCH[1]}"
+  fi
+fi
+
+# 上次巡邏時間：從 JSONL log 讀取，取最近一筆 timestamp；首次 cycle 用 fallback 視窗前
 LAST_PATROL_TIME=$(jq -r 'select(.type=="po-patrol") | .timestamp' "${CRUISE_LOG}" 2>/dev/null \
   | sort | tail -1)
 if [[ -z "$LAST_PATROL_TIME" ]]; then
-  LAST_PATROL_TIME=$(date -d "30 minutes ago" '+%Y-%m-%dT%H:%M:%S' 2>/dev/null \
-    || date -v-30M '+%Y-%m-%dT%H:%M:%S' 2>/dev/null \
+  LAST_PATROL_TIME=$(date -d "${FALLBACK_MINUTES} minutes ago" '+%Y-%m-%dT%H:%M:%S' 2>/dev/null \
+    || date -v-${FALLBACK_MINUTES}M '+%Y-%m-%dT%H:%M:%S' 2>/dev/null \
     || date '+%Y-%m-%dT%H:%M:%S')
 fi
 

--- a/skills/sprint-review/SKILL.md
+++ b/skills/sprint-review/SKILL.md
@@ -80,14 +80,28 @@ Story 驗收判定完成後，依判定結果回寫 GitHub Issue 狀態。在 §
 | Story PASS | 依 Issue 建立者判斷執行對應操作 | 內部 Issue 自動關閉；外部 Issue 保持 Open |
 | Story FAIL | Issue 保持 open | 回流 Backlog，等待下次 Sprint 選取 |
 
+### Epic Issue 判斷（優先檢查）
+
+**Epic Issue**：Issue title 含 `epic:` 前綴（大小寫不敏感）。
+
+Epic Issue **不得 close**，無論其為內部或外部 Issue，一律執行：
+
+1. `gh issue edit` 加 `done` label、移除 `in-sprint` label
+2. `gh issue comment` 留言記錄：「Sprint <N> Review PASS，此 Epic Issue 持續追蹤中，不自動關閉。」
+
+> **理由**：Epic 通常跨多個 Sprint，單一 Sprint 完成不代表 Epic 整體收斂，需手動判斷關閉時機。
+
 ### Issue 建立者判斷
 
 **內部 Issue**：建立者為 `github-actions[bot]` 或 body 含 `backlog-intake`。其餘為**外部 Issue**。
+
+> Epic Issue 已於上方獨立處理，以下規則僅適用於**非 Epic Issue**。
 
 ### Story PASS — 操作步驟
 
 | 情況 | 步驟 1（共通） | 步驟 2 |
 |------|--------------|--------|
+| **Epic Issue**（title 含 `epic:`） | `gh issue edit` 加 `done` label、移除 `in-sprint` label | `gh issue comment` 留言記錄，**不執行 close** |
 | **內部 Issue** | `gh issue edit` 加 `done` label、移除 `in-sprint` label | `gh issue close` 並留言 |
 | **外部 Issue（階段 1）** | 同上 | `gh issue comment` 留言通知，**不執行 close** |
 | **外部 Issue（階段 2）** | — | 觸發條件：**deployment-readiness PASS 且 E2E PASS**，方可執行 `gh issue comment` 補充留言 |
@@ -232,7 +246,9 @@ Sprint Review & Retrospective 所有產出文件完成最後修改後，立即 g
 - [ ] 通過驗收 Story 已移至 `PROJECT_BOARD.md` Done 欄位
 - [ ] `sprint_N.md` Story 狀態欄已回寫最終驗收結果
 - [ ] **Story Issue 狀態回寫**（§2.6，HARD-GATE）：
-  - [ ] PASS Story：已查詢 Issue 建立者、判斷內部/外部、執行對應操作
+  - [ ] PASS Story：先判斷是否為 Epic Issue（title 含 `epic:`）
+  - [ ] Epic Issue：done label + 移除 in-sprint + 留言記錄（**不 close**）
+  - [ ] 非 Epic — 查詢 Issue 建立者、判斷內部/外部、執行對應操作
   - [ ] 內部 Issue：done label + 移除 in-sprint + 關閉
   - [ ] 外部 Issue：done label + 移除 in-sprint + 階段 1 留言（保持 Open）
   - [ ] FAIL Story：已回復 backlog 狀態並留言


### PR DESCRIPTION
## Summary

- **#376（S, 2pts）**：Sprint Review §2.6 新增 Epic Issue 防護 — title 含 `epic:` 時不自動 close，改為加 `done` label + 留言記錄
- **#374（S, 1pt）**：Cruise 背景 Agent 進度偵測 fallback 視窗改為從 `.claude/shikigami.local.md` 讀取 `cruise.progress_fallback_window`（預設 30m）
- **#375（S, 1pt）**：OAuth Token 過期通知閾值改為從 `.claude/shikigami.local.md` 讀取 `oauth.warn_threshold_hours`（預設 24h），並更新示範設定

## Test plan

- [ ] Sprint Review 流程：Epic Issue（title 含 `epic:`）驗收 PASS → 確認只加 `done` label + 留言，不執行 close
- [ ] Cruise：移除 `.claude/shikigami.local.md` 中 `progress_fallback_window` 設定 → 確認 fallback 為 30m；設為 `60m` → 確認偵測視窗變為 60 分鐘
- [ ] OAuth Watchdog：設定 `warn_threshold_hours: 48` → 確認告警門檻改為 48 小時

Generated with Claude Code