### PR TITLE
fix: #470 PR 顆粒度規範 — 每 Story 對應獨立 PR

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "shikigami",
       "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-      "version": "0.83.3",
+      "version": "0.83.4",
       "source": "./",
       "author": {
         "name": "KCTW"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shikigami",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-  "version": "0.83.3",
+  "version": "0.83.4",
   "author": {
     "name": "KCTW"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **專案名稱**：Shikigami（式神）
 - **性質**：Claude Code Plugin — AI Agent Scrum Team 框架
-- **目前版本**：v0.83.3
+- **目前版本**：v0.83.4
 - **授權**：MIT
 - **Repository**：https://github.com/KCTW/shikigami
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 式神 Shikigami — AI Agent Scrum Team 框架
 
-![Version](https://img.shields.io/badge/version-v0.83.3-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-v0.83.4-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)
 ![Sprints](https://img.shields.io/badge/sprints-112%2B-orange?style=flat-square)
 ![Skills](https://img.shields.io/badge/skills-28-purple?style=flat-square)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "shikigami",
-  "version": "0.83.3",
+  "version": "0.83.4",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
   "author": "KCTW",
   "homepage": "https://github.com/KCTW/shikigami",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -124,6 +124,42 @@ Branch 命名規則參見 [第 3 節](#3-開發過程中)。
 必須先修復所有失敗測試。
 </HARD-GATE>
 
+### PR 顆粒度規範
+
+**規則：每個 Story 必須對應獨立 PR。**
+
+- 一個 Story = 一個 Feature Branch = 一個 PR
+- 不得將多個 Story 的變更打包在同一個 PR 中
+- 此規則確保 Review 可追溯性清晰，回滾影響範圍最小
+
+**例外：Strong Coupling**
+
+若兩個或多個 Story 之間存在 strong coupling（例如：共用介面定義無法拆分、原子性資料遷移），可允許例外打包，但**必須**在 PR 說明中明確標注：
+
+```markdown
+## Story Coupling 聲明
+
+本 PR 包含以下 Story（strong coupling 例外）：
+- #XXX Story 標題
+- #YYY Story 標題
+
+**Coupling 原因**：[說明為何無法拆分為獨立 PR]
+```
+
+若未標注 coupling 原因，視為違反規範，PR 不得合併。
+
+### Quality Gate：PR 提交前自我檢查
+
+建立 PR 前，必須確認以下 checklist：
+
+```
+[ ] 本 PR 是否只包含單一 Story 的變更？
+    → 是：繼續
+    → 否：是否有 strong coupling 原因？
+      → 有：在 PR 說明中填寫「Story Coupling 聲明」
+      → 無：必須拆分為獨立 PR，不得繼續
+```
+
 測試全數通過後，提供以下四個選項：
 
 ### 選項 1：本地合併（Merge to base branch）


### PR DESCRIPTION
## Summary

- AC1: `skills/git-workflow/SKILL.md` 新增「PR 顆粒度規範」明文規定每 Story 對應獨立 PR
- AC2: 允許 strong coupling 例外，但 PR 說明必須填寫「Story Coupling 聲明」，未標注不得合併
- AC3: 新增「Quality Gate：PR 提交前自我檢查」checklist，提示 Story coupling 確認
- chore: bump v0.83.3 → v0.83.4（Skill 行為變更）

## Motivation

Sprint 124 Retro Problem #2：PR #467 打包 3 個 Story（#456/#461/#463），Review 顆粒度降低。若其中一個 Story 需回改，影響範圍擴大。此規範防止未來重蹈覆轍。

## Test plan

- [x] `bash scripts/validate-skills.sh` 全部 PASS
- [x] `bash scripts/validate-version.sh` 全部 PASS
- [x] AC1 覆蓋：「PR 顆粒度規範」明文規定章節已加入
- [x] AC2 覆蓋：strong coupling 例外機制與 PR 聲明模板已加入
- [x] AC3 覆蓋：Quality Gate checklist 已加入

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)