### PR TITLE
feat: INFRA 回歸測試案例實作與 CI 整合 (#495)

### DIFF
--- a/.claude/debate/critique-round-1.md
+++ b/.claude/debate/critique-round-1.md
@@ -1,0 +1,71 @@
+# Team Debate — Critic Round 1
+**Story**: #495 feat: INFRA 回歸測試案例實作
+**Branch**: sprint-128/495-infra-test-cases
+**Critic Agent**: Developer Critic (Agent B)
+**Date**: 2026-03-24
+
+---
+
+## Verdict: PASS
+
+---
+
+## 批判維度評估
+
+### 1. 正確性（AC 覆蓋度）
+
+| AC | 說明 | 評估 |
+|----|------|------|
+| AC2a (#423 OIDC) | U-3a/b/c 驗證 id-token:write、permissions 區塊、CLAUDE_CODE_OAUTH_TOKEN；I-4a/b/c 驗證 ci-health-check.sh 的 API endpoint、404/401 判斷 | PASS |
+| AC2b (#442 unzip) | U-4a 冪等安裝（command -v unzip）、U-4b apt-get install -y unzip、U-4c sudo -n 退化偵測 | PASS |
+| AC2c (#424 版本釘定) | I-3a 實際執行 validate-ci-versions.sh、I-3b 輸出 PASS 驗證、I-3c 掃描到 3 個 workflow | PASS |
+| AC3 (CI pipeline) | S-3a/b/c/d 確認 infra-regression.yml 存在、觸發條件、checkout@v4 | PASS |
+
+邊界條件檢查：
+- 測試在各 workflow 檔案不存在時均有 `skip` fallback，不會誤 FAIL — 正確
+- U-4c 正確排除 YAML 註解行（grep -vE "^[[:space:]]*#"）— 正確
+
+### 2. 設計（SOLID / 耦合度 / 命名）
+
+**正向觀察：**
+- 新測試段落命名（U-3、U-4、I-3、I-4、S-3）沿用既有框架命名慣例，一致性佳
+- 每個 `assert_contains` 都有具體的 fix_hint，符合框架 INFRA-DIAG 規範
+- `infra-regression.yml` 使用 env 傳遞 `inputs.infra_test_level`（安全最佳實踐）
+- `paths` filter 避免每次 push 都觸發，減少 CI noise
+
+**可觀察的設計問題（LOW）：**
+
+- `tests/test-infra-regression.sh` 第 470 行：`VALIDATE_EXIT=$?` 在 `set -uo pipefail` 環境中，若 subshell 本身出錯可能不如預期。不過此處已用 `2>&1` 捕獲 stderr，且腳本頂部是 `set -uo pipefail`（未含 `-e`），實際風險極低。
+- `infra-regression.yml` 第 53 行：`runs-on: ubuntu-latest` — ubuntu-latest 版本會漂移。在強調版本釘定的專案中略顯矛盾，但屬已知取捨（現有 e2e.yml 亦同），無需在此 Story 修復。
+
+### 3. 測試覆蓋
+
+- 新增 12 個測試案例（U-3: 3個、U-4: 3個、I-3: 3個、I-4: 3個、S-3: 4個）
+- 從 20 個擴充至 36 個，覆蓋率顯著提升
+- TDD 流程：Red 階段發現了 U-4c 的真實問題（sudo -n 出現在 grep 結果中），並正確修正為排除注釋行 — 符合 TDD 精神
+- 既有 20 個測試均繼續通過 — 無退化
+
+### 4. 安全性
+
+- `infra-regression.yml`：`permissions: contents: read`（最小權限）— 正確
+- input 透過 env 傳遞，無命令注入風險（choice type + env 雙重防護）— 正確
+- 無硬編碼 secrets — 正確
+- validate-ci-versions.sh 透過 `CI_VERSIONS_REPO_ROOT` 環境變數注入，非直接 eval — 正確
+
+---
+
+## Issues Found
+
+無 HIGH severity 問題。LOW 問題不影響 AC 完整性，已記錄供參考，不要求修復。
+
+---
+
+## Summary
+
+Worker 正確實作了所有 4 個 AC：
+- AC2a: U-3 (3 tests) + I-4 (3 tests) 覆蓋 #423 OIDC 配置
+- AC2b: U-4 (3 tests) 覆蓋 #442 unzip 深度回歸
+- AC2c: I-3 (3 tests) 覆蓋 #424 版本釘定實際執行
+- AC3: S-3 (4 tests) + infra-regression.yml 覆蓋 CI pipeline 整合
+
+TDD 流程嚴格執行（Red→Green 可追蹤），無安全漏洞，設計無重大問題。

--- a/.github/workflows/infra-regression.yml
+++ b/.github/workflows/infra-regression.yml
@@ -1,0 +1,79 @@
+name: INFRA Regression Tests
+
+# AC3：INFRA 回歸測試可在 CI pipeline 中自動執行
+# 關聯 Story：#495（INFRA 回歸測試案例實作）
+# 父 Story：#452（INFRA 自動化回歸測試框架）
+#
+# 觸發時機：
+#   - PR 合併至 main 時（自動回歸）
+#   - 手動觸發（workflow_dispatch）
+#   - push 至 main（保護主分支）
+#
+# 執行內容：
+#   - tests/test-infra-regression.sh（INFRA 回歸測試套件）
+#   - scripts/validate-ci-versions.sh（CI Actions 版本釘定驗證）
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - "scripts/ci-health-check.sh"
+      - "scripts/validate-ci-versions.sh"
+      - "tests/test-infra-regression.sh"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - "scripts/ci-health-check.sh"
+      - "scripts/validate-ci-versions.sh"
+      - "tests/test-infra-regression.sh"
+  workflow_dispatch:
+    inputs:
+      infra_test_level:
+        description: "測試層級（smoke / unit / integration / all）"
+        required: false
+        default: "all"
+        type: choice
+        options:
+          - all
+          - smoke
+          - unit
+          - integration
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  infra-regression:
+    name: "INFRA Regression Tests"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    env:
+      # 安全：choice input 透過 env 傳遞，避免直接插值至 run: 指令
+      INPUT_TEST_LEVEL: ${{ inputs.infra_test_level || 'all' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install unzip（確保測試環境具備 unzip — #442 回歸驗證前置）
+        run: |
+          if ! command -v unzip > /dev/null 2>&1; then
+            sudo apt-get install -y unzip
+          fi
+
+      - name: Run INFRA regression tests
+        run: |
+          INFRA_TEST_LEVEL="${INPUT_TEST_LEVEL}" bash tests/test-infra-regression.sh
+        env:
+          CI: "true"
+
+      - name: Run CI Actions version validation（#424 釘定規範驗證）
+        run: bash scripts/validate-ci-versions.sh

--- a/tests/test-infra-regression.sh
+++ b/tests/test-infra-regression.sh
@@ -181,7 +181,7 @@ assert_output_contains() {
 
 # ── 測試套件開始 ──────────────────────────────────────────────────────────────
 
-echo "=== INFRA Regression Test Suite（#494）==="
+echo "=== INFRA Regression Test Suite（#494/#495）==="
 echo "  REPO_ROOT: ${REPO_ROOT}"
 echo "  INFRA_TEST_LEVEL: ${INFRA_TEST_LEVEL}"
 echo ""
@@ -362,6 +362,224 @@ if should_run "integration"; then
   fi
 else
   skip "I-2: GitHub App 安裝驗證（level=integration）"
+fi
+
+echo ""
+
+# ============================================================================
+# [UNIT] U-3：#423 OIDC token exchange 配置驗證（AC2a）
+# 關聯 Story：#423（GitHub App 安裝驗證 / OIDC token exchange）
+# 側重：CI workflow 是否正確配置 id-token 權限（OIDC token exchange 前置條件）
+# ============================================================================
+
+echo "--- [UNIT] U-3：#423 OIDC token exchange 配置驗證 ---"
+
+if should_run "unit"; then
+  INTAKE_WORKFLOW="${REPO_ROOT}/.github/workflows/new-issue-intake.yml"
+
+  if [[ -f "${INTAKE_WORKFLOW}" ]]; then
+    # AC2a：OIDC token exchange 需要 id-token: write 權限
+    assert_contains "${INTAKE_WORKFLOW}" \
+      "id-token.*write|id-token:.*write" \
+      "U-3a: new-issue-intake.yml 含 id-token: write 權限（OIDC 前置條件）" \
+      "#423" \
+      "在 new-issue-intake.yml 的 permissions 區塊加入 id-token: write，以啟用 OIDC token exchange"
+
+    # AC2a：workflow 包含 claude-code-action（OIDC token 消費方）
+    assert_contains "${INTAKE_WORKFLOW}" \
+      "anthropics/claude-code-action|claude.*oauth.*token|CLAUDE_CODE_OAUTH_TOKEN" \
+      "U-3b: new-issue-intake.yml 包含 Claude OAuth token 使用步驟" \
+      "#423" \
+      "確認 new-issue-intake.yml 中 claude-code-action 步驟仍使用 CLAUDE_CODE_OAUTH_TOKEN"
+
+    # AC2a：permissions 區塊存在（防止意外移除整段 permissions）
+    assert_contains "${INTAKE_WORKFLOW}" \
+      "^[[:space:]]*permissions:" \
+      "U-3c: new-issue-intake.yml 含 permissions 區塊（最小權限原則）" \
+      "#423" \
+      "確認 new-issue-intake.yml 保有明確的 permissions 區塊，避免預設 permissions 過寬"
+  else
+    skip "U-3: new-issue-intake.yml 不存在，跳過 OIDC 配置驗證"
+  fi
+else
+  skip "U-3: OIDC token exchange 配置（level=unit）"
+fi
+
+echo ""
+
+# ============================================================================
+# [UNIT] U-4：#442 unzip 修復深度回歸驗證（AC2b）
+# 關聯 Story：#442（unzip 可用性修復）
+# 側重：回歸驗證 — 確認修復後的 idempotent 安裝邏輯未退化
+# 與 test-442-ci-unzip-fix.sh 區分：本測試著重「修復後的行為結構是否保持正確」
+# ============================================================================
+
+echo "--- [UNIT] U-4：#442 unzip 修復深度回歸驗證 ---"
+
+if should_run "unit"; then
+  INTAKE_WORKFLOW="${REPO_ROOT}/.github/workflows/new-issue-intake.yml"
+
+  if [[ -f "${INTAKE_WORKFLOW}" ]]; then
+    # AC2b：冪等安裝：先檢查 unzip 是否存在，再決定是否安裝
+    assert_contains "${INTAKE_WORKFLOW}" \
+      "command -v unzip|which unzip" \
+      "U-4a: CI workflow unzip 安裝步驟包含冪等檢查（command -v unzip）" \
+      "#442" \
+      "確認 new-issue-intake.yml 中 unzip 安裝前有 'if ! command -v unzip' 冪等判斷，防止每次都重新安裝"
+
+    # AC2b：使用 apt-get 安裝（不依賴外部下載站台）
+    assert_contains "${INTAKE_WORKFLOW}" \
+      "apt-get install.*-y.*unzip|apt-get install.*unzip.*-y" \
+      "U-4b: CI workflow 使用 apt-get install -y unzip（非外部依賴）" \
+      "#442" \
+      "確認 new-issue-intake.yml 使用 'apt-get install -y unzip'，不依賴 busybox.net 或其他外部站台"
+
+    # AC2b：確認沒有 sudo -n（#464 修復後的退化檢查）
+    # #464 曾引入 sudo -n 導致靜默失敗，本測試確保此退化不再出現
+    # 注意：僅檢查非註解行（排除 # 開頭的說明行）
+    if grep -vE "^[[:space:]]*#" "${INTAKE_WORKFLOW}" 2>/dev/null | grep -qE "sudo[[:space:]]+-n[[:space:]]"; then
+      fail "U-4c: CI workflow 不含 sudo -n（已知靜默失敗根因）" \
+        "發現 sudo -n 用法（非註解行），此為 #464 引入的已知靜默失敗根因，#442/#472 已修復" \
+        "#442" \
+        "移除 workflow 中的 sudo -n，改用 sudo apt-get install -y unzip（無 -n flag）"
+    else
+      pass "U-4c: CI workflow 不含 sudo -n（已知靜默失敗根因）"
+    fi
+  else
+    skip "U-4: new-issue-intake.yml 不存在，跳過 unzip 深度回歸驗證"
+  fi
+else
+  skip "U-4: unzip 修復深度回歸（level=unit）"
+fi
+
+echo ""
+
+# ============================================================================
+# [INTEGRATION] I-3：#424 validate-ci-versions.sh 實際執行驗證（AC2c）
+# 關聯 Story：#424（Node.js 20 遷移 / CI Actions 版本釘定）
+# 側重：結合現有 validate-ci-versions.sh，驗證 CI Actions 版本符合釘定規範
+# ============================================================================
+
+echo "--- [INTEGRATION] I-3：#424 CI Actions 版本釘定實際執行驗證 ---"
+
+if should_run "integration"; then
+  VALIDATE_CI="${REPO_ROOT}/scripts/validate-ci-versions.sh"
+
+  if [[ -f "${VALIDATE_CI}" ]]; then
+    # AC2c：實際執行 validate-ci-versions.sh，驗證目前 workflows 均符合版本規範
+    VALIDATE_OUTPUT=$(CI_VERSIONS_REPO_ROOT="${REPO_ROOT}" bash "${VALIDATE_CI}" 2>&1)
+    VALIDATE_EXIT=$?
+
+    if [[ $VALIDATE_EXIT -eq 0 ]]; then
+      pass "I-3a: validate-ci-versions.sh 執行通過（所有 Actions 版本符合規範）"
+    else
+      fail "I-3a: validate-ci-versions.sh 執行失敗（發現不符合規範的 Actions 版本）" \
+        "validate-ci-versions.sh 回傳非零 exit code（${VALIDATE_EXIT}）" \
+        "#424" \
+        "執行 bash scripts/validate-ci-versions.sh 查看詳細報告，並依 CLAUDE.md 第 10 條更新 Actions 版本至允許清單版本"
+    fi
+
+    # AC2c：輸出包含 PASS 字串（確認腳本輸出格式穩定）
+    assert_output_contains "${VALIDATE_OUTPUT}" \
+      "PASS|結果：PASS" \
+      "I-3b: validate-ci-versions.sh 輸出包含 PASS 結果字串" \
+      "#424" \
+      "確認 validate-ci-versions.sh 在版本合規時輸出 PASS 狀態，格式未被改動"
+
+    # AC2c：確認至少掃描到 3 個 workflow 檔案（防止 workflows 目錄被清空的回歸）
+    assert_output_contains "${VALIDATE_OUTPUT}" \
+      "e2e\.yml|new-issue-intake\.yml|sprint-dispatch\.yml" \
+      "I-3c: validate-ci-versions.sh 掃描到預期的 workflow 檔案" \
+      "#424" \
+      "確認 .github/workflows/ 中的三個核心 workflow 檔案均存在且被掃描"
+  else
+    skip "I-3: validate-ci-versions.sh 不存在，跳過版本釘定執行驗證"
+  fi
+else
+  skip "I-3: CI Actions 版本釘定實際執行（level=integration）"
+fi
+
+echo ""
+
+# ============================================================================
+# [INTEGRATION] I-4：#423 GitHub App 安裝 — OIDC token 端對端結構驗證（AC2a）
+# 關聯 Story：#423（GitHub App 安裝驗證 / OIDC token exchange）
+# 側重：ci-health-check.sh 中 GitHub App 偵測邏輯的完整端對端結構
+# ============================================================================
+
+echo "--- [INTEGRATION] I-4：#423 OIDC token 端對端結構驗證 ---"
+
+if should_run "integration"; then
+  HEALTH_SCRIPT="${REPO_ROOT}/scripts/ci-health-check.sh"
+
+  if [[ -f "${HEALTH_SCRIPT}" ]]; then
+    # AC2a：健康檢查腳本呼叫 GitHub API installation endpoint
+    assert_contains "${HEALTH_SCRIPT}" \
+      "repos/.*installation|/installation" \
+      "I-4a: ci-health-check.sh 使用 /repos/{owner}/{repo}/installation API endpoint" \
+      "#423" \
+      "確認 ci-health-check.sh 呼叫 GitHub API '/repos/\$repo_slug/installation' 偵測 App 安裝狀態"
+
+    # AC2a：健康檢查腳本能辨識 404（App 未安裝）vs 401/403（認證問題）
+    assert_contains "${HEALTH_SCRIPT}" \
+      "404|Not Found" \
+      "I-4b: ci-health-check.sh 能辨識 404（GitHub App 未安裝）" \
+      "#423" \
+      "確認 ci-health-check.sh 對 GitHub API 404 回應有明確處理（App 未安裝）"
+
+    assert_contains "${HEALTH_SCRIPT}" \
+      "401|403|Unauthorized|Forbidden" \
+      "I-4c: ci-health-check.sh 能辨識 401/403（認證不足）" \
+      "#423" \
+      "確認 ci-health-check.sh 對 GitHub API 401/403 回應有明確處理（認證問題與安裝問題區分）"
+  else
+    skip "I-4: ci-health-check.sh 不存在，跳過 OIDC 端對端結構驗證"
+  fi
+else
+  skip "I-4: OIDC token 端對端結構（level=integration）"
+fi
+
+echo ""
+
+# ============================================================================
+# [SMOKE] S-3：AC3 CI pipeline 整合驗證（#495 AC3）
+# 關聯 Story：#495（INFRA 回歸測試案例實作與 CI 整合）
+# 側重：確認 INFRA 回歸測試有對應的 GitHub Actions workflow，可被 CI 觸發
+# ============================================================================
+
+echo "--- [SMOKE] S-3：AC3 CI pipeline 整合驗證 ---"
+
+if should_run "smoke"; then
+  INFRA_CI_WORKFLOW="${REPO_ROOT}/.github/workflows/infra-regression.yml"
+
+  assert_file_exists "${INFRA_CI_WORKFLOW}" \
+    "S-3a: .github/workflows/infra-regression.yml 存在（AC3 CI 整合）" \
+    "#495"
+
+  if [[ -f "${INFRA_CI_WORKFLOW}" ]]; then
+    # 確認 CI workflow 觸發 INFRA regression 測試
+    assert_contains "${INFRA_CI_WORKFLOW}" \
+      "test-infra-regression\.sh" \
+      "S-3b: CI workflow 包含 test-infra-regression.sh 執行步驟" \
+      "#495" \
+      "確認 infra-regression.yml 中包含執行 tests/test-infra-regression.sh 的步驟"
+
+    # 確認 CI workflow 有 push/pull_request 觸發（自動回歸）
+    assert_contains "${INFRA_CI_WORKFLOW}" \
+      "pull_request|push" \
+      "S-3c: CI workflow 包含 push/pull_request 自動觸發條件" \
+      "#495" \
+      "確認 infra-regression.yml 在 push 或 pull_request 時自動觸發，實現持續回歸"
+
+    # 確認 CI workflow 使用 @v4 Actions（版本釘定）
+    assert_contains "${INFRA_CI_WORKFLOW}" \
+      "actions/checkout@v4" \
+      "S-3d: CI workflow Actions 版本符合釘定規範（actions/checkout@v4）" \
+      "#424" \
+      "確認 infra-regression.yml 使用 actions/checkout@v4（CLAUDE.md 第 10 條）"
+  fi
+else
+  skip "S-3: CI pipeline 整合驗證（level=smoke）"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- 擴充 `tests/test-infra-regression.sh`：20 → 36 個測試案例，覆蓋 Sprint 122 三個 INFRA Stories 的具體回歸場景
- 新增 `.github/workflows/infra-regression.yml`（AC3 CI pipeline 整合）

## AC 對應

| AC | 實作 | 測試 |
|----|------|------|
| AC2a (#423 OIDC) | `id-token: write` 已在 new-issue-intake.yml | U-3 (3), I-4 (3) |
| AC2b (#442 unzip) | 冪等安裝邏輯、無 sudo -n | U-4 (3) |
| AC2c (#424 版本釘定) | validate-ci-versions.sh 實際執行 | I-3 (3) |
| AC3 (CI pipeline) | infra-regression.yml 新增 | S-3 (4) |

## 新增測試案例

- **U-3** (#423 OIDC): id-token:write 權限、permissions 區塊、CLAUDE_CODE_OAUTH_TOKEN
- **U-4** (#442 unzip): 冪等安裝 (command -v unzip)、apt-get install -y、sudo -n 退化偵測
- **I-3** (#424 版本釘定): validate-ci-versions.sh 執行通過、輸出格式、workflow 檔案掃描
- **I-4** (#423 OIDC 端對端): API endpoint 結構、404/401 辨識能力
- **S-3** (CI 整合): infra-regression.yml 存在、觸發條件、Actions 版本合規

## Team Debate

Round 1 Verdict: **PASS** — Critic 無 HIGH severity issues。批判報告：`.claude/debate/critique-round-1.md`

## Test plan

- [x] `bash tests/test-infra-regression.sh` — 36 PASS, 0 FAIL
- [x] `bash scripts/validate-ci-versions.sh` — PASS（infra-regression.yml 使用 checkout@v4 合規）
- [x] `bash scripts/validate-skills.sh` — 29/29 PASS

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)