### PR TITLE
feat: #469 Cruise/Sprint 執行時建立 Task List — 防止 compact 後跳步

### DIFF
--- a/skills/cruise/SKILL.md
+++ b/skills/cruise/SKILL.md
@@ -198,6 +198,50 @@ echo "[CRUISE] Flag file: $CRUISE_FLAG"
 echo "[CRUISE] 停止指令：/cruise stop"
 ```
 
+### 4.2 建立 Task List（#469）
+
+<!-- #469 Cruise/Sprint 執行時建立 Task List — 防止 compact 後跳步 -->
+
+Cruise 啟動後立即建立 Task List，記錄本次巡航的所有 phase。compact 後可透過 TaskList 查詢恢復進度，跳過已完成的 phase，防止跳步或重複執行。
+
+```
+# 建立 Cruise Task List（多 session 隔離：以 SESSION_ID 命名）
+TASK_LIST_ID="cruise-${SESSION_ID}"
+
+TaskCreate 以下 tasks（依執行順序）：
+  1. "cruise-init-${SESSION_ID}"        — 初始化（參數解析、repo 偵測、flag file）
+  2. "po-patrol-${SESSION_ID}"          — PO 巡邏（每個 cycle 更新）
+  3. "sre-inspection-${SESSION_ID}"     — SRE 巡檢（每個 cycle 更新）
+  4. "auto-shoot-${SESSION_ID}"         — Auto-shoot 派遣（有 actionable issue 時）
+  5. "cruise-cleanup-${SESSION_ID}"     — 清理（flag 清除、退出）
+
+# 恢復進度：compact 後重啟時先查詢 TaskList（#469 AC4）
+# 若 task 狀態為 completed → 跳過
+# 若 task 狀態為 failed    → 從該 task 重試
+# 若 task 狀態為 pending   → 正常執行
+EXISTING_TASKS=$(TaskList --filter "cruise-${SESSION_ID}")
+if [[ -n "$EXISTING_TASKS" ]]; then
+  echo "[CRUISE] 偵測到既有 Task List，恢復進度（compact 後重啟）"
+  # 讀取各 phase 狀態，跳過已完成的 phase
+fi
+```
+
+**Task 狀態轉換規則**（#469 AC2 / AC6）：
+
+| 事件 | TaskUpdate 動作 |
+|------|----------------|
+| phase 開始執行 | `TaskUpdate id="<task_id>" status=in-progress` |
+| phase 成功完成 | `TaskUpdate id="<task_id>" status=completed` |
+| phase 執行失敗 | `TaskUpdate id="<task_id>" status=failed` |
+| compact 後重啟 | 查詢 TaskList，從第一個非 completed 的 task 繼續 |
+
+**多 session 隔離**（#469 AC5）：
+
+- Task List 名稱含 SESSION_ID（`cruise-${SESSION_ID}`），每個 session 獨立，互不干擾
+- 不同 session 的 Task List 不會互相覆蓋或干擾
+
+---
+
 ### 4.5 讀取 project_level（#348）
 
 ```bash
@@ -329,6 +373,12 @@ Once Mode 執行單輪 PO 巡邏 + SRE 巡檢，寫入 log 後自動退出，不
 # [AUTO-CONTINUE] 以下各步驟在 project_level=low 時自動執行，不停下來詢問
 CYCLE=1
 
+# ── Task List 狀態更新：cruise-init 完成（#469 AC2）──
+TaskUpdate id="cruise-init-${SESSION_ID}" status=completed
+# ── Task List 狀態更新：po-patrol / sre-inspection 開始（#469 AC2）──
+TaskUpdate id="po-patrol-${SESSION_ID}" status=in-progress
+TaskUpdate id="sre-inspection-${SESSION_ID}" status=in-progress
+
 for REPO_PATH in REPOS:
   OWNER_REPO = REPO_REMOTES[REPO_PATH]
   平行派遣：
@@ -340,15 +390,23 @@ for each subagent result:
   if subagent 成功:
     寫入正常 log entry（JSONL append，含 "repo" 欄位）
     # log entry 格式與 Loop Mode 一致（AC4：格式統一）
+    # ── Task List 狀態更新：phase 完成（#469 AC2）──
+    TaskUpdate id="po-patrol-${SESSION_ID}" status=completed
+    TaskUpdate id="sre-inspection-${SESSION_ID}" status=completed
   else:
     寫入錯誤 log entry：
       {"type":"error","repo":"<OWNER_REPO>","cycle":1,"timestamp":"<ISO8601>","summary":"subagent failed: <reason>","mode":"once"}
     echo "[CRUISE] WARNING: ${OWNER_REPO} 巡邏/巡檢失敗，見 log"
+    # ── Task List 狀態更新：phase 失敗（#469 AC6）──
+    TaskUpdate id="po-patrol-${SESSION_ID}" status=failed
+    TaskUpdate id="sre-inspection-${SESSION_ID}" status=failed
 
 # ── Auto-shoot（與 Loop Mode 相同，依 project_level 控制）──
 # [AUTO-CONTINUE] project_level=low → 自動派 auto-shoot，不停
 ACTIONABLE_ISSUES = PO 巡邏結果.actionable_issues
 if PROJECT_LEVEL != "high":
+  # ── Task List 狀態更新：auto-shoot 開始（#469 AC2）──
+  TaskUpdate id="auto-shoot-${SESSION_ID}" status=in-progress
   while ACTIONABLE_ISSUES is not empty:
     ISSUE = ACTIONABLE_ISSUES.shift()
     echo "$ISSUE" > SHOOT_FLAG
@@ -359,10 +417,15 @@ if PROJECT_LEVEL != "high":
     else:
       rm -f SHOOT_FLAG
       寫入 log：{"type":"auto-shoot-completed","issue":ISSUE,"result":"failed","mode":"once",...}
+  # ── Task List 狀態更新：auto-shoot 完成（#469 AC2）──
+  TaskUpdate id="auto-shoot-${SESSION_ID}" status=completed
 
 # ── Once Mode 完成 log entry ──
 寫入 log：{"type":"once-mode-complete","timestamp":"<ISO8601>","session_id":"<SESSION_ID>","repos":[<OWNER_REPO>,...]}
 echo "[CRUISE] Once Mode 執行完成，寫入 log：${CRUISE_LOG}"
+
+# ── Task List 狀態更新：cruise-cleanup 完成（#469 AC2）──
+TaskUpdate id="cruise-cleanup-${SESSION_ID}" status=completed
 
 # ── 清除 flag 並退出（AC1：不進入 sleep loop）──
 rm -f "$CRUISE_FLAG"
@@ -397,11 +460,19 @@ Once Mode 各 phase 轉換點均加入 `[AUTO-CONTINUE]` 備注，指示 `projec
 
 ```
 # [AUTO-CONTINUE] project_level=low 時 cycle 間自動推進，不停
+# ── Task List 狀態更新：cruise-init 完成（#469 AC2）──
+TaskUpdate id="cruise-init-${SESSION_ID}" status=completed
+
 while 檢查 flag file 存在:
   CYCLE += 1
   # #449 AC1：每個 cycle 開始時 touch flag file，重置 mtime，避免 systemd-tmpfiles-clean 清除
   touch "$CRUISE_FLAG"
   if [[ -f "$SHOOT_FLAG" ]]; then touch "$SHOOT_FLAG"; fi
+
+  # ── Task List 狀態更新：po-patrol / sre-inspection 開始（#469 AC2）──
+  TaskUpdate id="po-patrol-${SESSION_ID}" status=in-progress
+  TaskUpdate id="sre-inspection-${SESSION_ID}" status=in-progress
+
   for REPO_PATH in REPOS:
     OWNER_REPO = REPO_REMOTES[REPO_PATH]
     平行派遣：
@@ -411,10 +482,16 @@ while 檢查 flag file 存在:
   for each subagent result:
     if subagent 成功:
       寫入正常 log entry（JSONL append，含 "repo" 欄位）
+      # ── Task List 狀態更新：phase 完成（#469 AC2）──
+      TaskUpdate id="po-patrol-${SESSION_ID}" status=completed
+      TaskUpdate id="sre-inspection-${SESSION_ID}" status=completed
     else:
       寫入錯誤 log entry：
         {"type":"error","repo":"<OWNER_REPO>","cycle":<N>,"timestamp":"<ISO8601>","summary":"subagent failed: <reason>"}
       echo "[CRUISE] WARNING: ${OWNER_REPO} 巡邏/巡檢失敗，見 log"
+      # ── Task List 狀態更新：phase 失敗（#469 AC6）──
+      TaskUpdate id="po-patrol-${SESSION_ID}" status=failed
+      TaskUpdate id="sre-inspection-${SESSION_ID}" status=failed
 
   # ── SHOOT_FLAG 殘留防護 ──────────────────────
   if SHOOT_FLAG 存在:

--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -450,9 +450,79 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 ---
 
+## 2.13 Sprint Task List — compact 後進度恢復（#469）
+
+<!-- #469 Cruise/Sprint 執行時建立 Task List — 防止 compact 後跳步 -->
+
+Sprint Execution 啟動時建立 Task List，記錄 Sprint 的三個主要 phase。compact 後可透過 TaskList 查詢恢復進度，跳過已完成的 phase，防止跳步或停下來詢問使用者。
+
+### Task List 建立時機
+
+Sprint Execution **啟動時**（§3 流程最開始，Sprint Checkpoint 偵測之前）立即建立：
+
+```
+# 建立 Sprint Task List（多 session 隔離：以 SESSION_ID 命名）
+SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+TASK_LIST_ID="sprint-${SESSION_ID}"
+
+TaskCreate 以下 tasks（依執行順序）：
+  1. "sprint-planning-${SESSION_ID}"   — Sprint Planning（backlog refinement 至排程確定）
+  2. "sprint-execution-${SESSION_ID}"  — Sprint Execution（Story 逐一開發交付）
+  3. "sprint-review-${SESSION_ID}"     — Sprint Review（驗收、Velocity 計算、Retro）
+
+# ── compact 後恢復進度（#469 AC4）──
+# 重啟時先查詢 TaskList，判斷從哪個 phase 繼續
+EXISTING_TASKS=$(TaskList --filter "sprint-${SESSION_ID}")
+if [[ -n "$EXISTING_TASKS" ]]; then
+  echo "[SPRINT] 偵測到既有 Task List，恢復進度（compact 後重啟）"
+  # 讀取各 phase 狀態：
+  #   completed → 跳過（已完成）
+  #   failed    → 從該 phase 重試（#469 AC6）
+  #   in-progress / pending → 正常繼續
+fi
+```
+
+### Task 狀態轉換規則（#469 AC2 / AC6）
+
+| 事件 | TaskUpdate 動作 |
+|------|----------------|
+| Execution 開始 | `TaskUpdate id="sprint-execution-${SESSION_ID}" status=in-progress` |
+| 每個 Story 完成時更新進度 | `TaskUpdate id="sprint-execution-${SESSION_ID}" content="completed: #N1,#N2..."` |
+| Execution 完成 | `TaskUpdate id="sprint-execution-${SESSION_ID}" status=completed` |
+| Review 開始 | `TaskUpdate id="sprint-review-${SESSION_ID}" status=in-progress` |
+| Review 完成 | `TaskUpdate id="sprint-review-${SESSION_ID}" status=completed` |
+| 任一 phase 失敗 | `TaskUpdate id="sprint-<phase>-${SESSION_ID}" status=failed` |
+
+### 多 session 隔離（#469 AC5）
+
+- Task List 名稱含 SESSION_ID，每個 session 獨立，互不干擾
+- 不同 session 的 Task List 不會互相覆蓋（`sprint-${SESSION_ID}` 命名空間）
+
+### 容錯設計
+
+- TaskCreate / TaskUpdate 失敗時**靜默略過**，不阻塞主流程
+- Task List 為輔助進度追蹤機制，sprint-checkpoint.json（§2.12）為主要斷點恢復依據，兩者互補
+
+---
+
 ## 3. 執行流程
 
 ```
+Task List 初始化（§2.13，#469 AC1/AC3）
+  # Sprint 啟動時建立 Task List，記錄三個主要 phase
+  SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+  TaskCreate tasks：
+    - "sprint-planning-${SESSION_ID}"   status=pending
+    - "sprint-execution-${SESSION_ID}"  status=pending
+    - "sprint-review-${SESSION_ID}"     status=pending
+  # compact 後恢復進度：查詢 TaskList，從第一個非 completed 的 task 繼續（#469 AC4）
+  EXISTING_TASKS=$(TaskList --filter "sprint-${SESSION_ID}")
+  |
+  v
+# ── Task List 狀態更新：sprint-execution 開始（#469 AC2）──
+TaskUpdate id="sprint-execution-${SESSION_ID}" status=in-progress
+  |
+  v
 Sprint Checkpoint 偵測（AC-2 斷點續跑，§2.12）
   |-- docs/sprints/sprint-checkpoint.json 不存在
   |     → [CHECKPOINT-NEW] 正常開始（無先前 checkpoint）

--- a/tests/test-469-task-list-progress.sh
+++ b/tests/test-469-task-list-progress.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# tests/test-469-task-list-progress.sh
+# #469 Cruise/Sprint 執行時建立 Task List — 防止 compact 後跳步
+# AC1: Cruise 啟動時呼叫 TaskCreate 建立所有 phase 的 task
+# AC2: 每個 phase 完成時呼叫 TaskUpdate 標記 completed
+# AC3: Sprint 執行啟動時同樣建立 Task List（Planning/Execution/Review）
+# AC4: compact 後透過 TaskList 恢復進度，跳過已完成的 phase
+# AC5: 多 session 隔離：不同 session 的 Task List 互不干擾
+# AC6: 失敗恢復：phase 執行失敗時 task 標記為 failed
+
+set -uo pipefail
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  echo "PASS: $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if grep -qE "$pattern" "$file" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label (pattern='${pattern}' not found in $file)"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if ! grep -qE "$pattern" "$file" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label (pattern='${pattern}' found but should not be in $file)"
+  fi
+}
+
+assert_file_exists() {
+  local path="$1"
+  local label="$2"
+  if [[ -f "$path" ]]; then
+    pass "$label"
+  else
+    fail "$label (file not found: $path)"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CRUISE_SKILL="${REPO_ROOT}/skills/cruise/SKILL.md"
+SPRINT_EXEC_SKILL="${REPO_ROOT}/skills/sprint-execution/SKILL.md"
+
+echo "=== #469 Task List 防跳步驗證 ==="
+echo "CRUISE_SKILL: $CRUISE_SKILL"
+echo "SPRINT_EXEC_SKILL: $SPRINT_EXEC_SKILL"
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC1: Cruise 啟動時 TaskCreate 建立所有 phase 的 task
+# ---------------------------------------------------------------------------
+echo "--- AC1: Cruise 啟動時 TaskCreate 建立所有 phase 的 task ---"
+
+assert_file_exists "$CRUISE_SKILL" "AC1: Cruise SKILL.md 存在"
+assert_contains "$CRUISE_SKILL" "TaskCreate" "AC1: Cruise SKILL.md 包含 TaskCreate 指令"
+assert_contains "$CRUISE_SKILL" "task_list_id|TASK_LIST_ID" "AC1: Cruise SKILL.md 定義 task_list_id 變數"
+assert_contains "$CRUISE_SKILL" "PO.*巡邏|SRE.*巡檢" "AC1: Cruise SKILL.md Task List 包含 PO 巡邏和 SRE 巡檢 phase"
+
+# ---------------------------------------------------------------------------
+# AC2: 每個 phase 完成時 TaskUpdate 標記 completed
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC2: 每個 phase 完成時 TaskUpdate 標記 completed ---"
+
+assert_contains "$CRUISE_SKILL" "TaskUpdate" "AC2: Cruise SKILL.md 包含 TaskUpdate 指令"
+assert_contains "$CRUISE_SKILL" "completed" "AC2: Cruise SKILL.md 包含 completed 狀態標記"
+
+# ---------------------------------------------------------------------------
+# AC3: Sprint 執行啟動時建立 Task List（Planning/Execution/Review）
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC3: Sprint 執行啟動時建立 Task List ---"
+
+assert_file_exists "$SPRINT_EXEC_SKILL" "AC3: Sprint Execution SKILL.md 存在"
+assert_contains "$SPRINT_EXEC_SKILL" "TaskCreate" "AC3: Sprint Execution SKILL.md 包含 TaskCreate 指令"
+assert_contains "$SPRINT_EXEC_SKILL" "Sprint.*Plan|Planning" "AC3: Sprint Execution Task List 包含 Planning phase"
+assert_contains "$SPRINT_EXEC_SKILL" "Sprint.*Execut|Execution" "AC3: Sprint Execution Task List 包含 Execution phase"
+assert_contains "$SPRINT_EXEC_SKILL" "Sprint.*Review|Review" "AC3: Sprint Execution Task List 包含 Review phase"
+
+# ---------------------------------------------------------------------------
+# AC4: compact 後透過 TaskList 恢復進度，跳過已完成的 phase
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC4: compact 後 TaskList 恢復進度 ---"
+
+assert_contains "$CRUISE_SKILL" "TaskList|task.list|task_list" "AC4: Cruise SKILL.md 包含 TaskList 查詢恢復機制"
+assert_contains "$CRUISE_SKILL" "恢復|recover|resume|compact" "AC4: Cruise SKILL.md 包含 compact 恢復說明"
+assert_contains "$SPRINT_EXEC_SKILL" "TaskList|task.list|task_list" "AC4: Sprint Execution SKILL.md 包含 TaskList 查詢恢復機制"
+
+# ---------------------------------------------------------------------------
+# AC5: 多 session 隔離 — Task List 以 SESSION_ID 命名，互不干擾
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC5: 多 session 隔離 ---"
+
+assert_contains "$CRUISE_SKILL" "SESSION_ID|session_id" "AC5: Cruise SKILL.md Task List 包含 SESSION_ID 隔離"
+assert_contains "$SPRINT_EXEC_SKILL" "SESSION_ID|session_id" "AC5: Sprint Execution SKILL.md Task List 包含 SESSION_ID 隔離"
+
+# ---------------------------------------------------------------------------
+# AC6: 失敗恢復 — phase 失敗時 task 標記 failed
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC6: 失敗恢復 ---"
+
+assert_contains "$CRUISE_SKILL" "failed|TaskUpdate.*failed" "AC6: Cruise SKILL.md 包含 failed 狀態標記"
+assert_contains "$SPRINT_EXEC_SKILL" "failed|TaskUpdate.*failed" "AC6: Sprint Execution SKILL.md 包含 failed 狀態標記"
+
+# ---------------------------------------------------------------------------
+# 彙整結果
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================="
+echo "結果：PASS=${PASS_COUNT}，FAIL=${FAIL_COUNT}"
+echo "========================================="
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- `skills/cruise/SKILL.md`：新增 §4.2 建立 Task List，在 Cruise 啟動時以 SESSION_ID 命名建立 5 個 phase task（cruise-init/po-patrol/sre-inspection/auto-shoot/cruise-cleanup），實現多 session 隔離
- `skills/sprint-execution/SKILL.md`：新增 §2.13 Sprint Task List，Sprint 啟動時建立 planning/execution/review 三個 phase task，並在 §3 執行流程加入 TaskCreate 初始化和 TaskList compact 恢復邏輯
- `tests/test-469-task-list-progress.sh`：新增 TDD 測試（18 cases，全 PASS）

## AC 對照

| AC | 實作位置 | 狀態 |
|----|---------|------|
| AC1 Cruise TaskCreate | cruise/SKILL.md §4.2 | ✅ |
| AC2 phase 完成 TaskUpdate | Once Mode / Loop Mode 各轉換點 | ✅ |
| AC3 Sprint TaskCreate | sprint-execution/SKILL.md §2.13 + §3 | ✅ |
| AC4 compact 後 TaskList 恢復 | 兩個 SKILL.md 均有 TaskList 查詢邏輯 | ✅ |
| AC5 SESSION_ID 隔離 | 所有 task 名稱含 SESSION_ID | ✅ |
| AC6 失敗 status=failed | 錯誤路徑均加入 TaskUpdate failed | ✅ |

## Test plan

- [x] `bash tests/test-469-task-list-progress.sh` — 18 PASS / 0 FAIL
- [x] `bash tests/test-cruise-skill.sh` — 127 PASS / 0 FAIL
- [x] `bash tests/test-460-cruise-module-split.sh` — 33 PASS / 0 FAIL
- [x] `bash scripts/validate-skills.sh` — 29 skills all PASS
- [x] `bash scripts/validate-xrefs.sh` — 292 refs all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)