### PR TITLE
feat: #536 平行 subagent OOM 防護（SHIKIGAMI_MAX_PARALLEL 預設 2）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@
    - `project_level=high`：每個重要步驟都必須等人確認，只標記不自動觸發。
 10. **CI Actions 版本釘定**：所有 GitHub Actions 統一使用 `@v4`，升級需先確認 self-hosted runner 相容性，並經人工審核後才能更新版本號。新增或修改 workflow 時執行 `bash scripts/validate-ci-versions.sh` 驗證。
 11. **GitHub URL 可讀取**：遇到 GitHub URL（含 attachment），帶 `gh auth token` 認證直接讀取，不要報「無法讀取」。
+12. **平行 Worktree OOM 防護**：平行 worktree subagent 過多會 OOM（Sprint 127 歷史案例：4 個 worktree 觸發 core dump）。`SHIKIGAMI_MAX_PARALLEL` 預設 2，**未設定時亦視為 2，不得無限平行**。派遣前必須執行 `git worktree list` 計算現存數量；重派前必須確認同任務 agent 是否還在跑，避免重複派遣。詳見 `skills/sprint-execution/references/parallel-safety.md`。
 
 ## 目錄結構
 

--- a/skills/cruise/references/auto-shoot.md
+++ b/skills/cruise/references/auto-shoot.md
@@ -17,8 +17,19 @@ for ISSUE in CLOSE_ISSUES:
 
 # Step 2：連續 auto-shoot（走完整 /shoot 流程）
 while ACTIONABLE_ISSUES is not empty:
+  # OOM 防護：派工前確認現存 worktree 數量（#536 AC2）
+  MAX_PARALLEL=${SHIKIGAMI_MAX_PARALLEL:-2}
+  EXISTING_WT=$(git worktree list | grep -v "bare\|（main branch）" | tail -n +2 | wc -l)
+  if EXISTING_WT >= MAX_PARALLEL:
+    echo "[OOM-WARN] 現存 worktree 已達上限（${EXISTING_WT}/${MAX_PARALLEL}），暫緩本次 auto-shoot"
+    break  # 等待下一 cycle 再試
+
   if SHOOT_FLAG 不存在:
     ISSUE = ACTIONABLE_ISSUES.shift()  # 取出第一個
+    # 重派前確認同 Story 是否已有 worktree 在跑（#536 AC2）
+    if git worktree list | grep -q "sprint-.*${ISSUE}":
+      echo "[OOM-SKIP] Story #${ISSUE} 已有 worktree 執行中，跳過重派"
+      continue
     echo "$ISSUE" > SHOOT_FLAG
     # !! 必須 invoke shikigami:shoot，不是派 Developer Agent !!
     # 更新對應 Story Task 狀態為 in-progress（#513 AC3）

--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -42,7 +42,7 @@ Sprint 執行支援**雙軌派遣機制**：由環境變數 `SHIKIGAMI_MODEL_PRO
 <!-- US-255 SHIKIGAMI_MAX_PARALLEL 平行數量上限控制 — Sprint 93 -->
 
 <HARD-GATE>
-**平行 Story-Lifecycle subagent 禁止直接修改 `docs/PROJECT_BOARD.md` 和 `docs/sprints/sprint_N.md`**（競態條件防護）。所有平行 subagent 完成後，主 session 統一批次更新。`SHIKIGAMI_MAX_PARALLEL` 環境變數控制最大平行數量。Git Worktree 隔離（`isolation: "worktree"`）消除大部分並發衝突。
+**平行 Story-Lifecycle subagent 禁止直接修改 `docs/PROJECT_BOARD.md` 和 `docs/sprints/sprint_N.md`**（競態條件防護）。所有平行 subagent 完成後，主 session 統一批次更新。`SHIKIGAMI_MAX_PARALLEL` 環境變數控制最大平行數量（**預設值 2**，未設定時視為 2，OOM 防護，#536）。派遣前必須計算現存 worktree 數量，超限時輸出 `[OOM-WARN]` 並等待釋放（見 `references/parallel-safety.md`）。Git Worktree 隔離（`isolation: "worktree"`）消除大部分並發衝突。
 </HARD-GATE>
 
 > 詳見 `references/parallel-safety.md`

--- a/skills/sprint-execution/references/parallel-safety.md
+++ b/skills/sprint-execution/references/parallel-safety.md
@@ -17,38 +17,66 @@
 ## 平行數量上限控制（SHIKIGAMI_MAX_PARALLEL）
 
 <!-- US-255 低記憶體環境平行 Subagent 數量上限控制 — Sprint 93 -->
+<!-- #536 平行 subagent OOM 防護 — Sprint 129 -->
 
-環境變數 `SHIKIGAMI_MAX_PARALLEL` 控制 Sprint Execution 平行派遣 subagent 的最大數量，用於低記憶體環境避免記憶體不足（swap thrashing）。
+環境變數 `SHIKIGAMI_MAX_PARALLEL` 控制 Sprint Execution 平行派遣 subagent 的最大數量，用於防止記憶體不足（OOM）。
+
+**歷史依據**：Sprint 127 中 4 個 worktree 同時執行觸發 OOM core dump，確認安全上限為 2–3 個。
+
+**預設值**：`SHIKIGAMI_MAX_PARALLEL` 未設定時，**預設視為 2**（不再無限制平行）。
 
 | 環境變數值 | 行為 |
 |-----------|------|
-| 未設定 | 不限制平行數量，維持現有行為（Sprint Planning Architect 決定的批次） |
+| 未設定 | **預設 2**：最多同時 2 個 subagent（OOM 防護預設值） |
 | `1` | 強制循序執行：所有 Story 一個接一個執行，不出現平行派遣 |
 | `N`（N ≥ 2） | 最多同時 N 個 subagent；超出部分排入下一批次依序執行 |
 
-### 上限檢查規則
+### 上限檢查規則（含現存 Worktree 計數）
 
 Sprint Execution **派遣 subagent 前**，主 session 執行以下檢查：
 
 ```
 讀取 SHIKIGAMI_MAX_PARALLEL 環境變數
-  |-- 未設定 → 不限制，依 Architect 分群建議直接平行派遣
+  |-- 未設定 → 使用預設值 2（OOM 防護預設，#536 AC1）
   |-- = 1    → 強制循序：忽略 Architect 平行分群，所有 Story 單一循序執行
   +-- = N（N ≥ 2）
         |
         v
-      取得本批次待派遣 Story 清單（Architect 分群的 Phase 1 Story）
-        |-- 清單數 ≤ N → 全部同批次平行派遣（不超限）
-        +-- 清單數 > N → 拆分批次：
-              批次 1：前 N 個 Story 平行派遣
-              批次 2+：剩餘 Story 等待批次 1 完成後繼續（可再拆）
+      計算現存 worktree 數量（重派前確認）
+        EXISTING_WT=$(git worktree list | grep -v "bare\|main\|master" | wc -l)
+        AVAILABLE_SLOTS=$((N - EXISTING_WT))
+        |
+        |-- AVAILABLE_SLOTS ≤ 0 → [OOM-WARN] 現存 worktree 已達上限（${EXISTING_WT}/${N}），
+        |       等待現有 subagent 完成後再派遣（不阻塞主流程，進入等待循環）
+        +-- AVAILABLE_SLOTS > 0
+              |
+              v
+            取得本批次待派遣 Story 清單（Architect 分群的 Phase 1 Story）
+              |-- 清單數 ≤ AVAILABLE_SLOTS → 全部同批次平行派遣
+              +-- 清單數 > AVAILABLE_SLOTS → 拆分批次：
+                    批次 1：前 AVAILABLE_SLOTS 個 Story 平行派遣
+                    批次 2+：剩餘 Story 等待批次 1 完成後繼續（可再拆）
+```
+
+### Cruise Auto-Shoot 同任務防護
+
+Cruise Auto-Shoot 派工前，必須先確認同任務 subagent 是否還在跑（重派前確認）：
+
+```
+取得現存 worktree 清單
+  RUNNING_WT=$(git worktree list --porcelain | grep "branch" | grep "sprint-")
+  |-- 若 story_id 對應的 branch 已存在於 worktree → [OOM-SKIP] 跳過重派（同 Story 已有 agent 執行中）
+  |-- 現存 worktree 總數 ≥ MAX_PARALLEL → [OOM-WARN] 輸出告警，暫緩本次 auto-shoot
+  +-- 現存 worktree 數 < MAX_PARALLEL → 繼續派遣
 ```
 
 ### 輸出格式
 
 ```
-[MAX-PARALLEL] SHIKIGAMI_MAX_PARALLEL={N}，本次派遣批次數={B}，每批最多 {N} 個 Story
-[MAX-PARALLEL-SKIP] SHIKIGAMI_MAX_PARALLEL 未設定，不限制平行數量
+[MAX-PARALLEL] SHIKIGAMI_MAX_PARALLEL={N}，現存 worktree={E}，可用槽={S}，本次派遣批次數={B}
+[MAX-PARALLEL-DEFAULT] SHIKIGAMI_MAX_PARALLEL 未設定，使用預設值 2（OOM 防護）
+[OOM-WARN] 現存 worktree 已達上限（{E}/{N}），等待釋放後繼續
+[OOM-SKIP] Story #{id} 已有 worktree 執行中，跳過重派
 ```
 
 ## Git Worktree 隔離（#379）


### PR DESCRIPTION
## Summary

- **AC1**: 定義明確平行 worktree 上限 — `SHIKIGAMI_MAX_PARALLEL` 預設值設為 **2**（依據：Sprint 127 實測 4 worktree 觸發 OOM core dump，2-3 為安全範圍）。未設定時不再無限制平行。
- **AC2**: 超限告警與阻擋 — 派遣前計算現存 worktree 數量，超限輸出 `[OOM-WARN]` 並等待；重派前確認同 Story 是否已有 agent 執行中，輸出 `[OOM-SKIP]` 跳過重派。
- **AC3**: 文件化至 CLAUDE.md 開發紅線（#12）與 Sprint Execution / Cruise 相關 Skill 文件。

## Changed Files

- `CLAUDE.md` — 新增紅線 #12：平行 Worktree OOM 防護
- `skills/sprint-execution/references/parallel-safety.md` — 更新預設值、加入 worktree 計數邏輯與輸出格式
- `skills/sprint-execution/SKILL.md` — §2.2 HARD-GATE 補充預設值與 [OOM-WARN] 說明
- `skills/cruise/references/auto-shoot.md` — auto-shoot 派工前加 OOM 防護檢查

## Test Plan

- [x] `bash scripts/validate-skills.sh` — 29/29 PASS
- [x] 確認 CLAUDE.md 紅線編號連續無跳號（#12 緊接 #11）
- [x] 確認 parallel-safety.md 的預設值表格與上限檢查邏輯一致

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)