### PR TITLE
feat: #483 Trace Log 端到端驗證 — 完整性指標、驗證腳本、MCP trace 查詢

### DIFF
--- a/docs/km/trace-log-completeness-spec.md
+++ b/docs/km/trace-log-completeness-spec.md
@@ -1,0 +1,157 @@
+# Trace Log 完整性指標規範
+
+**版本**：1.0.0
+**建立日期**：2026-03-24
+**相關 ADR**：ADR-033（Structured Trace Log 架構）
+**相關 Issue**：#483、#392、#473
+
+---
+
+## 1. 概述
+
+本文件定義 Shikigami Trace Log 的品質度量基線，包含：
+
+- 必要欄位定義（依據 ADR-033）
+- 完整性指標計算方式
+- 健康門檻
+- parentSpanId 參照完整性規則
+
+---
+
+## 2. 必要欄位定義（ADR-033 Schema）
+
+依據 ADR-033 決策 2，每筆 trace span 必須包含以下 **8 個必要欄位**：
+
+| 欄位 | 類型 | 說明 |
+|------|------|------|
+| `traceId` | string | 一次完整執行鏈的唯一識別碼 |
+| `spanId` | string | 本 span 的唯一識別碼 |
+| `parentSpanId` | string \| null | 父 span 的 spanId；根 span 為 null |
+| `agentRole` | string | 執行動作的 Agent 角色 |
+| `action` | string | 執行的動作名稱 |
+| `timestamp` | string | ISO 8601 帶時區，精確到秒 |
+| `status` | string | `"started"` \| `"completed"` \| `"failed"` |
+| `sessionId` | string | Claude session 識別碼 |
+
+---
+
+## 3. 完整性指標
+
+### 3.1 必要欄位覆蓋率（Primary Metric）
+
+**定義**：
+
+```
+必要欄位覆蓋率 = 包含全部 8 個必要欄位的 span 數 / 總 span 數 × 100%
+```
+
+**計算方式**：
+- 逐行讀取 JSONL 檔案
+- 每行必須為合法 JSON 物件
+- 檢查是否包含全部 8 個必要欄位（欄位值允許 null，但欄位鍵必須存在）
+- 統計完整 span 數與總 span 數
+
+**健康門檻**：
+
+| 等級 | 覆蓋率 | 說明 |
+|------|--------|------|
+| HEALTHY | ≥ 100% | 全部 span 包含必要欄位 |
+| WARNING | 80% ~ 99% | 部分 span 缺少欄位，需調查原因 |
+| CRITICAL | < 80% | 嚴重欄位缺失，Trace 可用性不足 |
+
+### 3.2 JSON 格式合法性
+
+每行必須為合法 JSON 物件（`{...}`）。非法 JSON 行視為無效 span，計入總 span 數但不計入完整 span 數。
+
+### 3.3 parentSpanId 參照完整性
+
+**定義**：
+
+```
+parentSpanId 參照完整性率 =
+  parentSpanId 指向有效 spanId 的 span 數（排除 null）/
+  parentSpanId 非 null 的 span 數 × 100%
+```
+
+**規則**：
+- `parentSpanId = null`：合法，代表根 span（root span）
+- `parentSpanId = "<spanId>"`：必須指向同一 session 檔案或同一 traceId 的已知 spanId
+- 孤立 parentSpanId（跨 session 引用）：視為 WARNING，非 ERROR（多機器場景允許）
+
+---
+
+## 4. 檔案命名格式
+
+per-session 檔案命名規則（依據 ADR-033 決策 4）：
+
+```
+docs/trace-logs/{YYYY-MM-DD}-{session-id}.jsonl
+```
+
+範例：
+```
+docs/trace-logs/2026-03-24-session-abc123.jsonl
+docs/trace-logs/2026-03-24-session-xyz456.jsonl
+```
+
+**格式驗證正規表達式**：
+```
+^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-zA-Z0-9_-]+\.jsonl$
+```
+
+---
+
+## 5. status 欄位合法值
+
+`status` 欄位僅允許以下三個值：
+
+- `"started"` — span 開始執行
+- `"completed"` — span 執行完成
+- `"failed"` — span 執行失敗
+
+---
+
+## 6. timestamp 欄位格式
+
+`timestamp` 欄位必須符合 ISO 8601 帶時區格式，精確到秒：
+
+```
+YYYY-MM-DDTHH:MM:SS+HH:MM
+YYYY-MM-DDTHH:MM:SSZ
+```
+
+範例：`2026-03-24T10:00:00+0800`、`2026-03-24T02:00:00Z`
+
+---
+
+## 7. 與自動化驗證腳本的對應
+
+本規範的指標均由 `scripts/validate-trace-log.sh` 實作自動化驗證：
+
+| 規範章節 | 腳本驗證項 |
+|----------|-----------|
+| 3.1 必要欄位覆蓋率 | AC2：驗證必要欄位存在 |
+| 3.2 JSON 格式合法性 | AC1：JSONL 格式驗證 |
+| 3.3 parentSpanId 參照完整性 | AC3：parentSpanId 參照完整性檢查 |
+| 4 檔案命名格式 | AC4：per-session 命名格式驗證 |
+
+---
+
+## 8. quality-observer MCP 整合
+
+trace 查詢透過 `shikigami-quality-observer` MCP Server 提供：
+
+| Tool | 功能 |
+|------|------|
+| `get_trace_recent` | 查詢最近 N 條 trace span |
+| `get_trace_by_session` | 按 session ID 篩選 trace span |
+| `get_trace_summary` | 取得 human-readable trace 摘要（完整性、分佈統計）|
+
+---
+
+## 9. 參照
+
+- [ADR-033 Structured Trace Log 架構](../adr/ADR-033-structured-trace-log.md)
+- [ADR-028 Multi-Sprint Observability](../adr/ADR-028-multi-sprint-observability.md)
+- `scripts/validate-trace-log.sh`
+- `mcp-servers/quality-observer/index.js`

--- a/mcp-servers/quality-observer/index.js
+++ b/mcp-servers/quality-observer/index.js
@@ -21,7 +21,7 @@ import {
   ErrorCode,
   McpError,
 } from "@modelcontextprotocol/sdk/types.js";
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, readdirSync } from "fs";
 import { join, resolve } from "path";
 
 // ─── 環境設定 ────────────────────────────────────────────────────────────────
@@ -33,6 +33,7 @@ const SHIKIGAMI_ROOT = process.env.SHIKIGAMI_ROOT
 const METRICS_LOG_PATH = join(SHIKIGAMI_ROOT, "docs/km/Metrics_Log.md");
 const QUALITY_OBSERVER_PATH = join(SHIKIGAMI_ROOT, "docs/km/Quality_Observer.md");
 const RETROSPECTIVE_LOG_PATH = join(SHIKIGAMI_ROOT, "docs/km/Retrospective_Log.md");
+const TRACE_LOGS_DIR = join(SHIKIGAMI_ROOT, "docs/trace-logs");
 
 // ─── Markdown 解析工具 ────────────────────────────────────────────────────────
 
@@ -124,6 +125,115 @@ function analyzeVelocityTrend(metricsData, lastN = 10) {
   };
 }
 
+// ─── Trace Log 解析工具 ───────────────────────────────────────────────────────
+
+/**
+ * 列出 docs/trace-logs/ 下所有 .jsonl 檔案（不含 .gitkeep），依名稱降序排列
+ */
+function listTraceLogFiles() {
+  if (!existsSync(TRACE_LOGS_DIR)) {
+    return [];
+  }
+  return readdirSync(TRACE_LOGS_DIR)
+    .filter((f) => f.endsWith(".jsonl") && f !== ".gitkeep")
+    .sort()
+    .reverse(); // 最新在前（依日期命名 YYYY-MM-DD-...）
+}
+
+/**
+ * 解析單一 .jsonl trace log 檔案，回傳 span 陣列（跳過非法行）
+ * @param {string} filepath 完整路徑
+ * @returns {Array<Object>} span 物件陣列
+ */
+function parseTraceLogFile(filepath) {
+  if (!existsSync(filepath)) return [];
+  const lines = readFileSync(filepath, "utf-8").split("\n");
+  const spans = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed);
+      if (typeof obj === "object" && obj !== null && !Array.isArray(obj)) {
+        spans.push(obj);
+      }
+    } catch {
+      // 非法 JSON 行跳過
+    }
+  }
+  return spans;
+}
+
+/**
+ * 從檔案名稱提取 sessionId（basename 去除副檔名後，移除日期前綴 YYYY-MM-DD-）
+ * 例：2026-03-24-session-abc123.jsonl -> session-abc123
+ */
+function extractSessionIdFromFilename(filename) {
+  const base = filename.replace(/\.jsonl$/, "");
+  const match = base.match(/^\d{4}-\d{2}-\d{2}-(.+)$/);
+  return match ? match[1] : base;
+}
+
+/**
+ * 計算 trace 完整性統計
+ * @param {Array<Object>} spans
+ * @returns {Object} 統計資料
+ */
+const REQUIRED_TRACE_FIELDS = [
+  "traceId", "spanId", "parentSpanId", "agentRole",
+  "action", "timestamp", "status", "sessionId",
+];
+
+function calcTraceCompleteness(spans) {
+  if (spans.length === 0) {
+    return { total: 0, complete: 0, completenessRate: null };
+  }
+  const complete = spans.filter((s) =>
+    REQUIRED_TRACE_FIELDS.every((f) => Object.prototype.hasOwnProperty.call(s, f))
+  ).length;
+  return {
+    total: spans.length,
+    complete,
+    completenessRate: Math.round((complete / spans.length) * 1000) / 10,
+  };
+}
+
+/**
+ * 生成 human-readable trace summary
+ */
+function buildTraceSummary(spans, filename) {
+  const stats = calcTraceCompleteness(spans);
+  const byAgent = {};
+  const byStatus = {};
+  const byAction = {};
+
+  for (const span of spans) {
+    const role = span.agentRole || "unknown";
+    const status = span.status || "unknown";
+    const action = span.action || "unknown";
+    byAgent[role] = (byAgent[role] || 0) + 1;
+    byStatus[status] = (byStatus[status] || 0) + 1;
+    byAction[action] = (byAction[action] || 0) + 1;
+  }
+
+  const lines = [
+    `=== Trace Log Summary: ${filename} ===`,
+    `總 span 數：${stats.total}`,
+    `完整 span 數：${stats.complete}（含全部 8 個必要欄位）`,
+    `必要欄位覆蓋率：${stats.completenessRate !== null ? stats.completenessRate + "%" : "N/A"}`,
+    "",
+    "Agent 角色分佈：",
+    ...Object.entries(byAgent).map(([k, v]) => `  ${k}: ${v} span`),
+    "",
+    "Status 分佈：",
+    ...Object.entries(byStatus).map(([k, v]) => `  ${k}: ${v}`),
+    "",
+    "Action 分佈：",
+    ...Object.entries(byAction).map(([k, v]) => `  ${k}: ${v}`),
+  ];
+  return lines.join("\n");
+}
+
 // ─── MCP Server 設定 ──────────────────────────────────────────────────────────
 
 const server = new Server(
@@ -190,6 +300,50 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         inputSchema: {
           type: "object",
           properties: {},
+        },
+      },
+      {
+        name: "get_trace_recent",
+        description:
+          "查詢最近 N 條 trace span（依檔案日期排序，最新優先）。回傳 span 物件陣列，含 traceId、spanId、agentRole、action、timestamp、status 等欄位。",
+        inputSchema: {
+          type: "object",
+          properties: {
+            limit: {
+              type: "number",
+              description: "最多回傳幾條 span（預設 20，最大 200）",
+              default: 20,
+            },
+          },
+        },
+      },
+      {
+        name: "get_trace_by_session",
+        description:
+          "按 session ID 篩選 trace span。回傳指定 session 的所有 span，依 timestamp 升序排列。",
+        inputSchema: {
+          type: "object",
+          properties: {
+            session_id: {
+              type: "string",
+              description: "要篩選的 session ID（如 session-abc123）",
+            },
+          },
+          required: ["session_id"],
+        },
+      },
+      {
+        name: "get_trace_summary",
+        description:
+          "取得 human-readable trace 摘要。包含必要欄位覆蓋率、Agent 角色分佈、Status 分佈、Action 分佈等統計資訊。可指定 session 或取全域摘要。",
+        inputSchema: {
+          type: "object",
+          properties: {
+            session_id: {
+              type: "string",
+              description: "僅摘要指定 session（選填；省略時摘要全部 session）",
+            },
+          },
         },
       },
     ],
@@ -342,6 +496,172 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           {
             type: "text",
             text: content,
+          },
+        ],
+      };
+    }
+
+    case "get_trace_recent": {
+      const limit = Math.min(Math.max(1, args?.limit || 20), 200);
+      const files = listTraceLogFiles();
+
+      if (files.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                spans: [],
+                total: 0,
+                message: `docs/trace-logs/ 目錄下無 trace log 檔案（路徑：${TRACE_LOGS_DIR}）`,
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      const collected = [];
+      for (const filename of files) {
+        if (collected.length >= limit) break;
+        const filepath = join(TRACE_LOGS_DIR, filename);
+        const spans = parseTraceLogFile(filepath);
+        // 從最新的 span 開始（reverse 後取）
+        const reversed = spans.slice().reverse();
+        for (const span of reversed) {
+          if (collected.length >= limit) break;
+          collected.push({ _file: filename, ...span });
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              spans: collected,
+              total: collected.length,
+              files_scanned: files.length,
+            }, null, 2),
+          },
+        ],
+      };
+    }
+
+    case "get_trace_by_session": {
+      const sessionId = args?.session_id;
+      if (!sessionId) {
+        throw new McpError(ErrorCode.InvalidParams, "session_id 為必要參數");
+      }
+
+      const files = listTraceLogFiles();
+      const matchedSpans = [];
+
+      for (const filename of files) {
+        // 先用檔名快速篩選（性能優化）
+        const fileSessionId = extractSessionIdFromFilename(filename);
+        const filepath = join(TRACE_LOGS_DIR, filename);
+        const spans = parseTraceLogFile(filepath);
+
+        for (const span of spans) {
+          // 支援兩種匹配：span 內的 sessionId 欄位，或檔名推斷的 sessionId
+          if (span.sessionId === sessionId || fileSessionId === sessionId) {
+            matchedSpans.push({ _file: filename, ...span });
+          }
+        }
+      }
+
+      // 依 timestamp 升序排列
+      matchedSpans.sort((a, b) => {
+        const ta = a.timestamp || "";
+        const tb = b.timestamp || "";
+        return ta.localeCompare(tb);
+      });
+
+      if (matchedSpans.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                spans: [],
+                total: 0,
+                session_id: sessionId,
+                message: `找不到 session「${sessionId}」的 trace span`,
+                available_sessions: files.map(extractSessionIdFromFilename),
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              spans: matchedSpans,
+              total: matchedSpans.length,
+              session_id: sessionId,
+            }, null, 2),
+          },
+        ],
+      };
+    }
+
+    case "get_trace_summary": {
+      const filterSessionId = args?.session_id || null;
+      const files = listTraceLogFiles();
+
+      if (files.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `docs/trace-logs/ 目錄下無 trace log 檔案（路徑：${TRACE_LOGS_DIR}）`,
+            },
+          ],
+        };
+      }
+
+      const summaries = [];
+
+      for (const filename of files) {
+        const fileSessionId = extractSessionIdFromFilename(filename);
+
+        // 若指定 session，只處理匹配的檔案
+        if (filterSessionId && fileSessionId !== filterSessionId) {
+          // 也嘗試從 span 的 sessionId 欄位匹配（需讀取檔案）
+          const filepath = join(TRACE_LOGS_DIR, filename);
+          const spans = parseTraceLogFile(filepath);
+          const matchedSpans = spans.filter((s) => s.sessionId === filterSessionId);
+          if (matchedSpans.length === 0) continue;
+          summaries.push(buildTraceSummary(matchedSpans, filename));
+          continue;
+        }
+
+        const filepath = join(TRACE_LOGS_DIR, filename);
+        const spans = parseTraceLogFile(filepath);
+        summaries.push(buildTraceSummary(spans, filename));
+      }
+
+      if (summaries.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: filterSessionId
+                ? `找不到 session「${filterSessionId}」的 trace span`
+                : "無 trace 資料可摘要",
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: summaries.join("\n\n" + "=".repeat(60) + "\n\n"),
           },
         ],
       };

--- a/scripts/validate-trace-log.sh
+++ b/scripts/validate-trace-log.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# scripts/validate-trace-log.sh
+# #483 Sprint 126 — Trace Log 端到端驗證
+#
+# 依據 ADR-033（Structured Trace Log 架構）與 docs/km/trace-log-completeness-spec.md
+# 驗證 docs/trace-logs/ 目錄下的 JSONL trace log 品質。
+#
+# 驗證項目：
+#   AC1：JSONL 格式合法性（每行為合法 JSON 物件）
+#   AC2：必要欄位存在（traceId/spanId/parentSpanId/agentRole/action/timestamp/status/sessionId）
+#   AC3：parentSpanId 參照完整性（指向已知 spanId 或 null）
+#   AC4：per-session 檔案命名格式（YYYY-MM-DD-{session-id}.jsonl）
+#   AC5：status 欄位合法值（started|completed|failed）
+#
+# 使用方式：
+#   bash scripts/validate-trace-log.sh                    # 驗證所有檔案
+#   bash scripts/validate-trace-log.sh [FILE]             # 驗證指定檔案
+#   bash scripts/validate-trace-log.sh --dir [DIR]        # 驗證指定目錄
+#
+# Exit code:
+#   0 = 全部通過（PASS / INFO / WARNING）
+#   1 = 有 ERROR
+#
+# 依賴：bash >= 4, python3（JSON 解析）
+# 技術規範：ADR-033 + docs/km/trace-log-completeness-spec.md
+
+set -uo pipefail
+
+source "$(dirname "$0")/lib/validate-helpers.sh"
+
+# ---------------------------------------------------------------------------
+# 常數
+# ---------------------------------------------------------------------------
+readonly TRACE_LOGS_DIR="docs/trace-logs"
+readonly REQUIRED_FIELDS=("traceId" "spanId" "parentSpanId" "agentRole" "action" "timestamp" "status" "sessionId")
+readonly VALID_STATUS_VALUES=("started" "completed" "failed")
+# per-session 檔案命名格式：YYYY-MM-DD-{session-id}.jsonl
+readonly NAMING_PATTERN='^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-zA-Z0-9_-]+\.jsonl$'
+
+# ---------------------------------------------------------------------------
+# 狀態追蹤
+# ---------------------------------------------------------------------------
+EXIT_CODE=0
+ERROR_COUNT=0
+WARNING_COUNT=0
+TOTAL_FILES=0
+TOTAL_SPANS=0
+COMPLETE_SPANS=0
+
+# ---------------------------------------------------------------------------
+# 前置條件：確認 python3 存在
+# ---------------------------------------------------------------------------
+check_dependencies() {
+  if ! command -v python3 &>/dev/null; then
+    print_error "缺少依賴：python3 未安裝，無法進行 JSON 解析"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# AC4：驗證 per-session 檔案命名格式
+# 參數：$1 = 檔案名稱（basename）
+# ---------------------------------------------------------------------------
+validate_filename() {
+  local filename="$1"
+  if echo "$filename" | grep -qE "$NAMING_PATTERN"; then
+    print_pass "命名格式：$filename 符合 per-session 格式（YYYY-MM-DD-{session-id}.jsonl）"
+  else
+    print_error "命名格式：$filename 不符合 per-session 格式，應為 YYYY-MM-DD-{session-id}.jsonl"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 驗證單一 JSONL 檔案
+# 參數：$1 = 完整檔案路徑
+# ---------------------------------------------------------------------------
+validate_file() {
+  local filepath="$1"
+  local filename
+  filename=$(basename "$filepath")
+  local file_error=0
+  local line_num=0
+  local file_spans=0
+  local file_complete_spans=0
+  local -a seen_span_ids=()
+
+  print_section "檔案：$filepath"
+  TOTAL_FILES=$((TOTAL_FILES + 1))
+
+  # AC4：檔案命名格式
+  validate_filename "$filename"
+
+  # 檢查檔案是否為空
+  if [ ! -s "$filepath" ]; then
+    print_info "檔案為空，跳過內容驗證"
+    return
+  fi
+
+  # 第一輪：收集所有 spanId（用於 AC3 參照完整性）
+  local -a all_span_ids=()
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -z "$line" ] && continue
+    local span_id
+    span_id=$(python3 -c "
+import json, sys
+try:
+    obj = json.loads(sys.argv[1])
+    print(obj.get('spanId', ''))
+except:
+    print('')
+" "$line" 2>/dev/null || true)
+    [ -n "$span_id" ] && all_span_ids+=("$span_id")
+  done < "$filepath"
+
+  # 第二輪：逐行驗證
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_num=$((line_num + 1))
+    [ -z "$line" ] && continue
+
+    file_spans=$((file_spans + 1))
+
+    # AC1：JSONL 格式合法性
+    local parse_result
+    parse_result=$(python3 -c "
+import json, sys
+try:
+    obj = json.loads(sys.argv[1])
+    if isinstance(obj, dict):
+        print('OK')
+    else:
+        print('NOT_OBJECT')
+except json.JSONDecodeError as e:
+    print(f'INVALID_JSON:{e}')
+" "$line" 2>/dev/null || echo "PARSE_ERROR")
+
+    if [[ "$parse_result" == "NOT_OBJECT" ]]; then
+      print_error "行 $line_num：合法 JSON 但非物件格式（需為 {...}）"
+      file_error=1
+      continue
+    elif [[ "$parse_result" != "OK" ]]; then
+      print_error "行 $line_num：非合法 JSON — ${parse_result#INVALID_JSON:}"
+      file_error=1
+      continue
+    fi
+
+    # AC2：必要欄位存在性 + AC3 parentSpanId + AC5 status
+    local validation_result
+    validation_result=$(python3 -c "
+import json, sys
+
+line = sys.argv[1]
+all_span_ids = sys.argv[2].split(',') if sys.argv[2] else []
+
+required = ['traceId', 'spanId', 'parentSpanId', 'agentRole', 'action', 'timestamp', 'status', 'sessionId']
+valid_status = ['started', 'completed', 'failed']
+
+try:
+    obj = json.loads(line)
+    errors = []
+    warnings = []
+
+    # AC2：必要欄位檢查
+    for field in required:
+        if field not in obj:
+            errors.append(f'MISSING_FIELD:{field}')
+
+    # AC5：status 合法值
+    if 'status' in obj and obj['status'] not in valid_status:
+        errors.append(f'INVALID_STATUS:{obj[\"status\"]}')
+
+    # AC3：parentSpanId 參照完整性
+    if 'parentSpanId' in obj and obj['parentSpanId'] is not None:
+        parent_id = obj['parentSpanId']
+        if parent_id not in all_span_ids:
+            warnings.append(f'ORPHAN_PARENT:{parent_id}')
+
+    for e in errors:
+        print(f'ERROR:{e}')
+    for w in warnings:
+        print(f'WARNING:{w}')
+    if not errors:
+        print('COMPLETE')
+except Exception as e:
+    print(f'ERROR:PARSE_FAILED:{e}')
+" "$line" "$(IFS=','; echo "${all_span_ids[*]}")" 2>/dev/null || echo "ERROR:PYTHON_FAILED")
+
+    local is_complete=1
+    while IFS= read -r check_line; do
+      [ -z "$check_line" ] && continue
+      if [[ "$check_line" == ERROR:MISSING_FIELD:* ]]; then
+        local field_name="${check_line#ERROR:MISSING_FIELD:}"
+        print_error "行 $line_num：缺少必要欄位「$field_name」"
+        file_error=1
+        is_complete=0
+      elif [[ "$check_line" == ERROR:INVALID_STATUS:* ]]; then
+        local status_val="${check_line#ERROR:INVALID_STATUS:}"
+        print_error "行 $line_num：status 值「$status_val」不合法（允許：started|completed|failed）"
+        file_error=1
+        is_complete=0
+      elif [[ "$check_line" == ERROR:* ]]; then
+        print_error "行 $line_num：驗證錯誤 — ${check_line#ERROR:}"
+        file_error=1
+        is_complete=0
+      elif [[ "$check_line" == WARNING:ORPHAN_PARENT:* ]]; then
+        local parent_id="${check_line#WARNING:ORPHAN_PARENT:}"
+        print_warning "行 $line_num：parentSpanId「$parent_id」未在本檔案中找到對應 spanId（可能為跨 session 引用）"
+        WARNING_COUNT=$((WARNING_COUNT + 1))
+      fi
+    done <<< "$validation_result"
+
+    if [ "$is_complete" -eq 1 ]; then
+      file_complete_spans=$((file_complete_spans + 1))
+    fi
+
+  done < "$filepath"
+
+  TOTAL_SPANS=$((TOTAL_SPANS + file_spans))
+  COMPLETE_SPANS=$((COMPLETE_SPANS + file_complete_spans))
+
+  # 計算本檔案完整性率
+  if [ "$file_spans" -gt 0 ]; then
+    local completeness_pct
+    completeness_pct=$(python3 -c "print(f'{$file_complete_spans / $file_spans * 100:.1f}')" 2>/dev/null || echo "N/A")
+    if [ "$file_complete_spans" -eq "$file_spans" ]; then
+      print_pass "完整性率：${completeness_pct}%（$file_complete_spans/$file_spans span 包含全部 8 個必要欄位）"
+    elif [ "$file_error" -eq 0 ]; then
+      print_warning "完整性率：${completeness_pct}%（$file_complete_spans/$file_spans span 完整）"
+      WARNING_COUNT=$((WARNING_COUNT + 1))
+    else
+      print_error "完整性率：${completeness_pct}%（$file_complete_spans/$file_spans span 完整），存在必要欄位缺失"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 主流程
+# ---------------------------------------------------------------------------
+main() {
+  print_banner "validate-trace-log.sh - Trace Log 品質驗證（ADR-033）"
+
+  check_dependencies
+
+  # 決定驗證目標
+  local target_dir="$TRACE_LOGS_DIR"
+  local specific_file=""
+
+  if [ "${1:-}" = "--dir" ] && [ -n "${2:-}" ]; then
+    target_dir="$2"
+  elif [ -n "${1:-}" ] && [ "${1:-}" != "--dir" ]; then
+    specific_file="$1"
+  fi
+
+  if [ -n "$specific_file" ]; then
+    # 驗證指定檔案
+    if [ ! -f "$specific_file" ]; then
+      print_error "找不到指定檔案：$specific_file"
+      exit 1
+    fi
+    validate_file "$specific_file"
+  else
+    # 驗證目錄下所有 .jsonl 檔案
+    if [ ! -d "$target_dir" ]; then
+      print_error "找不到 trace-logs 目錄：$target_dir"
+      print_info "請確認 docs/trace-logs/ 目錄存在（參見 ADR-033）"
+      exit 1
+    fi
+
+    local jsonl_files=()
+    while IFS= read -r -d $'\0' f; do
+      jsonl_files+=("$f")
+    done < <(find "$target_dir" -maxdepth 1 -name "*.jsonl" ! -name ".gitkeep" -print0 2>/dev/null | sort -z)
+
+    if [ "${#jsonl_files[@]}" -eq 0 ]; then
+      print_info "docs/trace-logs/ 目錄下無 .jsonl 檔案，跳過驗證"
+      print_info "（Trace log 由 Agent 執行時寫入，空目錄為正常初始狀態）"
+      echo ""
+      echo "=============================="
+      echo " 總結：無 trace log 檔案可驗證（正常）"
+      echo "=============================="
+      exit 0
+    fi
+
+    for f in "${jsonl_files[@]}"; do
+      validate_file "$f"
+    done
+  fi
+
+  # 全局總結
+  echo ""
+  echo "=============================="
+  echo " Trace Log 驗證摘要"
+  echo " 驗證檔案數：$TOTAL_FILES"
+  echo " 總 span 數：$TOTAL_SPANS"
+  echo " 完整 span 數：$COMPLETE_SPANS"
+
+  if [ "$TOTAL_SPANS" -gt 0 ]; then
+    local overall_pct
+    overall_pct=$(python3 -c "print(f'{$COMPLETE_SPANS / $TOTAL_SPANS * 100:.1f}')" 2>/dev/null || echo "N/A")
+    echo " 整體必要欄位覆蓋率：${overall_pct}%"
+  fi
+
+  if [ "$EXIT_CODE" -eq 0 ]; then
+    if [ "$WARNING_COUNT" -gt 0 ]; then
+      echo " 結果：通過（$WARNING_COUNT 個 WARNING）"
+    else
+      echo " 結果：全部通過 PASS"
+    fi
+  else
+    echo " 結果：FAIL（$ERROR_COUNT 個 ERROR）"
+  fi
+  echo "=============================="
+
+  exit "$EXIT_CODE"
+}
+
+main "${@}"


### PR DESCRIPTION
## Summary

- **AC1**: 建立 `docs/km/trace-log-completeness-spec.md`，定義 ADR-033 必要欄位覆蓋率指標（8 欄位完整性公式、HEALTHY/WARNING/CRITICAL 門檻、parentSpanId 參照完整性規則）
- **AC2**: 新增 `scripts/validate-trace-log.sh`，自動驗證 JSONL 格式合法性、8 個必要欄位存在性（traceId/spanId/parentSpanId/agentRole/action/timestamp/status/sessionId）、parentSpanId 參照完整性、per-session 命名格式、status 合法值
- **AC3**: 擴充 `mcp-servers/quality-observer/index.js`，新增三個 trace 查詢 tool：`get_trace_recent`（最近 N 條）、`get_trace_by_session`（按 session 篩選）、`get_trace_summary`（human-readable 摘要含覆蓋率、分佈統計）

## Test plan

- [x] `bash scripts/validate-trace-log.sh` — 空目錄正常退出（exit 0）
- [x] 合法 JSONL（含全部 8 欄位）— 覆蓋率 100% PASS
- [x] 缺少必要欄位的 span — 顯示 ERROR 並 exit 1
- [x] 非法 JSON 行 — 顯示 ERROR 並 exit 1
- [x] 非法 status 值 — 顯示 ERROR 並 exit 1
- [x] per-session 命名不符 — 顯示 ERROR 並 exit 1
- [x] `node --check mcp-servers/quality-observer/index.js` — 語法正確
- [x] `bash scripts/validate-json.sh` — 未破壞既有驗證

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)