### PR TITLE
fix: #446 PreToolUse prompt hooks 改為確定性 command hooks

### DIFF
--- a/hooks/branch-gate.sh
+++ b/hooks/branch-gate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# branch-gate.sh — #446 PreToolUse hook：偵測 git checkout -b / git switch -c，提示 claim 確認
+#
+# 攔截邏輯：
+#   - 偵測 git checkout -b 或 git switch -c 指令
+#   - 若偵測到，輸出 BRANCH-GATE 提醒（exit 1 讓 LLM 看見提示）
+#   - 其他指令直接放行（exit 0）
+#
+# 取代原有 type: prompt hook，改為確定性 shell script 排除 LLM 隨機性
+#
+# 使用方式：由 hooks.json PreToolUse hook 呼叫
+#   CLAUDE_TOOL_INPUT（JSON）提供 command 欄位
+
+set -euo pipefail
+
+# ── 讀取指令 ────────────────────────────────────────────────────────────────
+TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
+if [[ -z "$TOOL_INPUT" ]]; then
+  exit 0
+fi
+
+# 從 JSON 解析 command 欄位（支援 jq 與 POSIX sed 兩種方式）
+CMD=""
+if command -v jq &>/dev/null; then
+  JQ_OUT=$(echo "$TOOL_INPUT" | jq -r '.command // ""' 2>/dev/null || echo "__JQ_PARSE_ERROR__")
+  if [[ "$JQ_OUT" == "__JQ_PARSE_ERROR__" ]]; then
+    exit 0
+  fi
+  CMD="$JQ_OUT"
+else
+  CMD=$(echo "$TOOL_INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' 2>/dev/null | head -1 || echo "")
+fi
+
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# ── 只關心 git checkout -b 或 git switch -c 指令 ─────────────────────────
+if ! echo "$CMD" | grep -qE '(git\s+checkout\s+.*-b|git\s+switch\s+.*-c)'; then
+  exit 0
+fi
+
+# ── 輸出 BRANCH-GATE 提醒 ────────────────────────────────────────────────
+echo "[BRANCH-GATE] 建立新分支前，請確認："
+echo "1. 已在 Sprint Backlog 中 claim 本 Story（避免多 session 搶單）？"
+echo "2. 分支命名遵循慣例 sprint-{N}/{story-id}？"
+echo ""
+echo "若尚未 claim，請先更新 Sprint 文件再建立分支。"
+exit 1

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -47,16 +47,16 @@
             "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/protect-main.sh'"
           },
           {
-            "type": "prompt",
-            "prompt": "如果本次 Bash 工具的 command 欄位包含 'gh pr merge' 或 'pr merge'，請回覆以下提醒（否則不回覆任何內容）：\n\n[PR-MERGE-GATE] 合併前請確認以下審查已完成：\n1. pr-review-toolkit 三 agent 審查已執行且通過？（code-reviewer / silent-failure-hunter 無 CRITICAL/HIGH；comment-analyzer 無 Critical Issues）\n2. 外部獨立審查已 CONFIRM（或 doc-only 跳過）？\n3. CI/CD 雙審查 Gate（若有 .github/workflows 變更）已 PASS？\n\n若未完成，請先執行審查再合併。若確認已完成，可繼續合併。"
+            "type": "command",
+            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/pr-merge-gate.sh'"
           },
           {
-            "type": "prompt",
-            "prompt": "如果本次 Bash 工具的 command 欄位符合 'git checkout -b' 或 'git switch -c'，請回覆以下提醒（否則不回覆任何內容）：\n\n[BRANCH-GATE] 建立新分支前，請確認：\n1. 已在 Sprint Backlog 中 claim 本 Story（避免多 session 搶單）？\n2. 分支命名遵循慣例 sprint-{N}/{story-id}？\n\n若尚未 claim，請先更新 Sprint 文件再建立分支。"
+            "type": "command",
+            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/branch-gate.sh'"
           },
           {
-            "type": "prompt",
-            "prompt": "如果本次 Bash 工具的 command 欄位包含 'git push' 且同時包含 'main' 或 'origin main'，請回覆以下提醒（否則不回覆任何內容）：\n\n[PUSH-MAIN-GATE] 直接 push 到 main 分支前，請確認：\n1. 本次變更是否在豁免清單中（doc-only / hotfix / version-bump）？\n2. 若非豁免，請改用 PR 流程：git push origin {branch} 後執行 gh pr create。\n\n直接 push main 僅適用於豁免清單場景，一般功能實作必須走 PR 流程。"
+            "type": "command",
+            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/push-main-gate.sh'"
           }
         ]
       }

--- a/hooks/pr-merge-gate.sh
+++ b/hooks/pr-merge-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# pr-merge-gate.sh — #446 PreToolUse hook：偵測 gh pr merge，提示審查確認
+#
+# 攔截邏輯：
+#   - 偵測 gh pr merge 或 pr merge 指令
+#   - 若偵測到，輸出 PR-MERGE-GATE 提醒（exit 1 讓 LLM 看見提示）
+#   - 其他指令直接放行（exit 0）
+#
+# 取代原有 type: prompt hook，改為確定性 shell script 排除 LLM 隨機性
+#
+# 使用方式：由 hooks.json PreToolUse hook 呼叫
+#   CLAUDE_TOOL_INPUT（JSON）提供 command 欄位
+
+set -euo pipefail
+
+# ── 讀取指令 ────────────────────────────────────────────────────────────────
+TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
+if [[ -z "$TOOL_INPUT" ]]; then
+  exit 0
+fi
+
+# 從 JSON 解析 command 欄位（支援 jq 與 POSIX sed 兩種方式）
+CMD=""
+if command -v jq &>/dev/null; then
+  JQ_OUT=$(echo "$TOOL_INPUT" | jq -r '.command // ""' 2>/dev/null || echo "__JQ_PARSE_ERROR__")
+  if [[ "$JQ_OUT" == "__JQ_PARSE_ERROR__" ]]; then
+    exit 0
+  fi
+  CMD="$JQ_OUT"
+else
+  CMD=$(echo "$TOOL_INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' 2>/dev/null | head -1 || echo "")
+fi
+
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# ── 只關心包含 gh pr merge 或 pr merge 的指令 ────────────────────────────
+if ! echo "$CMD" | grep -qE '(gh\s+pr\s+merge|pr\s+merge)'; then
+  exit 0
+fi
+
+# ── 輸出 PR-MERGE-GATE 提醒 ──────────────────────────────────────────────
+echo "[PR-MERGE-GATE] 合併前請確認以下審查已完成："
+echo "1. pr-review-toolkit 三 agent 審查已執行且通過？（code-reviewer / silent-failure-hunter 無 CRITICAL/HIGH；comment-analyzer 無 Critical Issues）"
+echo "2. 外部獨立審查已 CONFIRM（或 doc-only 跳過）？"
+echo "3. CI/CD 雙審查 Gate（若有 .github/workflows 變更）已 PASS？"
+echo ""
+echo "若未完成，請先執行審查再合併。若確認已完成，可繼續合併。"
+exit 1

--- a/hooks/push-main-gate.sh
+++ b/hooks/push-main-gate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# push-main-gate.sh — #446 PreToolUse hook：偵測 git push + main，提示 PR 流程
+#
+# 攔截邏輯：
+#   - 偵測 git push 且包含 main 或 origin main 的指令
+#   - 若偵測到，輸出 PUSH-MAIN-GATE 提醒（exit 1 讓 LLM 看見提示）
+#   - 其他指令直接放行（exit 0）
+#
+# 取代原有 type: prompt hook，改為確定性 shell script 排除 LLM 隨機性
+#
+# 注意：此 hook 與 protect-main.sh 互補：
+#   protect-main.sh — 執行完整豁免邏輯並硬攔截
+#   push-main-gate.sh — 偵測明確包含 main 關鍵字的 push，輸出流程提示
+#
+# 使用方式：由 hooks.json PreToolUse hook 呼叫
+#   CLAUDE_TOOL_INPUT（JSON）提供 command 欄位
+
+set -euo pipefail
+
+# ── 讀取指令 ────────────────────────────────────────────────────────────────
+TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
+if [[ -z "$TOOL_INPUT" ]]; then
+  exit 0
+fi
+
+# 從 JSON 解析 command 欄位（支援 jq 與 POSIX sed 兩種方式）
+CMD=""
+if command -v jq &>/dev/null; then
+  JQ_OUT=$(echo "$TOOL_INPUT" | jq -r '.command // ""' 2>/dev/null || echo "__JQ_PARSE_ERROR__")
+  if [[ "$JQ_OUT" == "__JQ_PARSE_ERROR__" ]]; then
+    exit 0
+  fi
+  CMD="$JQ_OUT"
+else
+  CMD=$(echo "$TOOL_INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' 2>/dev/null | head -1 || echo "")
+fi
+
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# ── 只關心 git push + main 的指令 ───────────────────────────────────────
+if ! echo "$CMD" | grep -qE 'git\s+push'; then
+  exit 0
+fi
+
+if ! echo "$CMD" | grep -qE '(\s|^)main(\s|$)|origin\s+main'; then
+  exit 0
+fi
+
+# ── 輸出 PUSH-MAIN-GATE 提醒 ─────────────────────────────────────────────
+echo "[PUSH-MAIN-GATE] 直接 push 到 main 分支前，請確認："
+echo "1. 本次變更是否在豁免清單中（doc-only / hotfix / version-bump）？"
+echo "2. 若非豁免，請改用 PR 流程：git push origin {branch} 後執行 gh pr create。"
+echo ""
+echo "直接 push main 僅適用於豁免清單場景，一般功能實作必須走 PR 流程。"
+exit 1

--- a/tests/test-446-gate-hooks.sh
+++ b/tests/test-446-gate-hooks.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# test-446-gate-hooks.sh — 驗證 #446 gate hooks 確定性行為
+#
+# AC1: 3 個 prompt hooks 全部改為 command type（hooks.json 結構驗證）
+# AC2: gh pr merge 觸發 PR-MERGE-GATE
+# AC3: git checkout -b 觸發 BRANCH-GATE
+# AC4: git push origin main 觸發 PUSH-MAIN-GATE
+# AC5: 非目標指令不觸發（0 false positive）
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$REPO_ROOT/hooks"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# ── 輔助函式：模擬 CLAUDE_TOOL_INPUT 呼叫 hook ──────────────────────────
+run_hook() {
+  local script="$1"
+  local cmd="$2"
+  local input
+  input=$(printf '{"command": "%s"}' "$cmd")
+  CLAUDE_TOOL_INPUT="$input" bash "$HOOKS_DIR/$script" 2>&1
+  return $?
+}
+
+# ── AC1: hooks.json 不含任何 type: prompt ───────────────────────────────
+echo "=== AC1: hooks.json 無 type: prompt ==="
+if ! grep -q '"type": "prompt"' "$HOOKS_DIR/hooks.json"; then
+  pass "hooks.json 已無 type: prompt"
+else
+  fail "hooks.json 仍含 type: prompt"
+fi
+
+# 確認 3 個 gate scripts 存在
+for script in pr-merge-gate.sh branch-gate.sh push-main-gate.sh; do
+  if [[ -x "$HOOKS_DIR/$script" ]]; then
+    pass "$script 存在且可執行"
+  else
+    fail "$script 不存在或不可執行"
+  fi
+done
+
+# ── AC2: PR-MERGE-GATE ────────────────────────────────────────────────
+echo "=== AC2: PR-MERGE-GATE ==="
+# 目標指令應觸發（exit 1）
+for cmd in "gh pr merge 123" "gh pr merge --squash" "pr merge"; do
+  if output=$(run_hook pr-merge-gate.sh "$cmd" 2>&1); then
+    fail "應觸發但未觸發: $cmd"
+  else
+    if echo "$output" | grep -q "PR-MERGE-GATE"; then
+      pass "正確觸發: $cmd"
+    else
+      fail "觸發但無 PR-MERGE-GATE 文字: $cmd"
+    fi
+  fi
+done
+
+# AC5: 非目標指令應放行（exit 0）
+for cmd in "gh issue view 123" "gh run list" "gh pr list" "git status" "git log --oneline"; do
+  if run_hook pr-merge-gate.sh "$cmd" >/dev/null 2>&1; then
+    pass "正確放行: $cmd"
+  else
+    fail "誤攔截（false positive）: $cmd"
+  fi
+done
+
+# ── AC3: BRANCH-GATE ─────────────────────────────────────────────────
+echo "=== AC3: BRANCH-GATE ==="
+# 目標指令應觸發（exit 1）
+for cmd in "git checkout -b sprint-123/446" "git switch -c feature-xyz"; do
+  if output=$(run_hook branch-gate.sh "$cmd" 2>&1); then
+    fail "應觸發但未觸發: $cmd"
+  else
+    if echo "$output" | grep -q "BRANCH-GATE"; then
+      pass "正確觸發: $cmd"
+    else
+      fail "觸發但無 BRANCH-GATE 文字: $cmd"
+    fi
+  fi
+done
+
+# AC5: 非目標指令應放行
+for cmd in "git checkout main" "git switch main" "git status" "gh issue view 123"; do
+  if run_hook branch-gate.sh "$cmd" >/dev/null 2>&1; then
+    pass "正確放行: $cmd"
+  else
+    fail "誤攔截（false positive）: $cmd"
+  fi
+done
+
+# ── AC4: PUSH-MAIN-GATE ───────────────────────────────────────────────
+echo "=== AC4: PUSH-MAIN-GATE ==="
+# 目標指令應觸發（exit 1）
+for cmd in "git push origin main" "git push main" "git push --force origin main"; do
+  if output=$(run_hook push-main-gate.sh "$cmd" 2>&1); then
+    fail "應觸發但未觸發: $cmd"
+  else
+    if echo "$output" | grep -q "PUSH-MAIN-GATE"; then
+      pass "正確觸發: $cmd"
+    else
+      fail "觸發但無 PUSH-MAIN-GATE 文字: $cmd"
+    fi
+  fi
+done
+
+# AC5: 非目標指令應放行
+for cmd in "git push origin sprint-123/446" "git push" "git status" "gh run list" "git push origin feature-branch"; do
+  if run_hook push-main-gate.sh "$cmd" >/dev/null 2>&1; then
+    pass "正確放行: $cmd"
+  else
+    fail "誤攔截（false positive）: $cmd"
+  fi
+done
+
+# ── 結果彙總 ─────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════"
+echo "結果：PASS=$PASS，FAIL=$FAIL"
+echo "══════════════════════════════════════"
+
+if [[ $FAIL -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- 將 hooks.json 中 3 個 `type: prompt` hooks（PR-MERGE-GATE / BRANCH-GATE / PUSH-MAIN-GATE）改為 `type: command`
- 新增 3 個確定性 shell script：`pr-merge-gate.sh`、`branch-gate.sh`、`push-main-gate.sh`，使用 grep 模式匹配取代 LLM 判斷
- 新增 `tests/test-446-gate-hooks.sh`：26 項測試涵蓋目標觸發（AC2/3/4）與零 false positive（AC5）

## AC 驗證

- AC1: hooks.json 無任何 `type: prompt`
- AC2: `gh pr merge` 正確觸發 PR-MERGE-GATE
- AC3: `git checkout -b` / `git switch -c` 正確觸發 BRANCH-GATE
- AC4: `git push origin main` 正確觸發 PUSH-MAIN-GATE
- AC5: `gh issue view`、`gh run list`、`git status` 等 0 false positive（26/26 PASS）

## Test plan

- [x] `bash tests/test-446-gate-hooks.sh` — 26/26 PASS
- [x] `bash scripts/validate-json.sh` — PASS

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)