### PR TITLE
fix: #472 CI unzip 缺失復發 — 回歸 sudo apt-get（移除 sudo -n 靜默失敗）

### DIFF
--- a/.github/workflows/new-issue-intake.yml
+++ b/.github/workflows/new-issue-intake.yml
@@ -23,12 +23,13 @@ jobs:
 
       - name: Install unzip
         run: |
-          # AC2: 已有 unzip 時靜默跳過
-          # AC1: 用 sudo -n 避免密碼互動卡住
-          # AC3: 無 unzip + 無 sudo 權限時 graceful fallback
-          command -v unzip > /dev/null 2>&1 || \
-            sudo -n apt-get install -y unzip 2>/dev/null || \
-            echo "unzip not available via sudo, proceeding anyway"
+          # 冪等：已有 unzip 時靜默跳過（快取 runner 路徑，AC2/AC3）
+          # 無快取 runner 需安裝 unzip，供 oven-sh/setup-bun 下載 Bun 使用（AC1）
+          # 注意：不使用 sudo -n，因 self-hosted runner 可能無 NOPASSWD 設定
+          # #464 的 sudo -n 修復導致靜默失敗（本 Story #472 回歸根因）
+          if ! command -v unzip > /dev/null 2>&1; then
+            sudo apt-get install -y unzip
+          fi
 
       - name: New Issue Intake
         uses: anthropics/claude-code-action@v1

--- a/docs/sprints/subagent-results/471.md
+++ b/docs/sprints/subagent-results/471.md
@@ -1,0 +1,62 @@
+# Story #471 — [SRE] Runner offline: github-runner-mig-blpf
+
+**Sprint**：125
+**Story Type**：INFRA
+**Size**：S (1pt)
+**執行時間**：2026-03-23T16:23:02Z
+**結果**：PASS
+
+---
+
+## 調查結果
+
+### Runner 狀態（調查時）
+
+| Runner 名稱 | 狀態 | 備註 |
+|------------|------|------|
+| github-runner-mig-blpf | 不存在（已回收） | Issue 建立時 offline，現已被 MIG 回收 |
+| github-runner-mig-zfwb | online, idle | 正常 |
+| github-runner-mig-cj19 | online, busy | 新 VM，MIG 自動補充 |
+
+### 根因分析
+
+**根因**：GCP MIG SPOT VM 回收（preemption）或 autoscaler scale-in/replace。
+
+- `github-runner-mig-blpf` 屬於 GCP MIG（Managed Instance Group）管理的 self-hosted runner
+- SPOT VM 在 GCP 可能因資源緊縮而被搶占（preemption）
+- MIG Health Check 偵測到 VM 離線後，自動補充了新 VM `github-runner-mig-cj19`
+- GitHub Actions Runner 在新 VM 啟動後重新註冊，舊的 `blpf` 條目已從 GitHub API 消失
+
+### CI 健康狀態
+
+- CI 已自動恢復：最新 New Issue Intake run（23447395269）結論為 `success`
+- 兩個 runner 目前均 online，CI 容量充足
+
+### 是否需要人工介入
+
+**不需要**。此為 SPOT VM 正常生命週期行為：
+- MIG 已自動補充替代 VM（`cj19`）
+- 若需降低 runner 中斷風險，可考慮將 MIG 改為使用 Standard（非 SPOT）VM，但這屬於成本決策，需 Stakeholder 確認
+
+---
+
+## DoD 自檢
+
+| 項目 | 狀態 |
+|------|------|
+| Runner 狀態調查完成 | PASS |
+| 根因確認（SPOT 回收） | PASS |
+| MIG 自動恢復確認 | PASS |
+| CI 健康狀態確認 | PASS |
+| 無需程式碼修改（純調查） | N/A |
+| 結果文件寫入 | PASS |
+
+---
+
+## 結論
+
+**PASS** — github-runner-mig-blpf offline 為 GCP SPOT VM preemption 正常行為，MIG 已自動補充新 VM（cj19），CI 已恢復正常，無需進一步修復。
+
+若需強化 runner 可靠性（減少 SPOT 回收風險），建議另開 Issue 評估切換至 Standard VM 的成本效益。
+
+**MERGED_COMMIT**：無（純調查 Story，無程式碼修改）

--- a/tests/test-464-unzip-sudo-regression.sh
+++ b/tests/test-464-unzip-sudo-regression.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
-# Test #464: unzip sudo regression fix — 驗證 new-issue-intake.yml 不使用需要密碼的 sudo
-# AC1: workflow 不再因 sudo 密碼而失敗（使用 sudo -n 非互動模式）
-# AC2: 已有 unzip 時靜默跳過（command -v 守衛）
-# AC3: 無 unzip + 無 sudo 權限時 graceful fallback（不卡住）
-
-set -euo pipefail
+# Test #464: unzip sudo — 歷史測試，#472 已覆寫 sudo -n 方案
+# 注意：#472 發現 sudo -n 在無 NOPASSWD runner 上靜默失敗，已回歸至 sudo apt-get
+# 本測試保留核心不變量驗證（冪等性、apt-get 存在、無 busybox）
+# sudo -n 相關斷言已廢棄（由 test-472-unzip-regression-fix.sh 替代）
 
 WORKFLOW=".github/workflows/new-issue-intake.yml"
 PASS=0
@@ -22,35 +20,24 @@ check() {
   fi
 }
 
-echo "=== Test #464: unzip sudo regression fix ==="
+echo "=== Test #464: unzip core invariants (sudo -n ACs superseded by #472) ==="
 
-# AC1: 不使用會卡住的 plain sudo（必須是 sudo -n 非互動模式）
-! grep -qP "^\s+sudo apt-get" "$WORKFLOW"
-check "AC1: no plain 'sudo apt-get' (would block on password prompt)" $?
+# 核心不變量：使用 apt-get install unzip（#472 已確保不帶 -n）
+grep -q "apt-get install -y unzip" "$WORKFLOW"
+check "CORE: apt-get install -y unzip present" $?
 
-# AC1: 使用 sudo -n（non-interactive，無密碼時立即失敗而非卡住）
-grep -q "sudo -n apt-get install -y unzip" "$WORKFLOW"
-check "AC1: uses sudo -n apt-get install -y unzip (non-interactive)" $?
-
-# AC2: 冪等性守衛仍存在（已有 unzip 時跳過）
+# 核心不變量：冪等性守衛（command -v unzip）
 grep -q "command -v unzip" "$WORKFLOW"
-check "AC2: idempotency guard (command -v unzip) present" $?
+check "CORE: idempotency guard (command -v unzip) present" $?
 
-# AC3: graceful fallback — sudo 失敗時有 fallback echo（不卡住）
-grep -q "proceeding anyway" "$WORKFLOW"
-check "AC3: graceful fallback message present (proceeding anyway)" $?
-
-# AC3: sudo -n 輸出導向 /dev/null，不會因 stderr 雜訊而影響 log
-grep -q "sudo -n apt-get install -y unzip 2>/dev/null" "$WORKFLOW"
-check "AC3: sudo -n stderr redirected to /dev/null" $?
+# 核心不變量：busybox.net 未重新引入
+result=0
+grep -q "busybox.net" "$WORKFLOW" && result=1 || true
+check "CORE: no busybox.net dependency" $result
 
 # Structural: YAML is valid
 python3 -c "import yaml; yaml.safe_load(open('$WORKFLOW'))" 2>/dev/null
 check "STRUCTURE: YAML syntax valid" $?
-
-# Structural: apt-get 仍在（確認未被誤刪）
-grep -q "apt-get install -y unzip" "$WORKFLOW"
-check "STRUCTURE: apt-get install unzip still present" $?
 
 echo ""
 echo "Results: PASS=$PASS FAIL=$FAIL"

--- a/tests/test-472-unzip-regression-fix.sh
+++ b/tests/test-472-unzip-regression-fix.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Test #472: unzip 缺失問題復發 — 驗證 new-issue-intake.yml 使用正確的 sudo apt-get 安裝
+# 根因：#464 的 sudo -n 修復在無 NOPASSWD 的 runner 上靜默失敗，導致 unzip 仍未安裝
+# AC1: workflow 使用 sudo apt-get install -y unzip（不帶 -n flag）
+# AC2: 有 unzip 快取時靜默跳過（command -v 守衛，冪等性）
+# AC3: 不使用 sudo -n（避免靜默失敗）
+
+WORKFLOW=".github/workflows/new-issue-intake.yml"
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [ "$result" = "0" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Test #472: unzip regression fix (reverts #464 sudo -n approach) ==="
+
+# AC1: 使用 sudo apt-get install -y unzip（不帶 -n flag）
+grep -q "sudo apt-get install -y unzip" "$WORKFLOW"
+check "AC1: uses 'sudo apt-get install -y unzip' (without -n)" $?
+
+# AC3: 不使用 sudo -n（#464 回歸根因）
+result=0
+grep -q "sudo -n apt-get" "$WORKFLOW" && result=1 || true
+check "AC3: no 'sudo -n apt-get' (silent failure pattern removed)" $result
+
+# AC3: 不使用 graceful fallback（不再靜默忽略錯誤）
+result=0
+grep -q "proceeding anyway" "$WORKFLOW" && result=1 || true
+check "AC3: no silent fallback 'proceeding anyway' (unzip must succeed)" $result
+
+# AC2: 冪等性守衛仍存在（已有 unzip 時跳過安裝）
+grep -q "command -v unzip" "$WORKFLOW"
+check "AC2: idempotency guard (command -v unzip) present" $?
+
+# AC1: Install unzip 步驟位於 New Issue Intake step 之前（依賴順序正確）
+UNZIP_LINE=$(grep -n "Install unzip" "$WORKFLOW" | grep "name:" | head -1 | cut -d: -f1)
+INTAKE_LINE=$(grep -n "New Issue Intake" "$WORKFLOW" | grep "name:" | grep -v "^1:" | head -1 | cut -d: -f1)
+result=0
+{ [ -z "$UNZIP_LINE" ] || [ -z "$INTAKE_LINE" ] || [ "$UNZIP_LINE" -ge "$INTAKE_LINE" ]; } && result=1 || true
+check "AC1: Install unzip step is BEFORE New Issue Intake step" $result
+
+# Structural: busybox.net 未重新引入
+result=0
+grep -q "busybox.net" "$WORKFLOW" && result=1 || true
+check "STRUCTURE: no busybox.net dependency (regression guard)" $result
+
+# Structural: YAML is valid
+python3 -c "import yaml; yaml.safe_load(open('$WORKFLOW'))" 2>/dev/null
+check "STRUCTURE: YAML syntax valid" $?
+
+echo ""
+echo "Results: PASS=$PASS FAIL=$FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
## 摘要

修復 New Issue Intake workflow 中 `unzip` 缺失問題的第二次復發（#472）。

## 回歸根因分析（AC5：#442 修復失效原因）

| 修復版本 | Commit | 方案 | 結果 |
|---------|--------|------|------|
| #442 初次修復 | 01dbf56 | `sudo apt-get install -y unzip` | ✅ 正確 |
| #464 引入回歸 | a6e8a4a | `sudo -n apt-get ... 2>/dev/null \|\| echo "proceeding anyway"` | ❌ 靜默失敗 |
| #472 本次修復 | 本 PR | 回歸 `sudo apt-get install -y unzip`（無 -n） | ✅ 正確 |

**失效鏈**：`sudo -n` 在 self-hosted runner 無 `NOPASSWD` 設定時立即退出 → `2>/dev/null` 靜默吞錯誤 → `|| echo` fallback 使整行退出碼為 0 → unzip 未安裝 → setup-bun 下載 Bun 時 unzip 缺失失敗（85% failure rate）。

## 修改內容

### `.github/workflows/new-issue-intake.yml`
- 移除 `sudo -n apt-get install -y unzip 2>/dev/null` 靜默失敗模式
- 移除 `|| echo "proceeding anyway"` 靜默 fallback
- 回歸 `if ! command -v unzip > /dev/null 2>&1; then sudo apt-get install -y unzip; fi`
- 冪等性守衛（`command -v`）保留

### `tests/test-472-unzip-regression-fix.sh`（新增）
- 7 assertions 覆蓋 AC1/AC2/AC3 + 結構驗證

### `tests/test-464-unzip-sudo-regression.sh`（更新）
- 移除已廢棄的 `sudo -n` 斷言（由 test-472 替代）
- 保留核心不變量（apt-get 存在、冪等性守衛、無 busybox）

## AC 自檢

| AC | 狀態 | 說明 |
|----|------|------|
| AC1 | ✅ | `sudo apt-get install -y unzip` 步驟位於 setup-bun 之前 |
| AC2 | ✅ | `command -v unzip` 守衛，有快取時靜默跳過 |
| AC3 | ✅ | 有快取 runner 亦正確（idempotency guard 覆蓋） |
| AC4 | 待 CI | 合入後觸發 5 次確認 0 failure |
| AC5 | ✅ | 回歸根因記錄於本 PR description |

🤖 Generated with [Claude Code](https://claude.com/claude-code)