### PR TITLE
feat: #456 #461 #463 Sprint 124 — ADR 自動納入 Sprint、PR 品質門禁、ci-health-check 整合

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "shikigami",
       "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-      "version": "0.83.0",
+      "version": "0.83.1",
       "source": "./",
       "author": {
         "name": "KCTW"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shikigami",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-  "version": "0.83.0",
+  "version": "0.83.1",
   "author": {
     "name": "KCTW"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **專案名稱**：Shikigami（式神）
 - **性質**：Claude Code Plugin — AI Agent Scrum Team 框架
-- **目前版本**：v0.83.0
+- **目前版本**：v0.83.1
 - **授權**：MIT
 - **Repository**：https://github.com/KCTW/shikigami
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 式神 Shikigami — AI Agent Scrum Team 框架
 
-![Version](https://img.shields.io/badge/version-v0.83.0-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-v0.83.1-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)
 ![Sprints](https://img.shields.io/badge/sprints-112%2B-orange?style=flat-square)
 ![Skills](https://img.shields.io/badge/skills-28-purple?style=flat-square)

--- a/agents/developer.md
+++ b/agents/developer.md
@@ -85,3 +85,40 @@ color: green
 - 與 Architect 確認設計 — 實作前確認設計方向正確
 - 與 Security Engineer 確認安全性 — 涉及認證、授權、外部輸入時必須諮詢
 - 與 PO 釐清需求 — User Story 有任何模糊之處立即詢問
+
+## Team Debate 雙重角色（ADR-031，Phase 1）
+
+在 Team Debate 機制（`skills/team-debate/SKILL.md`）中，Developer 可以兩種身份參與：
+
+### Worker（Agent A）— 實作者
+
+- **觸發時機**：主 session 派遣執行 Story 時的主要身份
+- **職責**：完整 TDD 開發 + self-review，commit 至 branch
+- **修復義務**：接收 Critic 批判後逐項回應（accept/reject + 理由）並修復 accept 項目
+- **行為準則**：
+  - 不得拒絕 HIGH severity Issue（必須 accept 並修復）
+  - 拒絕（reject）LOW/MED Issue 需提供合理技術理由
+  - 修復 commit message 格式：`fix: Team Debate Round 2 修復 — {story_id}`
+
+### Critic（Agent B）— 批判者
+
+- **觸發時機**：主 session 明確以 Critic 身份派遣（prompt 中標注 Critic 角色）
+- **職責**：獨立批判 Worker 產出，不修改代碼，寫入批判結果至 `.claude/debate/critique-round-{N}.md`
+- **批判維度**：
+  1. **正確性**：每項 AC 是否有對應實作？邊界條件？
+  2. **設計**：SOLID 原則？耦合度？命名清晰度？
+  3. **測試覆蓋**：是否真正 TDD？測試覆蓋是否充分？
+  4. **安全性**：外部輸入是否受保護？有無硬編碼 secrets？
+- **行為準則**：
+  - 不能修改任何代碼，只能批判
+  - 批判必須具體，指出檔案和行號
+  - 不為了批判而批判：若真的找不到問題，Verdict = PASS
+  - HIGH severity 僅用於 AC 缺失或安全漏洞；設計優化建議用 LOW/MED
+
+### 角色切換規則
+
+| 主 session 派遣指示 | 本 Agent 身份 |
+|---------------------|--------------|
+| 標準 Story-Lifecycle（無特殊說明） | Worker（預設） |
+| prompt 中明確標注「Critic 角色」 | Critic |
+| `team_debate=false` | 不啟用 Team Debate，以標準 Developer 身份執行 |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "shikigami",
-  "version": "0.83.0",
+  "version": "0.83.1",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
   "author": "KCTW",
   "homepage": "https://github.com/KCTW/shikigami",

--- a/skills/cruise/SKILL.md
+++ b/skills/cruise/SKILL.md
@@ -1206,6 +1206,42 @@ SPRINT_FILE=$(ls ${REPO_PATH}/docs/sprints/sprint_*.md 2>/dev/null | sort -V | t
 **觸發**：每個 cruise cycle 由 Task tool 派遣 SRE Agent 執行
 **Repo context**：subagent 接收 `REPO_PATH` 與 `OWNER_REPO` 參數，所有 `gh` 指令加 `-R ${OWNER_REPO}`
 
+### CI 健康檢查（#463 ci-health-check.sh 整合）
+
+<!-- #463 ci-health-check.sh 整合至 Cruise SRE 啟動流程 — Sprint 124 -->
+
+SRE 巡檢**開頭**必須執行 CI 健康檢查腳本（AC1）：
+
+```bash
+# Step 0: CI 健康檢查（ci-health-check.sh 整合）
+CI_HEALTH_SCRIPT="${REPO_PATH}/scripts/ci-health-check.sh"
+
+if [[ -f "$CI_HEALTH_SCRIPT" ]]; then
+  echo "[SRE] 執行 CI 健康檢查：$CI_HEALTH_SCRIPT"
+  CI_HEALTH_OUTPUT=$(bash "$CI_HEALTH_SCRIPT" 2>&1)
+  CI_HEALTH_EXIT=$?
+  if [[ $CI_HEALTH_EXIT -eq 0 ]]; then
+    echo "[SRE] CI 健康檢查 PASS"
+  else
+    echo "[SRE] CI 健康檢查 WARN（exit code: $CI_HEALTH_EXIT）"
+    echo "$CI_HEALTH_OUTPUT"
+  fi
+else
+  # Graceful fallback（AC3）：腳本不存在時靜默跳過，不阻塞巡檢
+  echo "[SRE] ci-health-check.sh 不存在（${CI_HEALTH_SCRIPT}），跳過健康檢查"
+  CI_HEALTH_OUTPUT="[SKIPPED] ci-health-check.sh 不存在"
+  CI_HEALTH_EXIT=0
+fi
+```
+
+健康檢查結果（`CI_HEALTH_OUTPUT`、`CI_HEALTH_EXIT`）**納入 SRE 巡檢報告**（AC2），格式見「SRE 巡檢結果格式」的 `ci_health_check` 欄位。
+
+| 情境 | 行為 |
+|------|------|
+| 腳本存在且 exit 0 | `[SRE] CI 健康檢查 PASS`，結果納入報告 |
+| 腳本存在但 exit ≠ 0 | `[SRE] CI 健康檢查 WARN`，輸出結果納入報告，不阻塞巡檢繼續執行 |
+| 腳本不存在 | `[SRE] ci-health-check.sh 不存在，跳過健康檢查`，報告填 `SKIPPED`（AC3） |
+
 ### cruise-feedback label 標註規則（#339）
 
 SRE 建立 Issue 時，若判斷問題**屬於框架層級**（非 repo 特定，而是 Cruise Skill 本身的限制或設計缺陷），在 `--label` 參數中加入 `cruise-feedback`。
@@ -1510,9 +1546,22 @@ done
     "current_vm_count": <N>,
     "recommended_size": <N>
   },
+  "ci_health_check": {
+    "status": "PASS | WARN | SKIPPED",
+    "exit_code": 0,
+    "output": "<ci-health-check.sh 輸出摘要，或 SKIPPED 原因>"
+  },
   "actions": ["create-issue-with-debug #<N1>", "create-issue-deploy #<N2>", "create-issue-runner #<N3>", "create-issue-vm-anomaly #<N4>", "跳過重複 Issue: <title>"]
 }
 ```
+
+**ci_health_check.status 說明**（#463）：
+
+| 值 | 說明 |
+|----|------|
+| `"PASS"` | ci-health-check.sh 存在且 exit 0 |
+| `"WARN"` | ci-health-check.sh 存在但 exit ≠ 0，輸出已記錄 |
+| `"SKIPPED"` | ci-health-check.sh 不存在，graceful fallback |
 
 **SRE 巡檢 actions 行動類型說明**：
 

--- a/skills/scrum-master/SKILL.md
+++ b/skills/scrum-master/SKILL.md
@@ -40,6 +40,7 @@ description: "Use when starting any conversation - 自動調度 Shikigami Agent 
 | `health-check` | 框架狀態檢查、自我診斷、結構完整性驗證 |
 | `onboarding` | 新用戶安裝後初始化、專案目錄 scaffold、CLAUDE.md 生成 |
 | `dispel` | Legacy 系統考古、不熟悉 codebase 分析、解咒模式 |
+| `team-debate` | Developer Story 實作後觸發同職能雙 Agent 交替批判（ADR-031 Phase 1） |
 
 ---
 

--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -739,7 +739,7 @@ Claim Story（§2.11，多 Session 並行協調）
    - 7.3 審查閉環（現行流程不變：Spec Compliance + Code Quality）
    - 7.4 `git commit -m "feat: <story-id> <標題>"`
    - 7.5 `git push -u origin sprint-<N>/<story-id>`
-   - 7.6 `gh pr create --title "feat: <story-id> <標題>" --body "<AC 清單 + 審查摘要>"`
+   - 7.6 `gh pr create --title "feat: <story-id> <標題>" --body "<PR body（必須包含 Summary + AC Checklist，見 PR Description Quality Gate）>"`
          |-- `gh` 不可用 → `[PR-FLOW-DEGRADED]` 降級：直推 main + 內部審查
    - 7.7 Code Review Loop（ADR-023 決策 5，pr-review-toolkit 三 agent，#368 方向2 責任下放）
          pr-review-toolkit 三 agent：code-reviewer / silent-failure-hunter / comment-analyzer

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -119,6 +119,8 @@ size: "M"                                  # 必填：Story Size（S/M/L），�
 bypass: false                              # 必填：是否為 [BYPASS] Story（影響 Review 豁免）
 story_type: "FEATURE"                      # 必填：Story 類型（FEATURE/DESIGN/INFRA/SECURITY/INTEGRATION/RESEARCH）
                                            # 缺失時 fallback 至 FEATURE（見「story_type Fallback 規則」）
+team_debate: true                          # 可選：是否啟用 Team Debate（ADR-031，預設 true）
+                                           # 設為 false 時，跳過 §7.8 Team Debate，回退至標準單一 agent 自審
 ```
 
 <!-- US-204 Story Template 更新 — Sprint 76 -->
@@ -293,13 +295,22 @@ TDD 開發循環（§3）：Red → Green → Refactor（每小步一個 commit�
 ║  ├─ Security self-review（§7，條件觸發）             ║
 ║  │       |-- FAIL --> 修復或升級                       ║
 ║  │       +-- PASS / SKIP                               ║
-║  └─ pr-review-toolkit 補充審查（§7.5，條件觸發）      ║
-║         |-- Plugin 未安裝 → [WARN] 跳過，繼續          ║
-║         |-- Doc-only → 僅執行 comment-analyzer          ║
-║         |-- 全部 PASS → 繼續                            ║
-║         +-- CRITICAL/HIGH → 修復 → 二審                 ║
-║               |-- PASS → 繼續                           ║
-║               +-- 仍 CRITICAL/HIGH → 升級 Architect     ║
+║  ├─ pr-review-toolkit 補充審查（§7.5，條件觸發）      ║
+║  │      |-- Plugin 未安裝 → [WARN] 跳過，繼續          ║
+║  │      |-- Doc-only → 僅執行 comment-analyzer          ║
+║  │      |-- 全部 PASS → 繼續                            ║
+║  │      +-- CRITICAL/HIGH → 修復 → 二審                 ║
+║  │            |-- PASS → 繼續                           ║
+║  │            +-- 仍 CRITICAL/HIGH → 升級 Architect     ║
+║  └─ Team Debate（§7.8，ADR-031 Phase 1，條件觸發）    ║
+║         |-- [DEBATE-SKIP] doc_only/RESEARCH/DESIGN → 略過║
+║         |-- [DEBATE-SKIP] team_debate=false → 略過      ║
+║         |-- Round 1：Critic 批判                        ║
+║         │      |-- Verdict: PASS → [DEBATE-PASS-R1] 收斂║
+║         │      +-- Verdict: FAIL → Round 2              ║
+║         |-- Round 2：Worker 修復 → Critic 二次批判      ║
+║               |-- Verdict: PASS → [DEBATE-PASS-R2] 收斂║
+║               +-- Verdict: FAIL → [DEBATE-UNRESOLVED]  ║
 ╚══════════════════════════════════════════════════════╝
   |
   v
@@ -1282,6 +1293,152 @@ WARN 清單（若有）：
 
 ---
 
+## §7.8 Team Debate — 同職能雙 Agent 交替批判（ADR-031，Phase 1）
+
+<!-- ADR-031 Team Debate 機制 — Sprint 124 / #383 -->
+
+### 觸發條件
+
+Team Debate 在以下條件下啟用：
+
+```
+啟用條件（以下所有條件均需滿足）：
+  1. story_type ∈ {FEATURE, INFRA, SECURITY, INTEGRATION}
+  2. doc_only = false
+  3. team_debate ≠ false（未被明確關閉）
+  4. Story 角色為 Developer（Phase 1 限定）
+
+豁免條件（任一即豁免）：
+  - doc_only = true → 跳過（文件類 Story，成本不值得）
+  - story_type ∈ {RESEARCH, DESIGN} → 跳過
+  - team_debate = false（明確關閉）→ 跳過，回退至標準單一 agent 自審
+  - size = S 且 Scrum Master 未明確啟用 → 跳過（S 規模預設豁免）
+```
+
+若豁免：輸出 `[DEBATE-SKIP] {原因}`，繼續進入 §8 DoD 自檢。
+
+### 執行流程
+
+```
+Step 1：確認觸發
+  → 輸出：[DEBATE-START] 啟用 Team Debate（ADR-031 Phase 1）
+
+Step 2：當前 subagent 身份確認
+  本 subagent 即 Worker（Agent A）。至此已完成：
+    - TDD 開發（§3）
+    - Spec Compliance self-review（§5）
+    - Code Quality self-review（§6）
+    - Runtime Verification（§6.5）
+    - Security self-review（§7，條件觸發）
+    - pr-review-toolkit 審查（§7.5，條件觸發）
+  回傳主 session：WORKER_COMPLETE + branch + worktree path
+
+  注意：若本 subagent 為 Critic（Agent B），執行 §7.8.2 Critic 批判流程，
+        寫入 .claude/debate/critique-round-{N}.md 後回傳主 session。
+
+Step 3：（由主 session 協調）派遣 Critic（Agent B）
+  → 讀取 Worker 產出（git diff 或修改檔案清單）
+  → 執行獨立批判（正確性、設計、測試覆蓋、安全性）
+  → 寫入 .claude/debate/critique-round-1.md
+
+Step 4：主 session 讀取 critique-round-1.md
+  ├─ Verdict: PASS → [DEBATE-PASS-R1] 收斂，繼續 §8
+  └─ Verdict: FAIL → 主 session 傳入批判結果，Worker 執行 Round 2 修復
+
+Step 5（Round 2，若 Round 1 FAIL）：
+  Worker 讀取 critique-round-1.md → 逐項回應（accept/reject）→ 修復 → commit
+  → 主 session 派遣 Critic 二次批判 → critique-round-2.md
+
+Step 6（Round 2 收斂）：
+  ├─ Verdict: PASS → [DEBATE-PASS-R2] 收斂，繼續 §8
+  └─ Verdict: FAIL → [DEBATE-UNRESOLVED] 強制收斂（禁止 Round 3）
+     → 標記升級候選，記錄至 PR description
+     → 繼續 §8（不阻塞）
+```
+
+### §7.8.1 Worker 修復規則（Round 2）
+
+Worker 接收 critique-round-1.md 後：
+
+```
+1. 逐項閱讀 Issues Found
+2. 對每項 Issue 決定 accept / reject：
+   - accept：說明修復方式，執行修復，commit
+   - reject：說明拒絕理由（需有合理理由，如「此為已知設計取捨」）
+3. Commit message 格式：
+   fix: Team Debate Round 2 修復 — {story_id}
+4. 所有 HIGH severity Issue 必須 accept（不可 reject）
+```
+
+### §7.8.2 Critic 批判流程
+
+當本 subagent 以 Critic 身份被派遣時：
+
+```
+1. 讀取 Worker 的所有修改檔案（git diff origin/main...HEAD 或修改檔案清單）
+2. 讀取 Story AC（從 sprint_file 取得）
+3. 執行 4 維度批判：
+   - 正確性：每項 AC 是否有對應實作？邊界條件？
+   - 設計：SOLID 原則？耦合度？命名清晰度？
+   - 測試覆蓋：是否真正 TDD？測試是否僅測 happy path？
+   - 安全性：外部輸入是否過濾？有無硬編碼 secrets？
+4. 確認目錄存在：mkdir -p .claude/debate/
+5. 寫入 .claude/debate/critique-round-{N}.md（格式見下方）
+6. 回傳主 session：CRITIC_COMPLETE + Verdict + 批判摘要
+```
+
+**批判結果格式**：
+
+```markdown
+# Critique Round {N}
+
+## Verdict: PASS | FAIL
+
+## Issues Found
+- [SEVERITY: HIGH|MED|LOW] {問題描述}
+  - 位置：{file}:{line}
+  - 建議：{改善方向}
+
+## Summary
+{總結評語，說明主要發現與整體評估}
+```
+
+**Verdict 判定規則**：
+- 有 HIGH severity Issue → Verdict: FAIL
+- 有 MED severity Issue 且超過 2 項 → Verdict: FAIL
+- 只有 LOW severity Issue → Verdict: PASS（附 Issues Found，但不阻塞）
+- Issues Found 為空 → Verdict: PASS
+
+**重要原則**：
+- 不能修改任何代碼，只能批判
+- 批判必須具體，指出檔案和行號
+- 不為了批判而批判：若真的找不到問題，Verdict = PASS
+
+### §7.8.3 [DEBATE-UNRESOLVED] 處置
+
+| project_level | 處置行為 |
+|---------------|---------|
+| `low` | 標記 [DEBATE-UNRESOLVED] 後直接進入 §8，PR description 附上未解決清單 |
+| `medium` / `high` | 輸出升級通知，等待主 session / 使用者決策 |
+
+若未解決問題包含 HIGH severity 設計問題，可升級至 ESCALATE: DESIGN_ISSUE。
+
+### §7.8.4 PR Description 附加資訊
+
+Team Debate 收斂後，PR description 需附加：
+
+```
+## Team Debate 摘要
+
+- 批判輪數：{1 / 2}
+- 最終 Verdict：{PASS / [DEBATE-UNRESOLVED]}
+- Critic 發現：{主要問題摘要，若無則填「無重大問題」}
+- Worker 修復：{修復摘要，若 Round 1 PASS 則填「N/A（Round 1 直接通過）」}
+- 批判紀錄：`.claude/debate/critique-round-{N}.md`
+```
+
+---
+
 ## §8 DoD 自檢
 
 完成所有 self-review 後，逐項確認：
@@ -1335,6 +1492,46 @@ chore: #307 US-272 Story-Lifecycle 強制 git commit Hard Gate
   ```
 - 並回傳 `ESCALATE: DESIGN_ISSUE`（附上 `[COMMIT-FAIL]` 錯誤詳情），由主 session 決定後續處置
 - 不得靜默忽略 commit 失敗繼續執行後續步驟
+
+此 Gate 不受 `bypass=true` 豁免。
+</HARD-GATE>
+
+---
+
+## §8.06 PR Description Quality Gate（#461）
+
+<!-- #461 PR Description Quality Gate 強制 Summary + AC Checklist — Sprint 124 -->
+
+<HARD-GATE>
+**PR body 品質門禁**：執行 `gh pr create` 時，PR body **必須**包含以下兩個段落，缺一不可：
+
+### 必要段落
+
+**1. Summary 段落**（AC1）
+
+```markdown
+## Summary
+
+{簡述本次 PR 的變更內容、目的與影響範圍。1–3 句話。}
+```
+
+**2. AC Checklist 段落**（AC2）
+
+```markdown
+## AC Checklist
+
+- [x] AC1: {AC 描述}
+- [x] AC2: {AC 描述}
+...（逐一列出 Story 的所有 AC，完成打勾）
+```
+
+### 違規處理
+
+| 缺失項目 | 處理方式 |
+|---------|---------|
+| 缺少 Summary 段落 | PR body 補充後重新執行 `gh pr create` |
+| 缺少 AC Checklist 段落 | PR body 補充後重新執行 `gh pr create` |
+| AC Checklist 未打勾（`- [ ]`） | 視為尚未完成，Story-Lifecycle 不得繼續流程 |
 
 此 Gate 不受 `bypass=true` 豁免。
 </HARD-GATE>
@@ -1648,12 +1845,17 @@ status: "PASS"          # 必填：PASS | FAIL | ESCALATE
 summary: ""             # 必填：≤50 字的結果說明
 modified_files: []      # 必填：所有被修改的檔案清單（含變更描述）
 commit_sha: ""          # PASS 時必填；FAIL 時若有部分 commit 填最後 SHA，否則 N/A
-escalation: null        # 升級時必填：DESIGN_ISSUE | CONTEXT_OVERFLOW | REQUIREMENT_AMBIGUITY | DEPENDENCY_MISSING | SECURITY_CRITICAL
+escalation: null        # 升級時必填：DESIGN_ISSUE | CONTEXT_OVERFLOW | REQUIREMENT_AMBIGUITY | DEPENDENCY_MISSING | SECURITY_CRITICAL | DEBATE_DESIGN_ISSUE
 uncertainty_check:      # 必填：不確定性三問檢查結果（US-214，開始前準備步驟 7）
   assumptions: []       # 第 (1) 項：假設清單（若無則為空陣列）
   uncertain_items: []   # 第 (2) 項：[UNCERTAIN] 標記項目清單（含驗證方式與驗證結果）
   queries_needed: []    # 第 (3) 項：需查閱的項目清單（若無則為空陣列）
   assumption_violation: false  # 若 Spec Compliance FAIL 且三問(2)(3)均為「無」→ true，輸出 [ASSUMPTION-VIOLATION]
+team_debate:            # Team Debate 結果（§7.8，ADR-031，豁免時填 null）
+  status: null          # PASS | UNRESOLVED | SKIPPED | null
+  rounds: 0             # 執行批判輪數（0 = 豁免）
+  final_verdict: null   # Critic 最終 Verdict（PASS / FAIL / null）
+  critique_files: []    # 批判紀錄檔案路徑清單（如 .claude/debate/critique-round-1.md）
 # --- Phase 2 欄位（AC3 抽樣邏輯已實作，schema 啟用待後續版本）---
 # sampling_triggered: false   # Phase 2 AC3：是否觸發外部抽樣審查（邏輯已實作於 §AC3 章節）
 # batch_index: null           # Phase 2 AC4：M/L size 分批執行批次索引
@@ -1681,6 +1883,7 @@ uncertainty_check:      # 必填：不確定性三問檢查結果（US-214，開
 - Spec Compliance：PASS（{一句話說明}）
 - Code Quality：PASS（{一句話說明}）
 - Security：PASS / SKIP（{一句話說明或「未觸發安全審查條件」}）
+- Team Debate：{PASS-R1 / PASS-R2 / UNRESOLVED / SKIPPED}（{一句話說明或豁免原因}）
 
 **不確定性三問摘要**（uncertainty_check）：
 - 假設：{假設清單，若無則填「無」}
@@ -1705,6 +1908,7 @@ uncertainty_check:      # 必填：不確定性三問檢查結果（US-214，開
   - REQUIREMENT_AMBIGUITY：AC 描述模糊或存在矛盾，無法判斷完成標準
   - DEPENDENCY_MISSING：依賴的文件、資源或前置條件不存在
   - SECURITY_CRITICAL：發現 Critical 安全問題，需 Security Engineer 人工介入
+  - DEBATE_DESIGN_ISSUE：Team Debate 2 輪仍 FAIL 且含 HIGH severity 設計問題，需 Architect 介入
 ```
 
 **升級決策規則（主 session 職責）：**
@@ -1716,6 +1920,7 @@ uncertainty_check:      # 必填：不確定性三問檢查結果（US-214，開
 | REQUIREMENT_AMBIGUITY | 暫停 Sprint 執行，升級至 PO 釐清 AC |
 | DEPENDENCY_MISSING | 暫停 Sprint 執行，解決依賴後重試 |
 | SECURITY_CRITICAL | 暫停 Sprint 執行，觸發 security-review Skill |
+| DEBATE_DESIGN_ISSUE | 暫停 Sprint 執行，升級至 Architect 評估（Team Debate 未解決設計問題） |
 
 ---
 
@@ -1730,6 +1935,7 @@ uncertainty_check:      # 必填：不確定性三問檢查結果（US-214，開
 | 依賴的 ADR、SDD、前置 Story 不存在或未完成 | DEPENDENCY_MISSING | 需解決依賴後重試 |
 | 發現未受防護的外部輸入、硬編碼 API 金鑰等 Critical 安全問題 | SECURITY_CRITICAL | 需 Security Engineer 人工介入 |
 | subagent context 接近上限（Phase 2 實作） | CONTEXT_OVERFLOW | Phase 2 §AC4 fallback 策略處理 |
+| Team Debate 2 輪仍 FAIL 且含 HIGH severity 設計問題 | DEBATE_DESIGN_ISSUE | 需 Architect 介入評估設計問題 |
 
 ---
 
@@ -1753,5 +1959,7 @@ uncertainty_check:      # 必填：不確定性三問檢查結果（US-214，開
 ## 參照文件
 
 - **ADR-007**：`docs/adr/ADR-007-story-lifecycle-subagent.md`（架構決策、介面契約完整定義）
+- **ADR-031**：`docs/adr/ADR-031-team-debate.md`（Team Debate 機制決策）
+- **team-debate/SKILL.md**：`skills/team-debate/SKILL.md`（Team Debate 完整 Skill 定義）
 - **developer-prompt.md**：`skills/sprint-execution/developer-prompt.md`（TDD 細節、同檔案衝突偵測、Tech Debt 規則）
 - **SKILL.md**：`skills/sprint-execution/SKILL.md`（Sprint 執行流程、Hard Gates、doc-only 識別規則）

--- a/skills/sprint-planning/SKILL.md
+++ b/skills/sprint-planning/SKILL.md
@@ -42,7 +42,8 @@ Sprint Planning 是每個 Sprint 週期的起點儀式。由 **PO** 主持，**A
 - [ ] **PO** 掃描 GitHub open issues，對未分類 issues 執行 Triage（<!-- Claude Code -->invoke shikigami:issue-management Triage<!-- OpenCode -->使用 issue-management skill<!-- /OpenCode -->）
 - [ ] 記錄 Sprint Planning 開始時間：`START_TIME=$(date '+%Y-%m-%dT%H:%M+08:00')`
 - [ ] **PO** 執行 Backlog 排序與 Story 選取（詳見 [po-prompt.md](./po-prompt.md) Round 1）
-- [ ] 檢查選入 Story 是否標注「需要 ADR」— 若需要，ADR 必須已 Accepted
+- [ ] **PO Round 1 ADR 自動納入**（#456）：PO 選取 Story 後，掃描 Architect 技術評估的 ADR 欄位；若有標注「已補建 #N（RESEARCH）」的 ADR Story，自動將該 ADR RESEARCH Story 一併選入同一 Sprint（AC2）
+- [ ] 檢查選入 Story 是否標注「需要 ADR」— 若需要，ADR 必須已 Accepted 或已在本 Sprint 納入 ADR RESEARCH Story
 - [ ] **Architect** 技術評估（詳見 [architect-prompt.md](./architect-prompt.md)）
 - [ ] **QA** 驗收標準確認（詳見 [qa-prompt.md](./qa-prompt.md)）
 - [ ] 上個 Sprint 的 Retro Action Items 自動列入 Backlog（若有未完成項目）

--- a/skills/sprint-planning/architect-prompt.md
+++ b/skills/sprint-planning/architect-prompt.md
@@ -105,6 +105,30 @@ Architect 在技術評估時，必須檢查每個 Story 是否涉及 SDD 定義�
 - 若所有 Story 皆獨立，Phase 2 區塊可省略，填「無」
 - **SHIKIGAMI_MAX_PARALLEL=1 時**：Phase 1 與 Phase 2 合併為單一循序佇列，不出現平行分組（輸出「強制循序，無平行分群」）
 
+### ADR 依賴分群規則（#456 AC3）
+
+<!-- #456 ADR 自動納入 Sprint — Sprint 124 -->
+
+當 Sprint 中含有由 Architect 自動補建的 ADR RESEARCH Story 時，**強制應用以下分群**：
+
+| 分群 | 包含 Story | 說明 |
+|------|-----------|------|
+| **ADR Phase 1（必須先執行）** | ADR RESEARCH Story（`已補建 #N`） | ADR 必須先完成以確立技術決策，才能進入依賴 Story 的開發 |
+| **ADR Phase 2（等 ADR 完成後執行）** | 依賴該 ADR 的 Story | ADR Accepted 後方可執行 |
+
+**輸出格式**（加入技術評估表格下方）：
+
+```markdown
+### ADR 依賴分群（#456）
+
+> ADR Phase 1 必須在 ADR Phase 2 前完成。
+
+**ADR Phase 1（先執行）**：#{ADR_Issue_number} — {ADR 決策主題}
+**ADR Phase 2（ADR Accepted 後執行）**：#{story_id} — {Story 標題}
+```
+
+**豁免條件**：Sprint 中無 ADR RESEARCH Story 時，此分群規則不適用，輸出「無 ADR 依賴分群」。
+
 ---
 
 ## 方法論適用性評估
@@ -175,6 +199,57 @@ Architect 在技術評估時，必須檢查每個 Story 是否涉及 SDD 定義�
 | RESEARCH | N/A | 無 Contract（產出 Spike Report） | RESEARCH 恆為 N/A |
 
 > **衝突排除說明**：FEATURE 與 INTEGRATION 雖共享 Architect 作為 Contract Owner，但在同一 Sprint 中不會對同一介面同時產生 FEATURE 和 INTEGRATION Story，因此不存在 Contract 衝突。若罕見情況下出現同一介面的 FEATURE + INTEGRATION 並行，由 Architect 統一協調，以 INTEGRATION Contract 為主文件，FEATURE Contract 作為補充。
+
+---
+
+## ADR 補建自動行為（#456）
+
+<!-- #456 ADR 自動納入 Sprint — Sprint 124 -->
+
+在技術評估（Refinement 輸出）階段，Architect 若判斷某 Story **需要 ADR 但尚無對應 Accepted ADR**，必須自動執行以下步驟：
+
+### ADR 補建觸發條件
+
+| 條件 | 觸發 |
+|------|------|
+| Story 涉及新技術選型、架構邊界變更或跨模組設計決策 | 是 → 觸發 ADR 補建 |
+| 已有 Accepted ADR 對應 | 否 → 不觸發 |
+| RESEARCH type Story | 否 → RESEARCH 本身為調查性質，不強制 ADR |
+
+### ADR 補建流程（AC1）
+
+當觸發條件成立時，Architect **自動建立 ADR Issue**：
+
+```bash
+gh issue create \
+  -R ${OWNER_REPO} \
+  --title "RESEARCH: ADR — {決策主題}" \
+  --body "## ADR 補建需求
+
+**觸發 Story**：#{story_number} {story_title}
+**決策主題**：{具體需要 ADR 的技術決策描述}
+**影響範圍**：{受影響的模組、介面或系統}
+
+## 驗收標準
+- [ ] ADR 文件建立於 docs/adr/ 目錄
+- [ ] ADR 狀態標記為 Accepted
+- [ ] 相關 Story 更新 ADR 參照欄位
+
+> 此 Issue 由 Architect Refinement 自動建立。" \
+  --label "RESEARCH,size:S,story-points:1"
+```
+
+輸出 ADR Issue 建立確認：`[ADR-AUTO-CREATED] Issue #<N> — {決策主題}`
+
+### 技術評估表格 ADR 欄位更新
+
+ADR 補建觸發後，技術評估表格 `ADR 需求` 欄位格式：
+
+| ADR 需求欄位值 | 意義 |
+|--------------|------|
+| 無需 ADR | Story 不涉及架構決策，無需 ADR |
+| 已有 ADR-XXX（Accepted） | 已有對應 Accepted ADR，可進 Sprint |
+| **已補建 #N（RESEARCH）** | Architect 自動建立 ADR Issue #N，ADR Story 須先於本 Story 進 Sprint |
 
 ---
 

--- a/skills/team-debate/SKILL.md
+++ b/skills/team-debate/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: team-debate
+description: "Use when a Developer Story requires peer critique from an independent Critic Agent after implementation"
+---
+
+# Team Debate — 同職能雙 Agent 交替批判機制
+
+<!-- ADR-031 Team Debate 機制 — Sprint 124 / #383 -->
+
+## 1. 概述
+
+**Team Debate** 是 Story-Lifecycle 的品質增強機制。在 Developer Worker 完成實作與 self-review 後，派遣獨立的 Developer Critic Agent 執行外部批判，Worker 修復，最多 2 輪收斂。
+
+此機制基於 **ADR-031（Team Debate 機制）選項 C — 交替批判（2 輪上限）**，引入真正的外部視角，突破單一 Agent 認知盲點。
+
+---
+
+## 2. 適用條件（Phase 1）
+
+| 條件 | 說明 |
+|------|------|
+| **適用角色** | Developer only（Phase 1） |
+| **適用 Story 類型** | FEATURE、INFRA、SECURITY、INTEGRATION |
+| **豁免條件** | `doc_only=true` 的 Story（文件類不啟用，成本不值得） |
+| **豁免條件** | `story_type=RESEARCH` 的 Story |
+| **豁免條件** | `story_type=DESIGN` 的 Story |
+| **Size 門檻** | M/L 規模啟用；S 規模可由 Scrum Master 決定是否啟用 |
+
+**不適用角色（Phase 1 不包含）**：
+- PO、Scrum Master：流程管理角色，非產出角色
+- SRE、Security Engineer：低頻觸發，成本效益比不佳
+- UI/UX Designer：設計審查有獨立流程（Vision Critic）
+
+---
+
+## 3. Agent 角色定義
+
+### Worker（Agent A）
+
+- **職責**：執行 TDD 開發、self-review、接收批判後修復
+- **行為**：完整 Story-Lifecycle（TDD + Spec/Quality/Security self-review）
+- **修復義務**：接收 Critic 批判後必須逐項回應（accept/reject + 理由）並修復 accept 項目
+- **context**：獨立 worktree，不帶 Critic 的批判歷史進入修復
+
+### Critic（Agent B）
+
+- **職責**：獨立批判 Worker 的產出，不修改代碼
+- **行為**：讀取 Worker 的 branch + 產出，從外部視角進行批判
+- **批判維度**：
+  1. **正確性**：AC 是否全部覆蓋？邊界條件是否處理？
+  2. **設計**：是否符合 SOLID 原則？耦合度？單一職責？
+  3. **測試覆蓋**：測試是否充分？Red 階段是否真正先寫失敗測試？
+  4. **安全性**：外部輸入是否受保護？有無硬編碼 secrets？
+- **禁止行為**：不直接修改代碼；不與 Worker 進行 context 共享
+
+---
+
+## 4. 通訊機制
+
+### 批判結果檔案路徑
+
+```
+.claude/debate/critique-round-{N}.md
+```
+
+### 批判結果格式
+
+```markdown
+# Critique Round {N}
+
+## Verdict: PASS | FAIL
+
+## Issues Found
+- [SEVERITY: HIGH|MED|LOW] {問題描述}
+  - 位置：{file}:{line}
+  - 建議：{改善方向}
+
+## Summary
+{總結評語，說明主要發現與整體評估}
+```
+
+### 規則
+
+- `N` 從 1 開始，最大為 2
+- `Verdict: PASS`：Critic 認可 Worker 產出，無需修復
+- `Verdict: FAIL`：Critic 發現問題，Worker 需修復後再次批判
+- 若 Issues Found 為空，Verdict 必須為 PASS
+
+---
+
+## 5. 收斂機制（2 輪硬上限）
+
+```
+Round 1：
+  Worker 完成實作 + self-review
+    ↓
+  Critic 讀取產出 → 寫入 critique-round-1.md
+    ├─ Verdict: PASS → 收斂，進入 PR 流程
+    └─ Verdict: FAIL → 繼續 Round 2
+
+Round 2：
+  Worker 讀取 critique-round-1.md → 修復 → commit
+    ↓
+  Critic 讀取修復後產出 → 寫入 critique-round-2.md
+    ├─ Verdict: PASS → 收斂，進入 PR 流程
+    └─ Verdict: FAIL → [DEBATE-UNRESOLVED] 強制收斂
+```
+
+**強制收斂規則**：
+- 第 2 輪後無論 Verdict 均強制收斂，禁止第 3 輪批判
+- Verdict: FAIL 後強制收斂時，標記 `[DEBATE-UNRESOLVED]`，由主 session 決定升級處置
+
+---
+
+## 6. 執行流程（主 session 協調）
+
+### 步驟 1：觸發判斷
+
+```
+主 session 接收 Story 參數後，判斷是否啟用 Team Debate：
+
+若 doc_only=true → 跳過 Team Debate，使用標準 Story-Lifecycle
+若 story_type ∈ {RESEARCH, DESIGN} → 跳過 Team Debate
+若 size=S 且 Scrum Master 未明確啟用 → 跳過 Team Debate
+否則 → 啟用 Team Debate（Developer Story，Phase 1）
+```
+
+### 步驟 2：派遣 Worker（Agent A）
+
+```
+派遣 Story-Lifecycle subagent（Worker 角色）
+  - 使用標準 story-lifecycle-prompt.md
+  - 執行完整 TDD + self-review 流程
+  - commit 至 branch，回傳 branch + worktree path
+  - 輸出：WORKER_BRANCH={branch}、WORKER_COMMIT={sha}
+```
+
+### 步驟 3：派遣 Critic（Agent B）— Round 1
+
+```
+派遣 Developer subagent（Critic 角色）
+  - 讀取 Worker 的 branch 產出（git diff vs main 或讀取修改檔案）
+  - 執行獨立批判（4 維度：正確性、設計、測試覆蓋、安全性）
+  - 寫入 .claude/debate/critique-round-1.md
+  - 回傳 Verdict（PASS/FAIL）
+```
+
+### 步驟 4a：若 Round 1 Verdict = PASS
+
+```
+收斂，進入 PR 流程
+輸出：[DEBATE-PASS] Round 1 批判通過，收斂
+```
+
+### 步驟 4b：若 Round 1 Verdict = FAIL
+
+```
+派遣 Worker（修復）：
+  - 讀取 critique-round-1.md
+  - 逐項回應（accept/reject + 理由）
+  - 修復所有 accept 項目
+  - commit 修復，回傳 WORKER_COMMIT_R2={sha}
+
+派遣 Critic — Round 2：
+  - 讀取修復後產出
+  - 執行二次批判
+  - 寫入 .claude/debate/critique-round-2.md
+  - 回傳 Verdict（PASS/FAIL）
+```
+
+### 步驟 5：Round 2 後強制收斂
+
+```
+若 Round 2 Verdict = PASS：
+  收斂，進入 PR 流程
+  輸出：[DEBATE-PASS] Round 2 批判通過，收斂
+
+若 Round 2 Verdict = FAIL：
+  強制收斂
+  輸出：[DEBATE-UNRESOLVED] 2 輪後仍有未解決問題
+  標記升級候選，由主 session 決定是否 ESCALATE
+  仍進入 PR 流程，PR description 附上 debate 紀錄
+```
+
+### 步驟 6：PR 流程
+
+```
+Worker 執行 git push → gh pr create
+PR description 必須附上 debate 摘要：
+  - Debate rounds 數
+  - 最終 Verdict
+  - 若 [DEBATE-UNRESOLVED]，列出未解決問題
+```
+
+---
+
+## 7. Critic Prompt 指引
+
+Critic Agent 派遣時使用以下 prompt 框架：
+
+```
+你是 Developer Critic Agent，負責對以下 Story 的實作進行獨立外部批判。
+你不是作者，你沒有看過開發過程，你只看最終產出。
+
+Story ID：{story_id}
+Worker Branch：{branch}
+Story AC：{ac_list}
+
+批判任務：
+1. 讀取 Worker 修改的所有檔案（git diff 或讀取修改檔案清單）
+2. 逐項檢查 AC 是否有對應實作
+3. 從 4 個維度批判（正確性、設計、測試覆蓋、安全性）
+4. 輸出批判結果至 .claude/debate/critique-round-{N}.md（格式見 §4）
+
+重要原則：
+- 你的批判必須具體，指出檔案和行號
+- 你不能修改任何代碼，只能批判
+- 若你找不到明確問題，Verdict = PASS（不要為了批判而批判）
+- [SEVERITY: HIGH] 僅用於 AC 缺失或安全漏洞；設計優化建議用 LOW/MED
+```
+
+---
+
+## 8. [DEBATE-UNRESOLVED] 升級處置
+
+| 主 session 行為 | 條件 | 說明 |
+|----------------|------|------|
+| 繼續進入 PR | 預設 | `project_level=low` 時，標記後直接進入 PR |
+| 通知等待確認 | `project_level=medium/high` | 留言通知使用者，等待決策 |
+| 升級至 Architect | 特殊情況 | 若未解決問題屬設計層面（HIGH severity），升級 DESIGN_ISSUE |
+
+---
+
+## 9. 豁免機制（可關閉）
+
+Scrum Master 可明確關閉 Team Debate：
+
+```yaml
+# Story-Lifecycle 輸入中加入：
+team_debate: false  # 明確關閉，fallback 至標準單一 agent 模式
+```
+
+關閉後，Story 使用標準 Story-Lifecycle 流程（單一 subagent 自審）。
+
+---
+
+## 10. Token 成本參考
+
+| 場景 | 預估 token 倍率 |
+|------|-----------------|
+| Round 1 PASS（1 輪即收斂） | ~1.8x |
+| Round 2 收斂（2 輪） | ~2.5x |
+| [DEBATE-UNRESOLVED]（2 輪強制收斂） | ~2.5x |
+
+---
+
+## 參照文件
+
+- **ADR-031**：`docs/adr/ADR-031-team-debate.md`（架構決策）
+- **story-lifecycle-prompt.md**：`skills/sprint-execution/story-lifecycle-prompt.md`（整合點）
+- **developer.md**：`agents/developer.md`（Worker/Critic 角色定義）

--- a/tests/test-383-team-debate.sh
+++ b/tests/test-383-team-debate.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# test-383-team-debate.sh — Team Debate 機制驗證測試（ADR-031 Phase 1）
+# Story: #383 feat: 同職能 Team Debate — 雙 Agent 交替批判機制（方案 C）
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== test-383-team-debate.sh ==="
+echo ""
+
+# -------------------------------------------------------
+# AC1: Worker 實作後 Critic 產出獨立批判報告
+# → 驗證：SKILL.md 定義 Critic 批判格式（critique-round-N.md）
+# -------------------------------------------------------
+echo "[AC1] Critic 批判格式定義"
+
+SKILL="$REPO_ROOT/skills/team-debate/SKILL.md"
+
+if [[ ! -f "$SKILL" ]]; then
+  fail "skills/team-debate/SKILL.md 不存在"
+else
+  pass "skills/team-debate/SKILL.md 存在"
+fi
+
+if grep -q "critique-round-{N}.md" "$SKILL" 2>/dev/null; then
+  pass "批判檔案路徑格式 critique-round-{N}.md 已定義"
+else
+  fail "批判檔案路徑格式未定義"
+fi
+
+if grep -q "## Verdict: PASS | FAIL" "$SKILL" 2>/dev/null; then
+  pass "批判結果格式包含 Verdict 欄位"
+else
+  fail "批判結果格式缺少 Verdict 欄位"
+fi
+
+if grep -q "SEVERITY: HIGH|MED|LOW" "$SKILL" 2>/dev/null; then
+  pass "批判結果格式包含 SEVERITY 分級"
+else
+  fail "批判結果格式缺少 SEVERITY 分級"
+fi
+
+echo ""
+
+# -------------------------------------------------------
+# AC2: Worker 接收批判後修復，最多 2 輪
+# → 驗證：SKILL.md 定義 2 輪硬上限，story-lifecycle 有 §7.8 段落
+# -------------------------------------------------------
+echo "[AC2] 2 輪硬上限與修復循環"
+
+if grep -q "2 輪硬上限\|最多 2 輪\|禁止 Round 3" "$SKILL" 2>/dev/null; then
+  pass "SKILL.md 定義 2 輪硬上限"
+else
+  fail "SKILL.md 未定義 2 輪硬上限"
+fi
+
+LIFECYCLE="$REPO_ROOT/skills/sprint-execution/story-lifecycle-prompt.md"
+
+if grep -q "§7.8 Team Debate" "$LIFECYCLE" 2>/dev/null; then
+  pass "story-lifecycle-prompt.md 包含 §7.8 Team Debate 段落"
+else
+  fail "story-lifecycle-prompt.md 缺少 §7.8 Team Debate 段落"
+fi
+
+if grep -q "Round 2" "$LIFECYCLE" 2>/dev/null; then
+  pass "story-lifecycle-prompt.md 定義 Round 2 修復流程"
+else
+  fail "story-lifecycle-prompt.md 缺少 Round 2 修復流程"
+fi
+
+if grep -q "Worker 修復規則" "$LIFECYCLE" 2>/dev/null || grep -q "§7.8.1" "$LIFECYCLE" 2>/dev/null; then
+  pass "story-lifecycle-prompt.md 定義 Worker 修復規則"
+else
+  fail "story-lifecycle-prompt.md 缺少 Worker 修復規則"
+fi
+
+echo ""
+
+# -------------------------------------------------------
+# AC3: 2 輪後仍未收斂 → [DEBATE-UNRESOLVED] 升級
+# -------------------------------------------------------
+echo "[AC3] [DEBATE-UNRESOLVED] 升級機制"
+
+if grep -q "DEBATE-UNRESOLVED" "$SKILL" 2>/dev/null; then
+  pass "SKILL.md 定義 [DEBATE-UNRESOLVED] 標記"
+else
+  fail "SKILL.md 未定義 [DEBATE-UNRESOLVED] 標記"
+fi
+
+if grep -q "DEBATE-UNRESOLVED" "$LIFECYCLE" 2>/dev/null; then
+  pass "story-lifecycle-prompt.md 包含 [DEBATE-UNRESOLVED] 處置規則"
+else
+  fail "story-lifecycle-prompt.md 缺少 [DEBATE-UNRESOLVED] 處置規則"
+fi
+
+if grep -q "DEBATE_DESIGN_ISSUE" "$LIFECYCLE" 2>/dev/null; then
+  pass "story-lifecycle-prompt.md 定義 DEBATE_DESIGN_ISSUE 升級類型"
+else
+  fail "story-lifecycle-prompt.md 缺少 DEBATE_DESIGN_ISSUE 升級類型"
+fi
+
+echo ""
+
+# -------------------------------------------------------
+# AC4: 通訊透過檔案交換（.claude/debate/）
+# -------------------------------------------------------
+echo "[AC4] 檔案交換通訊機制"
+
+if grep -q "\.claude/debate/" "$SKILL" 2>/dev/null; then
+  pass "SKILL.md 定義 .claude/debate/ 通訊路徑"
+else
+  fail "SKILL.md 未定義 .claude/debate/ 通訊路徑"
+fi
+
+if grep -q "\.claude/debate/" "$LIFECYCLE" 2>/dev/null; then
+  pass "story-lifecycle-prompt.md 引用 .claude/debate/ 通訊路徑"
+else
+  fail "story-lifecycle-prompt.md 未引用 .claude/debate/ 通訊路徑"
+fi
+
+# 輸出 schema 包含 critique_files
+if grep -q "critique_files" "$LIFECYCLE" 2>/dev/null; then
+  pass "輸出 schema 包含 critique_files 欄位"
+else
+  fail "輸出 schema 缺少 critique_files 欄位"
+fi
+
+echo ""
+
+# -------------------------------------------------------
+# AC5: Phase 1 僅 Developer 角色適用
+# -------------------------------------------------------
+echo "[AC5] Phase 1 僅 Developer 角色適用"
+
+if grep -q "Phase 1.*Developer\|Developer.*Phase 1" "$SKILL" 2>/dev/null; then
+  pass "SKILL.md 明確限制 Phase 1 為 Developer 角色"
+else
+  fail "SKILL.md 未限制 Phase 1 角色範圍"
+fi
+
+DEVELOPER_AGENT="$REPO_ROOT/agents/developer.md"
+
+if grep -q "Team Debate\|Worker.*Critic\|Critic.*Worker" "$DEVELOPER_AGENT" 2>/dev/null; then
+  pass "agents/developer.md 包含 Worker/Critic 角色說明"
+else
+  fail "agents/developer.md 缺少 Worker/Critic 角色說明"
+fi
+
+if grep -q "PO.*不包含\|不適用角色\|不含.*PO\|PO.*不涉及\|PO.*非產出" "$SKILL" 2>/dev/null; then
+  pass "SKILL.md 說明 Phase 1 不包含 PO 等非產出角色"
+else
+  fail "SKILL.md 未說明 Phase 1 不包含哪些角色"
+fi
+
+echo ""
+
+# -------------------------------------------------------
+# 額外驗證：scrum-master SKILL.md 引用 team-debate
+# -------------------------------------------------------
+echo "[Extra] scrum-master SKILL.md 引用 team-debate"
+
+SCRUM_SKILL="$REPO_ROOT/skills/scrum-master/SKILL.md"
+
+if grep -q "team-debate" "$SCRUM_SKILL" 2>/dev/null; then
+  pass "scrum-master/SKILL.md 包含 team-debate Skill 引用"
+else
+  fail "scrum-master/SKILL.md 缺少 team-debate Skill 引用"
+fi
+
+echo ""
+
+# -------------------------------------------------------
+# 額外驗證：輸入 schema 包含 team_debate 欄位
+# -------------------------------------------------------
+echo "[Extra] story-lifecycle 輸入 schema 含 team_debate 欄位"
+
+if grep -q "team_debate:" "$LIFECYCLE" 2>/dev/null; then
+  pass "story-lifecycle-prompt.md 輸入 schema 包含 team_debate 欄位"
+else
+  fail "story-lifecycle-prompt.md 輸入 schema 缺少 team_debate 欄位"
+fi
+
+echo ""
+
+# -------------------------------------------------------
+# 結果統計
+# -------------------------------------------------------
+TOTAL=$((PASS + FAIL))
+echo "=== 結果：$PASS/$TOTAL PASS ==="
+echo ""
+
+if [[ $FAIL -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED ($FAIL/$TOTAL)"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Sprint 124 三個 S-size Stories 打包交付：ADR 自動補建機制（#456）、PR 描述品質門禁（#461）、ci-health-check.sh 整合至 Cruise SRE（#463）。

## AC Checklist

### #456 ADR 自動納入 Sprint（S, 1pt）
- [x] AC1: Architect 評估需要 ADR 時自動建 Issue（RESEARCH, S, 1pt）— architect-prompt.md 新增「ADR 補建自動行為」章節含 gh issue create 流程
- [x] AC2: PO Round 1 自動將依賴的 ADR Story 選入同一 Sprint — SKILL.md Checklist 新增 ADR 自動納入步驟
- [x] AC3: 平行分群：ADR Phase 1，依賴 Story Phase 2 — architect-prompt.md 分群規則新增「ADR 依賴分群規則」

### #461 PR Description Quality Gate（S, 1pt）
- [x] AC1: PR body 必須包含 Summary 段落 — §8.06 HARD-GATE 強制要求
- [x] AC2: PR body 必須包含 AC Checklist — §8.06 HARD-GATE 強制要求，含違規處理表格

### #463 ci-health-check.sh 整合至 Cruise SRE（S, 2pt）
- [x] AC1: SRE 巡檢自動執行 ci-health-check.sh — SRE 巡檢指引開頭新增 Step 0 健康檢查
- [x] AC2: 健康檢查結果納入 SRE 巡檢報告 — 巡檢結果格式新增 ci_health_check 欄位
- [x] AC3: 腳本不存在時 graceful fallback — 腳本存在性檢查 + [SKIPPED] 靜默跳過