### PR TITLE
fix: #443 Compact 後注入 project_level

### DIFF
--- a/hooks/session-start
+++ b/hooks/session-start
@@ -65,6 +65,13 @@ if [[ -f "$CHECKPOINT_FILE" ]]; then
   fi
 fi
 
+# ---------- #443：Compact 後注入 project_level ----------
+CONFIG_FILE="${REPO_ROOT_PATH}/.claude/shikigami.local.md"
+if [[ -f "$CONFIG_FILE" ]]; then
+  PL=$(grep -A5 'shikigami:' "$CONFIG_FILE" | grep 'project_level:' | awk '{print $2}' | head -1)
+  RECOVERY_HINTS="${RECOVERY_HINTS}[CONFIG] project_level=${PL:-medium}\n"
+fi
+
 # ---------- ADR-030：OAuth Token Watchdog ----------
 # 偵測 Claude OAuth token 是否即將過期，輸出告警（靜默跳過不阻塞）
 WATCHDOG_SCRIPT="${PLUGIN_ROOT}/hooks/oauth-token-watchdog.sh"


### PR DESCRIPTION
## Summary
- Context compact 會洗掉 `project_level` 設定，導致 cruise 行為退化回 `medium`
- 在 `hooks/session-start` 的 #359 恢復段落後加入 `.claude/shikigami.local.md` 讀取
- Compact 後自動注入 `[CONFIG] project_level=<value>`，無設定檔時靜默 fallback

## Test plan
- [ ] AC-1: compact 事件觸發後 context 包含 `[CONFIG] project_level=low`
- [ ] AC-2: 無 `.claude/shikigami.local.md` 時 fallback medium，不報錯
- [ ] AC-3: 既有功能（出勤簽到、cruise 恢復、sprint checkpoint）不受影響

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)