### PR TITLE
fix: project_level=low 自動行為加入 HARD-GATE 標記 (#517)

### DIFF
--- a/skills/cruise/SKILL.md
+++ b/skills/cruise/SKILL.md
@@ -166,6 +166,10 @@ PROJECT_LEVEL=$(grep -A5 'shikigami:' "$CONFIG_FILE" 2>/dev/null | grep 'project
 PROJECT_LEVEL="${PROJECT_LEVEL:-medium}"
 ```
 
+<HARD-GATE>
+project_level=low 的所有自動行為（auto-shoot、auto-close、auto-sprint-planning、auto-sprint-execution）為強制執行，Agent 禁止加入額外確認步驟。
+</HARD-GATE>
+
 | 行為 | low | medium（預設） | high |
 |------|-----|---------------|------|
 | auto-shoot | 自動派遣 invoke shikigami:shoot | 自動派遣 | 只標記，等人確認 |

--- a/skills/cruise/references/po-patrol.md
+++ b/skills/cruise/references/po-patrol.md
@@ -361,6 +361,9 @@ SHOULD_TRIGGER = (SPRINT_CANDIDATE_COUNT >= 3) OR (SPRINT_CANDIDATE_COUNT >= 1 A
 if SHOULD_TRIGGER:
   if PROJECT_LEVEL == "low":
     # low：PO 直接觸發，不等人
+    # <HARD-GATE>
+    # project_level=low 時，Sprint Planning 觸發條件達標後必須立即 invoke shikigami:sprint-planning，禁止詢問使用者確認。
+    # </HARD-GATE>
     invoke shikigami:sprint-planning
     log action: "trigger-sprint-planning (project_level=low, count=${SPRINT_CANDIDATE_COUNT})"
   elif PROJECT_LEVEL == "medium":
@@ -384,6 +387,9 @@ if [[ "$EFFECTIVELY_COMPLETE" -eq 1 ]]; then
   # Sprint 實質完成：所有 in-sprint Story 均 blocked，允許 bypass
   if [[ "$PROJECT_LEVEL" == "low" ]]; then
     # low：自動觸發 Sprint Review，將 blocked Story 回流 backlog
+    # <HARD-GATE>
+    # project_level=low 時，Sprint 實質完成後必須立即 invoke shikigami:sprint-review，禁止詢問使用者確認。
+    # </HARD-GATE>
     invoke shikigami:sprint-review
     log action: "sprint-effectively-complete-bypass (project_level=low, blocked=${BLOCKED_SPRINT_STORIES}, total=${TOTAL_SPRINT_STORIES})"
   elif [[ "$PROJECT_LEVEL" == "medium" ]]; then
@@ -417,6 +423,9 @@ if [[ "$IN_SPRINT_COUNT" -eq 0 && ! -f "$SHOOT_FLAG" && "$BACKLOG_COUNT" -gt 0 ]
   # 閒置狀態：無 Sprint、無 Shoot、backlog 有東西
   if [[ "$PROJECT_LEVEL" == "low" ]]; then
     # low：直接觸發 Sprint Planning
+    # <HARD-GATE>
+    # project_level=low 時，閒置偵測條件達標後必須立即 invoke shikigami:sprint-planning，禁止詢問使用者確認。
+    # </HARD-GATE>
     invoke shikigami:sprint-planning
     log action: "idle-trigger-sprint-planning (project_level=low, backlog=${BACKLOG_COUNT})"
   elif [[ "$PROJECT_LEVEL" == "medium" ]]; then

--- a/skills/sprint-planning/SKILL.md
+++ b/skills/sprint-planning/SKILL.md
@@ -103,6 +103,10 @@ Sprint Planning 是每個 Sprint 週期的起點儀式。由 **PO** 主持，**A
 
 詳見 [references/commit-and-trigger.md](./references/commit-and-trigger.md)。
 
+<HARD-GATE>
+project_level=low 時，Sprint Planning commit + push 完成後，必須自動 invoke shikigami:sprint-execution，禁止詢問使用者確認。
+</HARD-GATE>
+
 ---
 
 ## 6. Subagent 派遣順序

--- a/skills/sprint-planning/references/commit-and-trigger.md
+++ b/skills/sprint-planning/references/commit-and-trigger.md
@@ -69,6 +69,10 @@ git push
 
 Sprint Planning commit + push 完成後，依 `project_level` 決定是否自動啟動 Sprint Execution：
 
+<HARD-GATE>
+project_level=low 時，Sprint Planning commit + push 完成後，必須自動 invoke shikigami:sprint-execution，禁止詢問使用者確認。
+</HARD-GATE>
+
 ```bash
 # 讀取 project_level（同 Cruise 步驟 4.5 讀取方式）
 CONFIG_FILE=".claude/shikigami.local.md"


### PR DESCRIPTION
## Summary

- `cruise/SKILL.md` §4.5：在 project_level 行為表前加入 HARD-GATE，覆蓋 auto-shoot、auto-close、auto-sprint-planning、auto-sprint-execution 等所有 low 模式自動行為
- `cruise/references/po-patrol.md`：Step 5（Sprint Planning 觸發）、Step 5.5（Sprint 實質完成偵測）、Step 6（閒置偵測）的 `project_level=low` 分支均加入 HARD-GATE 標記
- `sprint-planning/SKILL.md` §5.1：加入 HARD-GATE 明確要求 low 模式 commit+push 後必須自動 invoke sprint-execution
- `sprint-planning/references/commit-and-trigger.md`：在自動啟動 Sprint Execution 偽碼前加入 HARD-GATE

## 根因

Agent 隱性行為（重量級操作先確認）覆蓋了 skill pseudocode 的明示規則。`<HARD-GATE>` 是 shikigami 中最強的指令標記，加入後 Agent 不敢違反，確保 `project_level=low` 語義被正確執行。

## 測試計畫

- [ ] 驗證 `bash scripts/validate-skills.sh` 全部通過（29/29 PASS）
- [ ] 確認 HARD-GATE 標記僅包裹 `project_level=low` 分支，不影響 medium/high 行為
- [ ] 確認所有標記位置符合 Issue #517 AC 要求的四個檔案

Closes #517