### PR TITLE
feat: #384 Review 建議清單分層（MUST FIX vs SUGGESTION）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "shikigami",
       "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-      "version": "0.82.0",
+      "version": "0.82.1",
       "source": "./",
       "author": {
         "name": "KCTW"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shikigami",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-  "version": "0.82.0",
+  "version": "0.82.1",
   "author": {
     "name": "KCTW"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **專案名稱**：Shikigami（式神）
 - **性質**：Claude Code Plugin — AI Agent Scrum Team 框架
-- **目前版本**：v0.82.0
+- **目前版本**：v0.82.1
 - **授權**：MIT
 - **Repository**：https://github.com/KCTW/shikigami
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 式神 Shikigami — AI Agent Scrum Team 框架
 
-![Version](https://img.shields.io/badge/version-v0.82.0-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-v0.82.1-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)
 ![Sprints](https://img.shields.io/badge/sprints-112%2B-orange?style=flat-square)
 ![Skills](https://img.shields.io/badge/skills-28-purple?style=flat-square)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "shikigami",
-  "version": "0.78.6",
+  "version": "0.82.1",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
   "author": "KCTW",
   "homepage": "https://github.com/KCTW/shikigami",

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -145,15 +145,26 @@ QA subagent 進行代碼審查時，必須逐項檢查以下清單：
 
 ---
 
-## 7. 缺陷分類
+## 7. 缺陷分類與建議分層
 
-審查發現的問題依嚴重度分為三級：
+<!-- US-384 Review 建議清單分層（MUST FIX vs SUGGESTION）— Sprint 119 -->
+
+審查發現的問題依阻塞性分為兩層，再細分三級：
+
+### MUST FIX 層（阻塞）
 
 | 等級 | 名稱 | 定義 | 處理方式 |
 |------|------|------|----------|
-| Critical | 關鍵缺陷 | 影響系統正確性、安全性或穩定性的嚴重問題 | **必須修復**才能合併，門禁不通過 |
-| Important | 重要缺陷 | 影響可維護性、效能或可讀性的問題 | **應該修復**，強烈建議在合併前處理 |
-| Suggestion | 改進建議 | 風格優化、更佳實踐方式的建議 | **建議改進**，可於後續迭代處理 |
+| Critical | 關鍵缺陷 | 影響系統正確性、安全性或穩定性的嚴重問題 | **必須修復**才能合併，進入 §7.1 CRITICAL 互動決策點 |
+| Important | 重要缺陷 | 影響可維護性、效能或可讀性的問題 | **應該修復**，累計 3 個以上**阻塞**門禁 |
+
+### SUGGESTION 層（非阻塞）
+
+| 等級 | 名稱 | 定義 | 處理方式 |
+|------|------|------|----------|
+| Suggestion | 改進建議 | 風格優化、更佳實踐方式的建議 | **非阻塞**，Developer 自行決定；選擇不採納時須記錄決策理由 |
+
+**分層設計原意**（參照 `docs/discovery/PB-2026-03-23-review-suggestions.md`）：MUST FIX 不修不過 gate；SUGGESTION 由 Developer 保留決策權，降低強制修復循環次數。
 
 ### 判定規則
 
@@ -229,14 +240,24 @@ QA subagent 進行代碼審查時，必須逐項檢查以下清單：
 
 ## 8. 審查失敗處理
 
-當品質門禁發現問題時：
+<!-- US-384 Review 建議清單分層（MUST FIX vs SUGGESTION）— Sprint 119 -->
 
-1. QA subagent 產出具體問題清單，每個問題標注嚴重度（Critical / Important / Suggestion）
+當品質門禁發現問題時，依分層處理：
+
+**MUST FIX 層（阻塞）**：
+
+1. QA subagent 產出問題清單，每個 MUST FIX 問題標注嚴重度（Critical / Important）
 2. **Critical 問題**：進入 §7.1 CRITICAL 互動決策點，使用者選擇 A/B/C
 3. 選擇 A（修復）：Developer subagent 接收問題清單進行修復，修復完成後重新執行品質門禁審查
 4. 選擇 B/C：強制寫入決策記錄（§7.2），流程繼續
 5. 同一門禁連續失敗 3 次（選擇 A 後仍 FAIL），升級至 Architect 評估是否存在設計層面的問題
 6. 同一 Story/PR 連續選擇 B/C 超過 2 次，強制升級至 Architect 審查
+
+**SUGGESTION 層（非阻塞）**：
+
+7. QA subagent 產出 SUGGESTION 清單，每個問題標注改善方向
+8. Developer 自行決定是否採納：選擇不採納時，在 commit message 或審查回覆中記錄決策理由
+9. SUGGESTION 問題不觸發 FAIL，不影響門禁判定，不進入修復循環
 
 ---
 

--- a/skills/sprint-execution/quality-reviewer-prompt.md
+++ b/skills/sprint-execution/quality-reviewer-prompt.md
@@ -162,13 +162,28 @@
 
 ---
 
-## 問題嚴重度分級
+## 問題嚴重度分級與分層
+
+<!-- US-384 Review 建議清單分層（MUST FIX vs SUGGESTION）— Sprint 119 -->
+
+審查問題分為兩層：
+
+### MUST FIX 層（阻塞，Critical + Important HIGH）
 
 | 等級 | 定義 | 要求 |
 |------|------|------|
-| **Critical** | 會導致 Bug、安全漏洞或資料遺失 | 進入 `skills/quality-gate/SKILL.md` §7.1 CRITICAL 互動決策點（A 修復 / B 降級 / C 接受風險） |
-| **Important** | 違反設計原則、影響可維護性 | 強烈建議修復，累計 3 個以上不過 |
-| **Suggestion** | 改善建議、風格偏好 | 可選擇性採納，不影響通過與否 |
+| **Critical** | 會導致 Bug、安全漏洞或資料遺失 | 阻塞合併，進入 `skills/quality-gate/SKILL.md` §7.1 CRITICAL 互動決策點（A 修復 / B 降級 / C 接受風險） |
+| **Important** | 違反設計原則、影響可維護性 | 阻塞合併（累計 3 個以上），強烈建議修復 |
+
+**處理規則**：MUST FIX 問題未處置完畢前，品質門禁不通過，不得繼續流程。
+
+### SUGGESTION 層（非阻塞，Developer 自行決定）
+
+| 等級 | 定義 | 要求 |
+|------|------|------|
+| **Suggestion** | 改善建議、風格偏好、可選優化 | 非阻塞，Developer 自行決定是否採納；**選擇不採納時必須記錄決策理由** |
+
+**處理規則**：SUGGESTION 問題不影響門禁判定。Developer 選擇跳過時，應在 commit message 或審查回覆中附上決策理由（例：「風格一致性暫緩，留待下次 refactor Sprint 統一處理」）。
 
 ---
 
@@ -183,21 +198,27 @@
 
 ### Issues（發現的問題）
 
-#### Critical
+#### MUST FIX（阻塞 — 必須修復）
+> Critical 與累計 3 個以上 Important 均屬此層，門禁不通過前不得繼續。
+
+##### Critical
 1. **[{檔案路徑}:{行號}] {問題標題}**
    - 問題：{具體描述}
    - 影響：{為什麼這是問題}
    - 建議：{具體修復方向}
 
-#### Important
+##### Important
 1. **[{檔案路徑}:{行號}] {問題標題}**
    - 問題：{具體描述}
    - 原則：{違反的設計原則}
    - 建議：{具體修復方向}
 
-#### Suggestion
+#### SUGGESTION（非阻塞 — Developer 自行決定）
+> Suggestion 等級問題不影響門禁。選擇不採納時請記錄決策理由。
+
 1. **[{檔案路徑}:{行號}] {問題標題}**
    - 建議：{改善方向}
+   - 決策理由（若不採納）：{填入或留空待 Developer 填寫}
 
 ### Assessment
 
@@ -214,6 +235,8 @@
 | 外部資源 Smoke Test（CQ-SMOKE） | {PASS / FAIL / N/A} |
 | 靜態資料覆蓋率 | {PASS / Hard Gate FAIL / N/A（不涉及靜態資料檔）} |
 
+**MUST FIX 摘要**：Critical {N} 個，Important {N} 個（阻塞門禁：{是 / 否}）
+**SUGGESTION 摘要**：{N} 個（不影響門禁）
 **總評**：{一句話總結代碼品質與是否通過}
 ```
 

--- a/tests/test-384-review-suggestions-tiering.sh
+++ b/tests/test-384-review-suggestions-tiering.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# tests/test-384-review-suggestions-tiering.sh
+# Story #384：Review 建議清單分層（MUST FIX vs SUGGESTION）
+# 驗證 quality-reviewer-prompt.md 與 quality-gate/SKILL.md 輸出格式已分兩層
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# 測試框架（輕量）
+# ---------------------------------------------------------------------------
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  echo "PASS: $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+QUALITY_REVIEWER="skills/sprint-execution/quality-reviewer-prompt.md"
+QUALITY_GATE="skills/quality-gate/SKILL.md"
+
+# ---------------------------------------------------------------------------
+# AC1：quality-reviewer-prompt.md 輸出格式包含 MUST FIX 分層標記
+# ---------------------------------------------------------------------------
+echo "--- AC1：quality-reviewer-prompt.md MUST FIX 分層 ---"
+
+if grep -q "MUST FIX" "$QUALITY_REVIEWER"; then
+  pass "AC1-1：quality-reviewer-prompt.md 包含 MUST FIX 標籤"
+else
+  fail "AC1-1：quality-reviewer-prompt.md 缺少 MUST FIX 標籤"
+fi
+
+if grep -q "SUGGESTION" "$QUALITY_REVIEWER"; then
+  pass "AC1-2：quality-reviewer-prompt.md 包含 SUGGESTION 標籤"
+else
+  fail "AC1-2：quality-reviewer-prompt.md 缺少 SUGGESTION 標籤"
+fi
+
+# MUST FIX 必須包含 CRITICAL 與 HIGH 的對照說明
+if grep -A5 "MUST FIX" "$QUALITY_REVIEWER" | grep -q "Critical\|CRITICAL\|Critical.*HIGH\|CRITICAL.*HIGH"; then
+  pass "AC1-3：MUST FIX 區塊涵蓋 Critical/HIGH 嚴重度"
+else
+  fail "AC1-3：MUST FIX 區塊未明確涵蓋 Critical/HIGH 嚴重度"
+fi
+
+# SUGGESTION 必須包含 MEDIUM 或 LOW 的對照說明
+if grep -A5 "SUGGESTION" "$QUALITY_REVIEWER" | grep -q "Suggestion\|MEDIUM\|LOW\|Medium\|Low"; then
+  pass "AC1-4：SUGGESTION 區塊涵蓋非阻塞嚴重度"
+else
+  fail "AC1-4：SUGGESTION 區塊未明確涵蓋非阻塞嚴重度"
+fi
+
+# ---------------------------------------------------------------------------
+# AC2：quality-reviewer-prompt.md 輸出格式的 Issues 區塊用 MUST FIX / SUGGESTION 分層
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC2：輸出格式 Issues 區塊結構 ---"
+
+# 在輸出格式（code block）中確認分層 header 存在
+if grep -q "MUST FIX\|### MUST FIX" "$QUALITY_REVIEWER"; then
+  pass "AC2-1：輸出格式包含 MUST FIX 分層 header"
+else
+  fail "AC2-1：輸出格式缺少 MUST FIX 分層 header"
+fi
+
+if grep -q "SUGGESTION\|### SUGGESTION" "$QUALITY_REVIEWER"; then
+  pass "AC2-2：輸出格式包含 SUGGESTION 分層 header"
+else
+  fail "AC2-2：輸出格式缺少 SUGGESTION 分層 header"
+fi
+
+# ---------------------------------------------------------------------------
+# AC3：SUGGESTION 必須要求記錄決策理由
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC3：SUGGESTION 決策理由記錄 ---"
+
+if grep -B2 -A10 "SUGGESTION" "$QUALITY_REVIEWER" | grep -q "決策理由\|理由\|decision\|reason"; then
+  pass "AC3-1：SUGGESTION 區塊要求記錄決策理由"
+else
+  fail "AC3-1：SUGGESTION 區塊未要求記錄決策理由"
+fi
+
+# ---------------------------------------------------------------------------
+# AC4：quality-gate/SKILL.md 審查失敗處理章節反映分層邏輯
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC4：quality-gate/SKILL.md 分層說明 ---"
+
+if grep -q "MUST FIX" "$QUALITY_GATE"; then
+  pass "AC4-1：quality-gate SKILL.md 包含 MUST FIX 說明"
+else
+  fail "AC4-1：quality-gate SKILL.md 缺少 MUST FIX 說明"
+fi
+
+if grep -q "SUGGESTION" "$QUALITY_GATE"; then
+  pass "AC4-2：quality-gate SKILL.md 包含 SUGGESTION 說明"
+else
+  fail "AC4-2：quality-gate SKILL.md 缺少 SUGGESTION 說明"
+fi
+
+# ---------------------------------------------------------------------------
+# AC5：分層說明中 MUST FIX 是阻塞、SUGGESTION 是非阻塞
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC5：阻塞 vs 非阻塞語意 ---"
+
+if grep -A3 "MUST FIX" "$QUALITY_REVIEWER" | grep -q "阻塞\|必須修復\|不通過\|block\|blocking"; then
+  pass "AC5-1：MUST FIX 明確標示為阻塞"
+else
+  fail "AC5-1：MUST FIX 未明確標示為阻塞"
+fi
+
+if grep -A3 "SUGGESTION" "$QUALITY_REVIEWER" | grep -q "自行決定\|非阻塞\|Developer\|可選\|optional"; then
+  pass "AC5-2：SUGGESTION 明確標示為非阻塞，Developer 自行決定"
+else
+  fail "AC5-2：SUGGESTION 未明確標示為非阻塞"
+fi
+
+# ---------------------------------------------------------------------------
+# 結果摘要
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================="
+echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"
+echo "========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- `quality-reviewer-prompt.md` 的問題清單輸出格式改為兩層：**MUST FIX**（阻塞）與 **SUGGESTION**（非阻塞）
- `quality-gate/SKILL.md` §7 缺陷分類與 §8 審查失敗處理同步更新，反映分層邏輯
- SUGGESTION 層明確要求 Developer 選擇不採納時記錄決策理由
- 同步 bump v0.82.0 → v0.82.1

## 變更檔案

- `skills/sprint-execution/quality-reviewer-prompt.md` — 問題嚴重度分級重構為兩層，輸出格式加入 MUST FIX / SUGGESTION 分層 header
- `skills/quality-gate/SKILL.md` — §7 缺陷分類改為 MUST FIX / SUGGESTION 兩層說明，§8 審查失敗處理增加 SUGGESTION 非阻塞流程
- `.claude-plugin/plugin.json`, `marketplace.json`, `gemini-extension.json`, `CLAUDE.md`, `README.md` — v0.82.1 版號同步

## Test plan

- [x] `tests/test-384-review-suggestions-tiering.sh` — 11 項新測試全部 PASS
- [x] `tests/test-266-pr-review-toolkit-integration.sh` — 16 項回歸測試全部 PASS
- [x] `scripts/validate-version.sh` — 版號一致性驗證通過
- [x] `scripts/validate-skills.sh` — Skill 完整性驗證通過

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)