### PR TITLE
feat: Worktree 自動清理 — 殘留 worktree 偵測與回收機制 (#500)

### DIFF
--- a/hooks/session-end-release.sh
+++ b/hooks/session-end-release.sh
@@ -200,6 +200,15 @@ printf '{"session_id":"%s","role":"%s","event":"%s","timestamp":"%s","repo":"%s"
 
 echo "[ATTENDANCE] checkout 紀錄已寫入：$ATTEND_JSONL"
 
+# ── Issue #500：Worktree 自動清理 ──────────────────────────────────────
+# SessionEnd 後自動清理殘留 worktree（不阻塞主流程）
+WORKTREE_CLEANUP_SCRIPT="${SCRIPT_DIR}/worktree-cleanup.sh"
+if [[ -x "$WORKTREE_CLEANUP_SCRIPT" ]]; then
+  bash "$WORKTREE_CLEANUP_SCRIPT" 2>/dev/null || true
+else
+  echo "[WARN] worktree-cleanup.sh 不存在或不可執行，跳過 worktree 清理"
+fi
+
 # ── US-321：Cruise Mode flag file cleanup ────────────────────────────────
 # 清除本 session 的 cruise flag file 與 shoot flag file（若存在）
 CRUISE_FLAG="/tmp/shikigami-cruise-${SESSION_ID}.active"

--- a/hooks/worktree-cleanup.sh
+++ b/hooks/worktree-cleanup.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# hooks/worktree-cleanup.sh
+# Issue #500 — SessionEnd / Sprint Review 後自動清理殘留 worktree
+#
+# 功能：
+#   - 掃描 .claude/worktrees/ 目錄，找出所有殘留 worktree
+#   - 檢查每個 worktree 是否有活躍進程（NFR1：不刪執行中的 subagent）
+#   - 執行 git worktree remove 清理已完成的 worktree
+#   - 輸出清理結果（清除數量、釋放磁碟空間）
+#
+# 環境變數：
+#   DRY_RUN=1   — 只掃描不刪除，輸出預計清理的 worktree 列表
+#
+# 輸出標記：
+#   [WORKTREE-CLEANUP] 清除 N 個殘留 worktree，釋放 X MB
+#   [WORKTREE-CLEANUP-SKIP] <path> — 仍有活躍進程，跳過
+#   [WORKTREE-CLEANUP-DRY] <path> — dry-run 模式，不實際刪除
+#   [WARN] <原因>
+#
+# NFR1: 清理前確認 worktree 無活躍進程
+# NFR2: 失敗不阻塞主流程（set +e）
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORKTREE_DIR="${REPO_ROOT}/.claude/worktrees"
+
+DRY_RUN="${DRY_RUN:-0}"
+
+# ── 確認 worktree 目錄存在 ───────────────────────────────────────────
+if [[ ! -d "$WORKTREE_DIR" ]]; then
+  echo "[WORKTREE-CLEANUP] .claude/worktrees/ 不存在，無需清理"
+  exit 0
+fi
+
+# ── 取得已登記的 git worktree 列表（所有 worktree 路徑）────────────────
+REGISTERED_WORKTREES=$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null \
+  | grep '^worktree ' | awk '{print $2}' || echo "")
+
+# ── 掃描 .claude/worktrees/ 子目錄 ────────────────────────────────────
+REMOVED=0
+SKIPPED=0
+TOTAL_FREED_KB=0
+
+shopt -s nullglob
+WORKTREE_PATHS=("${WORKTREE_DIR}"/*)
+shopt -u nullglob
+
+if [[ ${#WORKTREE_PATHS[@]} -eq 0 ]]; then
+  echo "[WORKTREE-CLEANUP] .claude/worktrees/ 無殘留目錄，跳過清理"
+  exit 0
+fi
+
+for WT_PATH in "${WORKTREE_PATHS[@]}"; do
+  [[ -d "$WT_PATH" ]] || continue
+
+  WT_NAME="$(basename "$WT_PATH")"
+
+  # ── NFR1：檢查是否有活躍進程使用此目錄 ─────────────────────────────
+  ACTIVE_PROCS=""
+  if command -v lsof &>/dev/null; then
+    ACTIVE_PROCS=$(lsof +D "$WT_PATH" 2>/dev/null | grep -v "^COMMAND" | head -1 || echo "")
+  elif command -v fuser &>/dev/null; then
+    ACTIVE_PROCS=$(fuser -c "$WT_PATH" 2>/dev/null || echo "")
+  else
+    # fallback：用 /proc 檢查開啟的文件描述符（Linux only）
+    ACTIVE_PROCS=$(ls /proc/*/cwd 2>/dev/null \
+      | xargs -I{} readlink {} 2>/dev/null \
+      | grep -F "$WT_PATH" | head -1 || echo "")
+  fi
+
+  if [[ -n "$ACTIVE_PROCS" ]]; then
+    echo "[WORKTREE-CLEANUP-SKIP] ${WT_NAME} — 仍有活躍進程，跳過（running）"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # ── 計算目錄磁碟佔用 ──────────────────────────────────────────────
+  DIR_SIZE_KB=$(du -sk "$WT_PATH" 2>/dev/null | awk '{print $1}' || echo "0")
+
+  # ── DRY_RUN 模式：只報告不刪除 ────────────────────────────────────
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "[WORKTREE-CLEANUP-DRY] ${WT_NAME} — 預計清除（${DIR_SIZE_KB} KB）"
+    REMOVED=$((REMOVED + 1))
+    TOTAL_FREED_KB=$((TOTAL_FREED_KB + DIR_SIZE_KB))
+    continue
+  fi
+
+  # ── 實際清理：優先用 git worktree remove ──────────────────────────
+  REMOVE_OK=false
+
+  # 確認此路徑是已登記的 git worktree
+  if echo "$REGISTERED_WORKTREES" | grep -qF "$WT_PATH"; then
+    git -C "$REPO_ROOT" worktree remove --force "$WT_PATH" 2>/dev/null
+    if [[ $? -eq 0 ]]; then
+      REMOVE_OK=true
+    fi
+  fi
+
+  # 若 git worktree remove 失敗（或不在 worktree 列表），直接刪目錄
+  if [[ "$REMOVE_OK" == "false" ]]; then
+    rm -rf "$WT_PATH" 2>/dev/null
+    if [[ $? -eq 0 ]]; then
+      REMOVE_OK=true
+    else
+      echo "[WARN] ${WT_NAME} 清除失敗，孤兒目錄可能殘留"
+    fi
+  fi
+
+  if [[ "$REMOVE_OK" == "true" ]]; then
+    REMOVED=$((REMOVED + 1))
+    TOTAL_FREED_KB=$((TOTAL_FREED_KB + DIR_SIZE_KB))
+  fi
+
+done
+
+# ── 計算釋放 MB（四捨五入）──────────────────────────────────────────
+FREED_MB=$(( (TOTAL_FREED_KB + 512) / 1024 ))
+
+# ── 輸出最終摘要 ───────────────────────────────────────────────────
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "[WORKTREE-CLEANUP] dry-run：預計清除 ${REMOVED} 個殘留 worktree，可釋放 ${FREED_MB} MB"
+else
+  echo "[WORKTREE-CLEANUP] 清除 ${REMOVED} 個殘留 worktree，釋放 ${FREED_MB} MB"
+fi
+
+if [[ $SKIPPED -gt 0 ]]; then
+  echo "[WORKTREE-CLEANUP] 跳過 ${SKIPPED} 個仍在執行中的 worktree（active）"
+fi
+
+exit 0

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -25,6 +25,7 @@ Health Check 是框架的自我診斷工具。一鍵掃描 Shikigami 的核心�
 | 4. CI 最新狀態 | PASS / FAIL / WARN |
 | 5. Retro Action Items 逾期偵測 | PASS / OVERDUE |
 | 6. 知識新鮮度檢查 | PASS / WARN / FAIL |
+| 7. Worktree 殘留偵測（#500） | PASS / WARN |
 
 ---
 
@@ -44,6 +45,7 @@ Health Check 是框架的自我診斷工具。一鍵掃描 Shikigami 的核心�
 ### 4. CI 最新狀態 — {PASS / FAIL / WARN}
 ### 5. Retro Action Items — {PASS / OVERDUE}
 ### 6. 知識新鮮度 — {PASS / WARN / FAIL}
+### 7. Worktree 殘留偵測 — {PASS / WARN}
 ```
 
 ### Overall Status 判定規則
@@ -63,7 +65,7 @@ Health Check 是框架的自我診斷工具。一鍵掃描 Shikigami 的核心�
 ### 4.1 正常執行流程
 
 1. 主 session 派遣一個 **Health Check Subagent**，並提供以下指令：
-   - 依序執行 [`references/diagnostic-rules.md`](references/diagnostic-rules.md) 定義的 6 項診斷檢查
+   - 依序執行 [`references/diagnostic-rules.md`](references/diagnostic-rules.md) 定義的 7 項診斷檢查（含第 7 項：Worktree 殘留偵測）
    - 使用 Read、Glob、Grep 工具讀取所有必要文件；執行 `gh run list` 取得 CI 狀態
    - 依照 §3 定義的格式產出完整報告字串
 2. Subagent 完成後，將完整報告字串回傳給主 session

--- a/skills/health-check/references/diagnostic-rules.md
+++ b/skills/health-check/references/diagnostic-rules.md
@@ -142,3 +142,29 @@
 | PASS | 無影響 |
 | WARN（STALE） | 升格為 WARNING（若原為 HEALTHY） |
 | FAIL（EXPIRED） | 升格為 CRITICAL |
+
+---
+
+## 檢查 7：Worktree 殘留偵測（#500）
+
+<!-- Issue #500 Worktree 自動清理 — Sprint 129 -->
+
+掃描 `.claude/worktrees/` 目錄，偵測殘留 worktree 數量與磁碟佔用。
+
+**執行方式**：執行 `bash hooks/worktree-cleanup.sh DRY_RUN=1` 或直接掃描目錄。
+
+**判定規則**：
+
+| 狀態 | 條件 |
+|------|------|
+| PASS | `.claude/worktrees/` 目錄不存在，或目錄下無任何子目錄 |
+| WARN | 發現 1 個以上殘留 worktree 子目錄（列出數量與估計磁碟佔用） |
+
+**WARN 時的修復建議**：「發現 {N} 個殘留 worktree（估計 {X} MB）。可執行 `bash hooks/worktree-cleanup.sh` 自動清理，或手動執行 `git worktree remove --force <path>`。」
+
+**對 Overall Status 的影響：**
+
+| 偵測結果 | Overall Status 影響 |
+|---------|-------------------|
+| PASS | 無影響 |
+| WARN（有殘留） | 升格為 WARNING（若原為 HEALTHY） |

--- a/tests/test-500-worktree-cleanup.sh
+++ b/tests/test-500-worktree-cleanup.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# tests/test-500-worktree-cleanup.sh
+# Issue #500 — 驗證 Worktree 自動清理機制
+#
+# AC1: health-check skill 新增 worktree 偵測段落（第 7 項檢查）
+# AC2: hooks/worktree-cleanup.sh 存在且可執行（SessionEnd 清理腳本）
+# AC3: worktree-cleanup.sh 清理前檢查活躍進程（NFR1：不刪執行中 worktree）
+# AC4: worktree-cleanup.sh 輸出 [WORKTREE-CLEANUP] 格式訊息
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HEALTH_CHECK_SKILL="${REPO_ROOT}/skills/health-check/SKILL.md"
+DIAGNOSTIC_RULES="${REPO_ROOT}/skills/health-check/references/diagnostic-rules.md"
+CLEANUP_SCRIPT="${REPO_ROOT}/hooks/worktree-cleanup.sh"
+SESSION_END_SCRIPT="${REPO_ROOT}/hooks/session-end-release.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if grep -qE "$pattern" "$file" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label (pattern='${pattern}' not found in $file)"
+  fi
+}
+
+# ── AC1: health-check skill 新增 worktree 偵測 ─────────────────────────
+echo "=== AC1: health-check skill 含 worktree 偵測 ==="
+
+assert_contains "$HEALTH_CHECK_SKILL" \
+  'worktree|Worktree' \
+  "AC1a: SKILL.md 含 worktree 相關說明"
+
+assert_contains "$HEALTH_CHECK_SKILL" \
+  '7\.|檢查 7|第 7|\.claude/worktrees' \
+  "AC1b: SKILL.md 含第 7 項檢查（worktree 偵測）"
+
+assert_contains "$DIAGNOSTIC_RULES" \
+  'worktree|Worktree' \
+  "AC1c: diagnostic-rules.md 含 worktree 偵測規則"
+
+assert_contains "$DIAGNOSTIC_RULES" \
+  '\.claude/worktrees' \
+  "AC1d: diagnostic-rules.md 說明掃描 .claude/worktrees/ 目錄"
+
+# ── AC2: hooks/worktree-cleanup.sh 存在且可執行 ────────────────────────
+echo ""
+echo "=== AC2: worktree-cleanup.sh 存在且可執行 ==="
+
+if [[ -f "$CLEANUP_SCRIPT" ]]; then
+  pass "AC2a: worktree-cleanup.sh 存在"
+else
+  fail "AC2a: worktree-cleanup.sh 不存在（路徑：$CLEANUP_SCRIPT）"
+fi
+
+if [[ -x "$CLEANUP_SCRIPT" ]]; then
+  pass "AC2b: worktree-cleanup.sh 可執行"
+else
+  fail "AC2b: worktree-cleanup.sh 不可執行"
+fi
+
+# AC2c: session-end-release.sh 中調用 worktree-cleanup.sh
+assert_contains "$SESSION_END_SCRIPT" \
+  'worktree-cleanup' \
+  "AC2c: session-end-release.sh 調用 worktree-cleanup.sh"
+
+# ── AC3: worktree-cleanup.sh 含活躍進程檢查邏輯 ───────────────────────
+echo ""
+echo "=== AC3: worktree-cleanup.sh 含活躍進程檢查（NFR1）==="
+
+assert_contains "$CLEANUP_SCRIPT" \
+  'lsof|fuser|proc|ps |pgrep' \
+  "AC3a: worktree-cleanup.sh 含進程偵測（lsof/fuser/pgrep）"
+
+assert_contains "$CLEANUP_SCRIPT" \
+  'SKIP|skip|活躍|active|正在執行|running' \
+  "AC3b: worktree-cleanup.sh 含跳過仍在執行的 worktree 邏輯"
+
+# ── AC4: worktree-cleanup.sh 輸出 [WORKTREE-CLEANUP] 格式 ──────────────
+echo ""
+echo "=== AC4: worktree-cleanup.sh 輸出 [WORKTREE-CLEANUP] ==="
+
+assert_contains "$CLEANUP_SCRIPT" \
+  '\[WORKTREE-CLEANUP\]' \
+  "AC4a: worktree-cleanup.sh 含 [WORKTREE-CLEANUP] 輸出標記"
+
+assert_contains "$CLEANUP_SCRIPT" \
+  '清除.*個.*worktree|MB|磁碟' \
+  "AC4b: worktree-cleanup.sh 輸出清除數量與磁碟釋放量"
+
+# ── AC4 執行測試：dry-run 模式不刪任何東西但輸出格式正確 ──────────────
+echo ""
+echo "=== AC4 執行測試（dry-run）==="
+if [[ -x "$CLEANUP_SCRIPT" ]]; then
+  DRY_OUTPUT=$(DRY_RUN=1 bash "$CLEANUP_SCRIPT" 2>&1 || true)
+  if echo "$DRY_OUTPUT" | grep -q '\[WORKTREE-CLEANUP\]'; then
+    pass "AC4c: dry-run 輸出含 [WORKTREE-CLEANUP] 標記"
+  else
+    fail "AC4c: dry-run 輸出未含 [WORKTREE-CLEANUP] 標記（output: ${DRY_OUTPUT:0:200}）"
+  fi
+else
+  fail "AC4c: 無法執行 dry-run（腳本不可執行）"
+fi
+
+# ── NFR2: cleanup 腳本自身不應以非零 exit code 阻塞 ───────────────────
+echo ""
+echo "=== NFR2: 清理失敗不阻塞主流程 ==="
+assert_contains "$CLEANUP_SCRIPT" \
+  'set \+e|\|\| true' \
+  "NFR2: worktree-cleanup.sh 含 set +e 或 || true（失敗不阻塞）"
+
+# ── 結果摘要 ───────────────────────────────────────────────────────────
+echo ""
+echo "=== 測試結果 ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [[ $FAIL -eq 0 ]]; then
+  echo "總結：#500 Worktree 自動清理機制驗證全部通過"
+  exit 0
+else
+  echo "總結：發現 $FAIL 個 FAIL，請修正後再 commit"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **AC1**: `skills/health-check/SKILL.md` 與 `references/diagnostic-rules.md` 新增第 7 項檢查「Worktree 殘留偵測」，掃描 `.claude/worktrees/`，發現殘留時 WARN + 修復建議
- **AC2**: 新增 `hooks/worktree-cleanup.sh`，`session-end-release.sh` SessionEnd 時自動調用清理
- **AC3**: 清理前以 `lsof`/`fuser`/`/proc` 確認無活躍進程，仍在執行的 worktree 輸出 `[WORKTREE-CLEANUP-SKIP]` 並跳過（NFR1）
- **AC4**: 輸出 `[WORKTREE-CLEANUP] 清除 N 個殘留 worktree，釋放 X MB`；支援 `DRY_RUN=1` 模式（NFR2：set +e 失敗不阻塞）

## Test plan

- [x] `bash tests/test-500-worktree-cleanup.sh` — 13/13 PASS（AC1-AC4 + NFR1/NFR2 全覆蓋）
- [x] `bash scripts/validate-skills.sh` — 29 個 Skill 驗證通過
- [x] `bash scripts/validate-json.sh` — JSON Schema 驗證通過
- [x] `bash scripts/validate-version.sh` — 版號一致性通過
- [x] `DRY_RUN=1 bash hooks/worktree-cleanup.sh` — dry-run 輸出 `[WORKTREE-CLEANUP]` 格式正確

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)