### PR TITLE
feat: security-review + team-debate progressive disclosure

### DIFF
--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -11,90 +11,37 @@ Security Engineer 主導的安全審查 Skill，確保在安全漏洞被利用�
 
 針對所有涉及外部輸入、API 端點、配置變更的程式碼，派遣 Security Engineer subagent 進行系統性安全審查。以 OWASP Top 10 為核心檢查框架，結合 DevSecOps 實踐與 Secrets Management 審查，在開發流程中建立完整的安全防線。
 
----
-
-## 2. OWASP Top 10 檢查清單
-
-每次安全審查必須逐項檢查以下十大風險類別：
-
-| # | 風險類別 | 說明 | 檢查重點 |
-|---|---------|------|---------|
-| A1 | Injection（注入攻擊） | SQL、NoSQL、OS、LDAP 注入 | 參數化查詢、輸入驗證、ORM 使用 |
-| A2 | Broken Authentication（認證失效） | Session 管理、密碼策略缺陷 | 多因素認證、Session 過期、密碼雜湊強度 |
-| A3 | Sensitive Data Exposure（敏感資料暴露） | 傳輸/儲存中的資料洩漏 | TLS 強制、加密儲存、資料分類標記 |
-| A4 | XML External Entities（XXE） | XML 解析器外部實體攻擊 | 停用外部實體、使用 JSON 替代、XML 解析器加固 |
-| A5 | Broken Access Control（存取控制失效） | 權限繞過、越權存取 | RBAC 驗證、最小權限原則、資源所有權檢查 |
-| A6 | Security Misconfiguration（安全設定錯誤） | 預設設定、錯誤的 HTTP Header | 安全 Header 設定、錯誤訊息處理、版本資訊隱藏 |
-| A7 | Cross-Site Scripting（XSS） | 反射型、儲存型、DOM 型 XSS | 輸出編碼、CSP 設定、輸入消毒 |
-| A8 | Insecure Deserialization（不安全的反序列化） | 物件注入、遠端代碼執行 | 反序列化白名單、完整性檢查、型別限制 |
-| A9 | Using Components with Known Vulnerabilities（使用已知漏洞元件） | 過時的依賴、未修補的漏洞 | 依賴版本檢查、CVE 掃描、自動更新策略 |
-| A10 | Insufficient Logging & Monitoring（日誌與監控不足） | 攻擊偵測與回應能力不足 | 安全事件日誌、異常告警、稽核軌跡完整性 |
+詳細檢查清單與實踐指引見 `references/owasp-devsecops.md`；Refinement 職責見 `references/refinement-security.md`。
 
 ---
 
-## 3. DevSecOps 實踐
+## 2. OWASP Top 10 檢查（摘要）
 
-### 3.1 Shift-Left Security（安全左移）
+10 大風險類別逐項檢查：Injection、Broken Authentication、Sensitive Data Exposure、XXE、Broken Access Control、Security Misconfiguration、XSS、Insecure Deserialization、Known Vulnerabilities、Insufficient Logging。
 
-將安全檢查從部署後移至開發階段，越早發現漏洞，修復成本越低：
-
-- 開發人員在本機即可執行安全掃描
-- Code Review 階段納入安全審查
-- PR 合併前強制通過安全品質門禁
-- 安全需求納入 Story 的 Acceptance Criteria
-
-### 3.2 SAST/DAST 整合到 CI/CD
-
-- **SAST（靜態應用安全測試）**：在 CI 階段分析原始碼，識別潛在漏洞（如 SQL Injection、XSS、硬編碼密鑰）
-- **DAST（動態應用安全測試）**：在 CD 階段對運行中的應用進行黑箱測試，模擬真實攻擊場景
-- 掃描結果自動回報至 PR，Critical/High 等級阻塞合併
-- 定期更新掃描規則庫，確保涵蓋最新威脅
-
-### 3.3 依賴漏洞掃描
-
-- 每次建構時自動掃描所有直接與間接依賴
-- 對照 CVE 資料庫比對已知漏洞
-- 自動產生修復建議（版本升級路徑）
-- 設定漏洞嚴重度閾值，超過閾值自動阻塞
-
-### 3.4 Container Image 掃描
-
-- Base image 安全性驗證
-- 多層掃描：OS 套件漏洞 + 應用依賴漏洞
-- 禁止使用 root 用戶運行容器
-- Image 簽名與來源驗證
+完整清單：`references/owasp-devsecops.md` §2。
 
 ---
 
-## 4. Secrets Management 審查
+## 3. DevSecOps 實踐（摘要）
 
-### 4.1 密鑰輪替自動化
+- **Shift-Left**：安全需求納入 Story AC，PR 前強制通過安全門禁
+- **SAST/DAST**：CI 靜態分析 + CD 動態測試，Critical/High 阻塞合併
+- **依賴掃描**：自動比對 CVE，超過閾值自動阻塞
+- **Container**：多層掃描，禁 root，Image 簽名驗證
 
-- 所有密鑰必須設定自動輪替排程
-- 輪替過程零停機（雙密鑰重疊期）
-- 輪替後自動驗證服務健康狀態
-- 輪替記錄納入稽核日誌
+完整細節：`references/owasp-devsecops.md` §3。
 
-### 4.2 動態密鑰生成
+---
 
-- 使用短期有效的動態密鑰取代長期靜態密鑰
-- 資料庫連線使用臨時憑證（如 Vault Dynamic Secrets）
-- 雲端服務使用臨時 Token（如 STS AssumeRole）
-- 密鑰有效期依最小必要原則設定
+## 4. Secrets Management（摘要）
 
-### 4.3 密鑰蔓延防護
+- 密鑰自動輪替（零停機，雙密鑰重疊期）
+- 動態短期密鑰取代靜態長期密鑰
+- Pre-commit hook 防密鑰蔓延
+- API 金鑰依服務/環境隔離，異常告警
 
-- 禁止在程式碼、設定檔、日誌中出現明文密鑰
-- Pre-commit hook 掃描密鑰洩漏
-- CI/CD Pipeline 密鑰注入而非靜態儲存
-- 定期掃描版本控制歷史中的密鑰殘留
-
-### 4.4 API 金鑰治理
-
-- API 金鑰依服務/環境隔離
-- 設定使用範圍限制（IP 白名單、權限範圍）
-- 金鑰使用量監控與異常告警
-- 停用未使用的金鑰，定期清理殭屍金鑰
+完整細節：`references/owasp-devsecops.md` §4。
 
 ---
 
@@ -102,55 +49,26 @@ Security Engineer 主導的安全審查 Skill，確保在安全漏洞被利用�
 
 ```
 Security Review 觸發
-  |
-  v
-1. Security Engineer subagent 派遣
-  |
-  v
-2. OWASP Top 10 逐項檢查
-  |
-  v
-3. 輸入驗證審查（所有外部入口）
-  |
-  v
-4. 認證/授權/密碼學審查
-  |
-  v
-5. 依賴掃描
-  |
-  v
-6. 漏洞分級判定
-  |-- Critical 漏洞 --> 阻塞，修復後重審
-  |-- High 漏洞 --> 阻塞，修復後重審
-  |-- Medium/Low 漏洞 --> 記錄追蹤，允許繼續
-  +-- 無漏洞
-        |
-        v
-7. 通過 --> 繼續流程
+  → Security Engineer subagent 派遣
+  → OWASP Top 10 逐項檢查
+  → 輸入驗證 / 認證授權密碼學審查
+  → 依賴掃描
+  → 漏洞分級判定
+      Critical/High → 阻塞，修復後重審
+      Medium/Low   → 記錄追蹤，允許繼續
+  → 通過 → 繼續流程
 ```
-
-### 步驟詳解
-
-1. **Security Engineer subagent 派遣**：建立全新的 Security Engineer subagent，注入待審查程式碼的上下文、相關 ADR、已知的安全需求。
-2. **OWASP Top 10 逐項檢查**：依照第 2 節檢查清單，逐一檢視程式碼是否存在對應風險。
-3. **輸入驗證審查**：識別所有外部輸入入口（API 參數、表單欄位、URL 參數、Header、檔案上傳），驗證是否有完整的輸入驗證與消毒處理。
-4. **認證/授權/密碼學審查**：檢查認證流程完整性、授權邏輯正確性、加密演算法選擇與實作是否符合最佳實踐。
-5. **依賴掃描**：掃描所有依賴套件的已知漏洞，確認無 Critical/High 等級的已知 CVE。
-6. **漏洞分級判定**：依 CVSS 評分分級，Critical/High 漏洞阻塞合併，Medium/Low 記錄追蹤。
-7. **通過**：所有 Critical/High 漏洞已解決，安全審查通過，繼續後續流程。
 
 ---
 
 ## 6. 升級觸發
 
-當發現 Critical 漏洞時，立即啟動升級機制：
-
-| 嚴重度 | 動作 | 時效要求 |
-|--------|------|---------|
-| Critical | 立即通知 Stakeholder + SRE，阻塞所有相關部署 | 發現後 15 分鐘內通知 |
-| High | 通知 Tech Lead，阻塞 PR 合併 | 發現後 1 小時內通知 |
-| Medium | 建立追蹤 Issue，排入下一 Sprint | Sprint 內處理 |
-| Low | 記錄至技術債清單 | 季度內處理 |
+| 嚴重度 | 動作 | 時效 |
+|--------|------|------|
+| Critical | 通知 Stakeholder + SRE，阻塞所有部署 | 15 分鐘內 |
+| High | 通知 Tech Lead，阻塞 PR 合併 | 1 小時內 |
+| Medium | 建立追蹤 Issue，排入下一 Sprint | Sprint 內 |
+| Low | 記錄至技術債清單 | 季度內 |
 
 <HARD-GATE>
 Critical 漏洞發現後必須立即通知 Stakeholder 與 SRE，不得延遲或靜默處理。
@@ -161,16 +79,14 @@ Critical 漏洞發現後必須立即通知 Stakeholder 與 SRE，不得延遲或
 
 ## 7. 安全品質門禁
 
-所有程式碼在合併前必須通過以下安全品質門禁：
-
-| 門禁條件 | 說明 | 阻塞等級 |
-|---------|------|---------|
-| 所有 Critical/High 漏洞必須在合併前解決 | SAST/DAST 掃描結果中不得存在未修復的 Critical 或 High 漏洞 | 硬性阻塞 |
-| 安全測試必須覆蓋所有外部輸入路徑 | 每個 API 端點、表單欄位、檔案上傳入口均需對應安全測試 | 硬性阻塞 |
-| 生產環境零 Critical 漏洞 | 生產環境中不得存在任何未修復的 Critical 等級漏洞 | 硬性阻塞 |
-| CIS Benchmarks 合規驗證 | 基礎設施配置符合 CIS（Center for Internet Security）基準要求 | 硬性阻塞 |
-| 無明文密鑰 | 程式碼庫中不得出現任何明文密鑰、Token、憑證 | 硬性阻塞 |
-| 依賴漏洞掃描通過 | 所有依賴套件無 Critical 等級已知 CVE | 硬性阻塞 |
+| 門禁條件 | 阻塞等級 |
+|---------|---------|
+| Critical/High 漏洞合併前解決 | 硬性阻塞 |
+| 安全測試覆蓋所有外部輸入路徑 | 硬性阻塞 |
+| 生產環境零 Critical 漏洞 | 硬性阻塞 |
+| CIS Benchmarks 合規驗證通過 | 硬性阻塞 |
+| 無明文密鑰 / Token / 憑證 | 硬性阻塞 |
+| 依賴套件無 Critical CVE | 硬性阻塞 |
 
 <HARD-GATE>
 所有 Critical/High 漏洞必須在合併前解決。
@@ -185,45 +101,20 @@ CIS Benchmarks 合規驗證必須通過。
 
 | 情境 | 觸發 |
 |------|------|
-| Sprint Execution 中涉及外部輸入/API/配置變更 | 由 `sprint-execution` 觸發 `security-review` |
-| 安全審查發現架構層級安全問題 | 觸發 `architecture-decision` 進行安全架構 ADR |
-| 安全審查通過 | 回到 `sprint-execution` 繼續後續流程 |
-| 安全審查發現 Critical 漏洞影響已上線功能 | 升級至 Stakeholder + SRE，建立緊急修復 Story 排入 Backlog |
+| Sprint Execution 涉及外部輸入/API/配置變更 | 由 `sprint-execution` 觸發 `security-review` |
+| 安全審查發現架構層級問題 | 觸發 `architecture-decision` |
+| 安全審查通過 | 回到 `sprint-execution` 繼續 |
+| Critical 漏洞影響已上線功能 | 升級 Stakeholder + SRE，建立緊急修復 Story |
 
 ---
 
-## 9. Security Engineer Refinement 職責
+## 9. Security Engineer Refinement 職責（摘要）
 
-<!-- US-203 角色 Refinement 職責定義 — Sprint 77 -->
+<!-- US-203 — Sprint 77 -->
 
-Security Engineer 在 Refinement 中負責提前識別 Story 的安全風險，確保安全需求在開發啟動前已明確定義於 AC 中。Security Engineer 在 Refinement 中為**諮詢（Consulted）**角色，不主持、不輸出正式報告，但需提供具體安全風險評估意見。
+諮詢（Consulted）角色，提前識別 Story 安全風險，確保安全 AC 在開發啟動前明確定義。
 
-### 觸發條件
+**觸發出席**：SECURITY Story、AC 含 `[安全]`、涉及外部輸入/認證/授權/加密、新 API 端點。
+**不觸發**：doc-only Story、純 RESEARCH 無程式碼交付物。
 
-Security Engineer **須出席 Refinement** 的情況（滿足任一條件）：
-
-| 觸發條件 | 說明 |
-|---------|------|
-| Story Type 為 SECURITY | SECURITY Story 必須由 Security Engineer 作為 Contract Owner 確認修復方案方向 |
-| Story 的 AC 含 `[安全]` 標記 | AC 已明確標注安全需求，需 Security Engineer 確認驗收標準可行性 |
-| Story 涉及外部輸入、認證、授權或加密 | 即使 Story Type 非 SECURITY，涉及安全面向需 Security Engineer 提前評估 |
-| FEATURE / INTEGRATION Story 引入新 API 端點 | 新 API 端點具備攻擊面，需提前識別輸入驗證與認證需求 |
-
-**不觸發出席**：doc-only Story（僅修改 docs/ 文件）、純 RESEARCH 探索性 Story 且無程式碼交付物。
-
-### 職責說明
-
-| 面向 | 職責內容 |
-|------|---------|
-| **威脅識別** | 針對 Story 草稿，識別潛在安全威脅向量（OWASP Top 10 類別），列出受影響範圍 |
-| **安全 AC 建議** | 若 Story 缺少對應安全驗收條件，建議補充至 AC 清單（如輸入驗證、認證流程、加密要求）|
-| **Contract Owner 確認（SECURITY Story）** | 作為 SECURITY Type 的 Contract Owner，確認修復方案方向，提供安全審查策略初稿 |
-| **Security Review 觸發預判** | 判斷 Story 完成後是否需觸發 Security Review Skill，並在 Refinement 報告中預先記錄 |
-
-### Refinement 輸出
-
-| 輸出項目 | 說明 |
-|---------|------|
-| 安全風險評估摘要 | 列出識別的威脅向量（OWASP 分類）、受影響範圍與嚴重度（Critical / High / Medium / Low）|
-| 安全 AC 補充建議（若有） | 建議補充的安全驗收條件，由 PO 決定是否納入 Story AC 清單 |
-| Security Review 觸發預判 | 明確說明 Story 完成後是否預期觸發 Security Review（是/否/條件觸發）|
+完整觸發條件、職責說明與輸出格式：`references/refinement-security.md` §9。

--- a/skills/security-review/references/owasp-devsecops.md
+++ b/skills/security-review/references/owasp-devsecops.md
@@ -1,0 +1,84 @@
+# Security Review — OWASP / DevSecOps / Secrets 參考
+
+## §2. OWASP Top 10 檢查清單
+
+每次安全審查必須逐項檢查以下十大風險類別：
+
+| # | 風險類別 | 說明 | 檢查重點 |
+|---|---------|------|---------|
+| A1 | Injection（注入攻擊） | SQL、NoSQL、OS、LDAP 注入 | 參數化查詢、輸入驗證、ORM 使用 |
+| A2 | Broken Authentication（認證失效） | Session 管理、密碼策略缺陷 | 多因素認證、Session 過期、密碼雜湊強度 |
+| A3 | Sensitive Data Exposure（敏感資料暴露） | 傳輸/儲存中的資料洩漏 | TLS 強制、加密儲存、資料分類標記 |
+| A4 | XML External Entities（XXE） | XML 解析器外部實體攻擊 | 停用外部實體、使用 JSON 替代、XML 解析器加固 |
+| A5 | Broken Access Control（存取控制失效） | 權限繞過、越權存取 | RBAC 驗證、最小權限原則、資源所有權檢查 |
+| A6 | Security Misconfiguration（安全設定錯誤） | 預設設定、錯誤的 HTTP Header | 安全 Header 設定、錯誤訊息處理、版本資訊隱藏 |
+| A7 | Cross-Site Scripting（XSS） | 反射型、儲存型、DOM 型 XSS | 輸出編碼、CSP 設定、輸入消毒 |
+| A8 | Insecure Deserialization（不安全的反序列化） | 物件注入、遠端代碼執行 | 反序列化白名單、完整性檢查、型別限制 |
+| A9 | Using Components with Known Vulnerabilities（使用已知漏洞元件） | 過時的依賴、未修補的漏洞 | 依賴版本檢查、CVE 掃描、自動更新策略 |
+| A10 | Insufficient Logging & Monitoring（日誌與監控不足） | 攻擊偵測與回應能力不足 | 安全事件日誌、異常告警、稽核軌跡完整性 |
+
+---
+
+## §3. DevSecOps 實踐
+
+### 3.1 Shift-Left Security（安全左移）
+
+將安全檢查從部署後移至開發階段，越早發現漏洞，修復成本越低：
+
+- 開發人員在本機即可執行安全掃描
+- Code Review 階段納入安全審查
+- PR 合併前強制通過安全品質門禁
+- 安全需求納入 Story 的 Acceptance Criteria
+
+### 3.2 SAST/DAST 整合到 CI/CD
+
+- **SAST（靜態應用安全測試）**：在 CI 階段分析原始碼，識別潛在漏洞（如 SQL Injection、XSS、硬編碼密鑰）
+- **DAST（動態應用安全測試）**：在 CD 階段對運行中的應用進行黑箱測試，模擬真實攻擊場景
+- 掃描結果自動回報至 PR，Critical/High 等級阻塞合併
+- 定期更新掃描規則庫，確保涵蓋最新威脅
+
+### 3.3 依賴漏洞掃描
+
+- 每次建構時自動掃描所有直接與間接依賴
+- 對照 CVE 資料庫比對已知漏洞
+- 自動產生修復建議（版本升級路徑）
+- 設定漏洞嚴重度閾值，超過閾值自動阻塞
+
+### 3.4 Container Image 掃描
+
+- Base image 安全性驗證
+- 多層掃描：OS 套件漏洞 + 應用依賴漏洞
+- 禁止使用 root 用戶運行容器
+- Image 簽名與來源驗證
+
+---
+
+## §4. Secrets Management 審查
+
+### 4.1 密鑰輪替自動化
+
+- 所有密鑰必須設定自動輪替排程
+- 輪替過程零停機（雙密鑰重疊期）
+- 輪替後自動驗證服務健康狀態
+- 輪替記錄納入稽核日誌
+
+### 4.2 動態密鑰生成
+
+- 使用短期有效的動態密鑰取代長期靜態密鑰
+- 資料庫連線使用臨時憑證（如 Vault Dynamic Secrets）
+- 雲端服務使用臨時 Token（如 STS AssumeRole）
+- 密鑰有效期依最小必要原則設定
+
+### 4.3 密鑰蔓延防護
+
+- 禁止在程式碼、設定檔、日誌中出現明文密鑰
+- Pre-commit hook 掃描密鑰洩漏
+- CI/CD Pipeline 密鑰注入而非靜態儲存
+- 定期掃描版本控制歷史中的密鑰殘留
+
+### 4.4 API 金鑰治理
+
+- API 金鑰依服務/環境隔離
+- 設定使用範圍限制（IP 白名單、權限範圍）
+- 金鑰使用量監控與異常告警
+- 停用未使用的金鑰，定期清理殭屍金鑰

--- a/skills/security-review/references/refinement-security.md
+++ b/skills/security-review/references/refinement-security.md
@@ -1,0 +1,35 @@
+# Security Engineer Refinement 職責
+
+<!-- US-203 角色 Refinement 職責定義 — Sprint 77 -->
+
+Security Engineer 在 Refinement 中負責提前識別 Story 的安全風險，確保安全需求在開發啟動前已明確定義於 AC 中。Security Engineer 在 Refinement 中為**諮詢（Consulted）**角色，不主持、不輸出正式報告，但需提供具體安全風險評估意見。
+
+## 觸發條件
+
+Security Engineer **須出席 Refinement** 的情況（滿足任一條件）：
+
+| 觸發條件 | 說明 |
+|---------|------|
+| Story Type 為 SECURITY | SECURITY Story 必須由 Security Engineer 作為 Contract Owner 確認修復方案方向 |
+| Story 的 AC 含 `[安全]` 標記 | AC 已明確標注安全需求，需 Security Engineer 確認驗收標準可行性 |
+| Story 涉及外部輸入、認證、授權或加密 | 即使 Story Type 非 SECURITY，涉及安全面向需 Security Engineer 提前評估 |
+| FEATURE / INTEGRATION Story 引入新 API 端點 | 新 API 端點具備攻擊面，需提前識別輸入驗證與認證需求 |
+
+**不觸發出席**：doc-only Story（僅修改 docs/ 文件）、純 RESEARCH 探索性 Story 且無程式碼交付物。
+
+## 職責說明
+
+| 面向 | 職責內容 |
+|------|---------|
+| **威脅識別** | 針對 Story 草稿，識別潛在安全威脅向量（OWASP Top 10 類別），列出受影響範圍 |
+| **安全 AC 建議** | 若 Story 缺少對應安全驗收條件，建議補充至 AC 清單（如輸入驗證、認證流程、加密要求）|
+| **Contract Owner 確認（SECURITY Story）** | 作為 SECURITY Type 的 Contract Owner，確認修復方案方向，提供安全審查策略初稿 |
+| **Security Review 觸發預判** | 判斷 Story 完成後是否需觸發 Security Review Skill，並在 Refinement 報告中預先記錄 |
+
+## Refinement 輸出
+
+| 輸出項目 | 說明 |
+|---------|------|
+| 安全風險評估摘要 | 列出識別的威脅向量（OWASP 分類）、受影響範圍與嚴重度（Critical / High / Medium / Low）|
+| 安全 AC 補充建議（若有） | 建議補充的安全驗收條件，由 PO 決定是否納入 Story AC 清單 |
+| Security Review 觸發預判 | 明確說明 Story 完成後是否預期觸發 Security Review（是/否/條件觸發）|

--- a/skills/team-debate/SKILL.md
+++ b/skills/team-debate/SKILL.md
@@ -17,217 +17,72 @@ description: "Use when a M/L size Story completes implementation and needs indep
 
 ## 2. 適用條件（Phase 1）
 
-| 條件 | 說明 |
-|------|------|
-| **適用角色** | Developer only（Phase 1） |
-| **適用 Story 類型** | FEATURE、INFRA、SECURITY、INTEGRATION |
-| **豁免條件** | `doc_only=true` 的 Story（文件類不啟用，成本不值得） |
-| **豁免條件** | `story_type=RESEARCH` 的 Story |
-| **豁免條件** | `story_type=DESIGN` 的 Story |
-| **Size 門檻** | M/L 規模啟用；S 規模可由 Scrum Master 決定是否啟用 |
-
-**不適用角色（Phase 1 不包含）**：
-- PO、Scrum Master：流程管理角色，非產出角色
-- SRE、Security Engineer：低頻觸發，成本效益比不佳
-- UI/UX Designer：設計審查有獨立流程（Vision Critic）
+- **適用**：Developer、FEATURE/INFRA/SECURITY/INTEGRATION、M/L 規模
+- **豁免**：`doc_only=true`、`story_type ∈ {RESEARCH, DESIGN}`、S 規模（SM 未明確啟用）
+- **不適用角色**：PO、SM（流程角色）、SRE/Security Engineer（低頻）、UI/UX（獨立 Vision Critic 流程）
 
 ---
 
 ## 3. Agent 角色定義
 
-### Worker（Agent A）
+**Worker（Agent A）**：TDD 開發 + self-review + 接收批判後逐項 accept/reject 修復；獨立 worktree，不帶批判歷史。
 
-- **職責**：執行 TDD 開發、self-review、接收批判後修復
-- **行為**：完整 Story-Lifecycle（TDD + Spec/Quality/Security self-review）
-- **修復義務**：接收 Critic 批判後必須逐項回應（accept/reject + 理由）並修復 accept 項目
-- **context**：獨立 worktree，不帶 Critic 的批判歷史進入修復
-
-### Critic（Agent B）
-
-- **職責**：獨立批判 Worker 的產出，不修改代碼
-- **行為**：讀取 Worker 的 branch + 產出，從外部視角進行批判
-- **批判維度**：
-  1. **正確性**：AC 是否全部覆蓋？邊界條件是否處理？
-  2. **設計**：是否符合 SOLID 原則？耦合度？單一職責？
-  3. **測試覆蓋**：測試是否充分？Red 階段是否真正先寫失敗測試？
-  4. **安全性**：外部輸入是否受保護？有無硬編碼 secrets？
-- **禁止行為**：不直接修改代碼；不與 Worker 進行 context 共享
+**Critic（Agent B）**：外部視角批判 4 維度（正確性、設計、測試覆蓋、安全性）；不修改代碼；不與 Worker 共享 context。
 
 ---
 
 ## 4. 通訊機制
 
-### 批判結果檔案路徑
+批判結果路徑：`.claude/debate/critique-round-{N}.md`（N 最大為 2）
 
-```
-.claude/debate/critique-round-{N}.md
-```
-
-### 批判結果格式
-
-```markdown
-# Critique Round {N}
-
-## Verdict: PASS | FAIL
-
-## Issues Found
-- [SEVERITY: HIGH|MED|LOW] {問題描述}
-  - 位置：{file}:{line}
-  - 建議：{改善方向}
-
-## Summary
-{總結評語，說明主要發現與整體評估}
-```
-
-### 規則
-
-- `N` 從 1 開始，最大為 2
-- `Verdict: PASS`：Critic 認可 Worker 產出，無需修復
-- `Verdict: FAIL`：Critic 發現問題，Worker 需修復後再次批判
-- 若 Issues Found 為空，Verdict 必須為 PASS
+格式：`Verdict: PASS | FAIL` + Issues Found（SEVERITY: HIGH|MED|LOW + 位置 + 建議）+ Summary。Issues 為空時 Verdict 必須為 PASS。
 
 ---
 
 ## 5. 收斂機制（2 輪硬上限）
 
 ```
-Round 1：
-  Worker 完成實作 + self-review
-    ↓
-  Critic 讀取產出 → 寫入 critique-round-1.md
-    ├─ Verdict: PASS → 收斂，進入 PR 流程
-    └─ Verdict: FAIL → 繼續 Round 2
+Round 1：Worker 完成 + self-review → Critic 批判
+  PASS → 收斂進 PR；FAIL → Round 2
 
-Round 2：
-  Worker 讀取 critique-round-1.md → 修復 → commit
-    ↓
-  Critic 讀取修復後產出 → 寫入 critique-round-2.md
-    ├─ Verdict: PASS → 收斂，進入 PR 流程
-    └─ Verdict: FAIL → [DEBATE-UNRESOLVED] 強制收斂
+Round 2：Worker 修復 → Critic 二次批判
+  PASS → 收斂進 PR；FAIL → [DEBATE-UNRESOLVED] 強制收斂
 ```
 
-**強制收斂規則**：
-- 第 2 輪後無論 Verdict 均強制收斂，禁止第 3 輪批判
-- Verdict: FAIL 後強制收斂時，標記 `[DEBATE-UNRESOLVED]`，由主 session 決定升級處置
+- 第 2 輪後無論 Verdict 均強制收斂，禁止第 3 輪
+- `[DEBATE-UNRESOLVED]` 由主 session 決定升級處置
+
+完整流程圖：`references/convergence-rules.md` §5。
 
 ---
 
 ## 6. 執行流程（主 session 協調）
 
-### 步驟 1：觸發判斷
+觸發判斷 → 派遣 Worker（完整 TDD + self-review）→ 派遣 Critic Round 1 → 依 Verdict 決定收斂或 Round 2 → PR 流程（附 debate 摘要）。
 
-```
-主 session 接收 Story 參數後，判斷是否啟用 Team Debate：
+**豁免跳過**：`doc_only=true`、`story_type ∈ {RESEARCH, DESIGN}`、`size=S` 且 SM 未啟用。
 
-若 doc_only=true → 跳過 Team Debate，使用標準 Story-Lifecycle
-若 story_type ∈ {RESEARCH, DESIGN} → 跳過 Team Debate
-若 size=S 且 Scrum Master 未明確啟用 → 跳過 Team Debate
-否則 → 啟用 Team Debate（Developer Story，Phase 1）
-```
-
-### 步驟 2：派遣 Worker（Agent A）
-
-```
-派遣 Story-Lifecycle subagent（Worker 角色）
-  - 使用標準 story-lifecycle-prompt.md
-  - 執行完整 TDD + self-review 流程
-  - commit 至 branch，回傳 branch + worktree path
-  - 輸出：WORKER_BRANCH={branch}、WORKER_COMMIT={sha}
-```
-
-### 步驟 3：派遣 Critic（Agent B）— Round 1
-
-```
-派遣 Developer subagent（Critic 角色）
-  - 讀取 Worker 的 branch 產出（git diff vs main 或讀取修改檔案）
-  - 執行獨立批判（4 維度：正確性、設計、測試覆蓋、安全性）
-  - 寫入 .claude/debate/critique-round-1.md
-  - 回傳 Verdict（PASS/FAIL）
-```
-
-### 步驟 4a：若 Round 1 Verdict = PASS
-
-```
-收斂，進入 PR 流程
-輸出：[DEBATE-PASS] Round 1 批判通過，收斂
-```
-
-### 步驟 4b：若 Round 1 Verdict = FAIL
-
-```
-派遣 Worker（修復）：
-  - 讀取 critique-round-1.md
-  - 逐項回應（accept/reject + 理由）
-  - 修復所有 accept 項目
-  - commit 修復，回傳 WORKER_COMMIT_R2={sha}
-
-派遣 Critic — Round 2：
-  - 讀取修復後產出
-  - 執行二次批判
-  - 寫入 .claude/debate/critique-round-2.md
-  - 回傳 Verdict（PASS/FAIL）
-```
-
-### 步驟 5：Round 2 後強制收斂
-
-```
-若 Round 2 Verdict = PASS：
-  收斂，進入 PR 流程
-  輸出：[DEBATE-PASS] Round 2 批判通過，收斂
-
-若 Round 2 Verdict = FAIL：
-  強制收斂
-  輸出：[DEBATE-UNRESOLVED] 2 輪後仍有未解決問題
-  標記升級候選，由主 session 決定是否 ESCALATE
-  仍進入 PR 流程，PR description 附上 debate 紀錄
-```
-
-### 步驟 6：PR 流程
-
-```
-Worker 執行 git push → gh pr create
-PR description 必須附上 debate 摘要：
-  - Debate rounds 數
-  - 最終 Verdict
-  - 若 [DEBATE-UNRESOLVED]，列出未解決問題
-```
+完整步驟：`references/debate-flow.md` §6。
 
 ---
 
 ## 7. Critic Prompt 指引
 
-Critic Agent 派遣時使用以下 prompt 框架：
+Critic 以外部視角批判，不修改代碼；批判必須具體指出檔案行號；找不到明確問題應給 PASS；`[SEVERITY: HIGH]` 僅用於 AC 缺失或安全漏洞。
 
-```
-你是 Developer Critic Agent，負責對以下 Story 的實作進行獨立外部批判。
-你不是作者，你沒有看過開發過程，你只看最終產出。
-
-Story ID：{story_id}
-Worker Branch：{branch}
-Story AC：{ac_list}
-
-批判任務：
-1. 讀取 Worker 修改的所有檔案（git diff 或讀取修改檔案清單）
-2. 逐項檢查 AC 是否有對應實作
-3. 從 4 個維度批判（正確性、設計、測試覆蓋、安全性）
-4. 輸出批判結果至 .claude/debate/critique-round-{N}.md（格式見 §4）
-
-重要原則：
-- 你的批判必須具體，指出檔案和行號
-- 你不能修改任何代碼，只能批判
-- 若你找不到明確問題，Verdict = PASS（不要為了批判而批判）
-- [SEVERITY: HIGH] 僅用於 AC 缺失或安全漏洞；設計優化建議用 LOW/MED
-```
+完整 prompt 框架：`references/critic-prompt.md` §7。
 
 ---
 
 ## 8. [DEBATE-UNRESOLVED] 升級處置
 
-| 主 session 行為 | 條件 | 說明 |
-|----------------|------|------|
-| 繼續進入 PR | 預設 | `project_level=low` 時，標記後直接進入 PR |
-| 通知等待確認 | `project_level=medium/high` | 留言通知使用者，等待決策 |
-| 升級至 Architect | 特殊情況 | 若未解決問題屬設計層面（HIGH severity），升級 DESIGN_ISSUE |
+| 主 session 行為 | 條件 |
+|----------------|------|
+| 繼續進入 PR | `project_level=low`（預設） |
+| 通知等待確認 | `project_level=medium/high` |
+| 升級至 Architect | HIGH severity 設計問題 |
+
+完整規則：`references/convergence-rules.md` §8。
 
 ---
 

--- a/skills/team-debate/references/convergence-rules.md
+++ b/skills/team-debate/references/convergence-rules.md
@@ -1,0 +1,33 @@
+# Team Debate — 收斂機制與升級處置
+
+## §5 收斂機制（2 輪硬上限）
+
+```
+Round 1：
+  Worker 完成實作 + self-review
+    ↓
+  Critic 讀取產出 → 寫入 critique-round-1.md
+    ├─ Verdict: PASS → 收斂，進入 PR 流程
+    └─ Verdict: FAIL → 繼續 Round 2
+
+Round 2：
+  Worker 讀取 critique-round-1.md → 修復 → commit
+    ↓
+  Critic 讀取修復後產出 → 寫入 critique-round-2.md
+    ├─ Verdict: PASS → 收斂，進入 PR 流程
+    └─ Verdict: FAIL → [DEBATE-UNRESOLVED] 強制收斂
+```
+
+**強制收斂規則**：
+- 第 2 輪後無論 Verdict 均強制收斂，禁止第 3 輪批判
+- Verdict: FAIL 後強制收斂時，標記 `[DEBATE-UNRESOLVED]`，由主 session 決定升級處置
+
+---
+
+## §8 [DEBATE-UNRESOLVED] 升級處置
+
+| 主 session 行為 | 條件 | 說明 |
+|----------------|------|------|
+| 繼續進入 PR | 預設 | `project_level=low` 時，標記後直接進入 PR |
+| 通知等待確認 | `project_level=medium/high` | 留言通知使用者，等待決策 |
+| 升級至 Architect | 特殊情況 | 若未解決問題屬設計層面（HIGH severity），升級 DESIGN_ISSUE |

--- a/skills/team-debate/references/critic-prompt.md
+++ b/skills/team-debate/references/critic-prompt.md
@@ -1,0 +1,26 @@
+# Team Debate — Critic Prompt 指引
+
+## §7 Critic Prompt 指引
+
+Critic Agent 派遣時使用以下 prompt 框架：
+
+```
+你是 Developer Critic Agent，負責對以下 Story 的實作進行獨立外部批判。
+你不是作者，你沒有看過開發過程，你只看最終產出。
+
+Story ID：{story_id}
+Worker Branch：{branch}
+Story AC：{ac_list}
+
+批判任務：
+1. 讀取 Worker 修改的所有檔案（git diff 或讀取修改檔案清單）
+2. 逐項檢查 AC 是否有對應實作
+3. 從 4 個維度批判（正確性、設計、測試覆蓋、安全性）
+4. 輸出批判結果至 .claude/debate/critique-round-{N}.md（格式見 §4）
+
+重要原則：
+- 你的批判必須具體，指出檔案和行號
+- 你不能修改任何代碼，只能批判
+- 若你找不到明確問題，Verdict = PASS（不要為了批判而批判）
+- [SEVERITY: HIGH] 僅用於 AC 缺失或安全漏洞；設計優化建議用 LOW/MED
+```

--- a/skills/team-debate/references/debate-flow.md
+++ b/skills/team-debate/references/debate-flow.md
@@ -1,0 +1,81 @@
+# Team Debate — 執行流程詳細步驟
+
+## §6 執行流程（主 session 協調）
+
+### 步驟 1：觸發判斷
+
+```
+主 session 接收 Story 參數後，判斷是否啟用 Team Debate：
+
+若 doc_only=true → 跳過 Team Debate，使用標準 Story-Lifecycle
+若 story_type ∈ {RESEARCH, DESIGN} → 跳過 Team Debate
+若 size=S 且 Scrum Master 未明確啟用 → 跳過 Team Debate
+否則 → 啟用 Team Debate（Developer Story，Phase 1）
+```
+
+### 步驟 2：派遣 Worker（Agent A）
+
+```
+派遣 Story-Lifecycle subagent（Worker 角色）
+  - 使用標準 story-lifecycle-prompt.md
+  - 執行完整 TDD + self-review 流程
+  - commit 至 branch，回傳 branch + worktree path
+  - 輸出：WORKER_BRANCH={branch}、WORKER_COMMIT={sha}
+```
+
+### 步驟 3：派遣 Critic（Agent B）— Round 1
+
+```
+派遣 Developer subagent（Critic 角色）
+  - 讀取 Worker 的 branch 產出（git diff vs main 或讀取修改檔案）
+  - 執行獨立批判（4 維度：正確性、設計、測試覆蓋、安全性）
+  - 寫入 .claude/debate/critique-round-1.md
+  - 回傳 Verdict（PASS/FAIL）
+```
+
+### 步驟 4a：若 Round 1 Verdict = PASS
+
+```
+收斂，進入 PR 流程
+輸出：[DEBATE-PASS] Round 1 批判通過，收斂
+```
+
+### 步驟 4b：若 Round 1 Verdict = FAIL
+
+```
+派遣 Worker（修復）：
+  - 讀取 critique-round-1.md
+  - 逐項回應（accept/reject + 理由）
+  - 修復所有 accept 項目
+  - commit 修復，回傳 WORKER_COMMIT_R2={sha}
+
+派遣 Critic — Round 2：
+  - 讀取修復後產出
+  - 執行二次批判
+  - 寫入 .claude/debate/critique-round-2.md
+  - 回傳 Verdict（PASS/FAIL）
+```
+
+### 步驟 5：Round 2 後強制收斂
+
+```
+若 Round 2 Verdict = PASS：
+  收斂，進入 PR 流程
+  輸出：[DEBATE-PASS] Round 2 批判通過，收斂
+
+若 Round 2 Verdict = FAIL：
+  強制收斂
+  輸出：[DEBATE-UNRESOLVED] 2 輪後仍有未解決問題
+  標記升級候選，由主 session 決定是否 ESCALATE
+  仍進入 PR 流程，PR description 附上 debate 紀錄
+```
+
+### 步驟 6：PR 流程
+
+```
+Worker 執行 git push → gh pr create
+PR description 必須附上 debate 摘要：
+  - Debate rounds 數
+  - 最終 Verdict
+  - 若 [DEBATE-UNRESOLVED]，列出未解決問題
+```


### PR DESCRIPTION
## Summary

- security-review: 230 → 120 lines；抽出 `references/owasp-devsecops.md`（§2 OWASP Top 10 + §3 DevSecOps + §4 Secrets Management）與 `references/refinement-security.md`（§9 Refinement 職責）
- team-debate: 262 → 116 lines；抽出 `references/critic-prompt.md`（§7 Critic Prompt）、`references/debate-flow.md`（§6 執行流程）、`references/convergence-rules.md`（§5 收斂機制 + §8 升級處置）
- 主文件保留摘要 + 指針，HARD-GATE 完整保留

## Test plan

- [x] validate-skills.sh PASS（29 Skills 全通過）
- [x] validate-xrefs.sh PASS（861 引用全通過）
- [x] security-review SKILL.md ≤ 120 lines（120 lines）
- [x] team-debate SKILL.md ≤ 130 lines（116 lines）

🤖 Generated with [Claude Code](https://claude.com/claude-code)