### PR TITLE
feat: #537 重複派遣防護 Gate（worktree 唯一性檢查）

### DIFF
--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -40,9 +40,10 @@ Sprint 執行支援**雙軌派遣機制**：由環境變數 `SHIKIGAMI_MODEL_PRO
 
 <!-- US-188 平行 subagent 禁止直接修改共用文件 — Sprint 72 -->
 <!-- US-255 SHIKIGAMI_MAX_PARALLEL 平行數量上限控制 — Sprint 93 -->
+<!-- #537 Worktree 唯一性檢查（重複派遣防護 Gate） — Sprint 129 -->
 
 <HARD-GATE>
-**平行 Story-Lifecycle subagent 禁止直接修改 `docs/PROJECT_BOARD.md` 和 `docs/sprints/sprint_N.md`**（競態條件防護）。所有平行 subagent 完成後，主 session 統一批次更新。`SHIKIGAMI_MAX_PARALLEL` 環境變數控制最大平行數量（**預設值 2**，未設定時視為 2，OOM 防護，#536）。派遣前必須計算現存 worktree 數量，超限時輸出 `[OOM-WARN]` 並等待釋放（見 `references/parallel-safety.md`）。Git Worktree 隔離（`isolation: "worktree"`）消除大部分並發衝突。
+**平行 Story-Lifecycle subagent 禁止直接修改 `docs/PROJECT_BOARD.md` 和 `docs/sprints/sprint_N.md`**（競態條件防護）。所有平行 subagent 完成後，主 session 統一批次更新。`SHIKIGAMI_MAX_PARALLEL` 環境變數控制最大平行數量（**預設值 2**，未設定時視為 2，OOM 防護，#536）。派遣前必須：(1) 執行 **Worktree 唯一性檢查**：以 `git worktree list --porcelain` 確認同 Story ID 的 worktree 不存在，若已存在則輸出 `[DISPATCH-SKIP]` 跳過（#537）；(2) 計算現存 worktree 數量，超限時輸出 `[OOM-WARN]` 並等待釋放（#536）。Git Worktree 隔離（`isolation: "worktree"`）消除大部分並發衝突。
 </HARD-GATE>
 
 > 詳見 `references/parallel-safety.md`
@@ -170,6 +171,13 @@ Sprint Backlog 中取出 Story
   |-- [FE-PRECHECK-SKIP] 非前端 Story --> 繼續執行
   |-- [FE-PRECHECK-PASS] 設計資訊完整 --> 繼續執行
   +-- [FE-PRECHECK-WARN] 設計資訊缺失 --> 輸出告警，標記「需 UIUX 介入」，繼續執行
+  |
+  v
+Worktree 唯一性檢查（§2.2，重複派遣防護，#537）
+  git worktree list --porcelain | grep -E "branch refs/heads/sprint-[0-9]+/${story_id}-"
+  |-- 找到對應 worktree → [DISPATCH-SKIP] 跳過此 Story，取出下一個 Story 繼續
+  |-- git worktree 指令失敗 → 靜默忽略，繼續執行（不阻塞）
+  +-- 未找到 → 繼續 OOM 上限檢查與 Claim 流程
   |
   v
 Claim Story（§2.11，多 Session 並行協調）

--- a/skills/sprint-execution/references/parallel-safety.md
+++ b/skills/sprint-execution/references/parallel-safety.md
@@ -58,6 +58,40 @@ Sprint Execution **派遣 subagent 前**，主 session 執行以下檢查：
                     批次 2+：剩餘 Story 等待批次 1 完成後繼續（可再拆）
 ```
 
+### Worktree 唯一性檢查（#537）
+
+<!-- #537 重複派遣防護 Gate — Sprint 129 -->
+
+Sprint Execution **派遣 Story-Lifecycle subagent 前**，必須執行 worktree 唯一性檢查，防止同一個 Story 被重複派遣：
+
+```
+取得現存 worktree 清單
+  STORY_BRANCH="sprint-*/$(echo ${story_id} | tr '#' '' | tr -d ' ')-*"
+  git worktree list --porcelain | grep "branch" | grep -q "${story_id}"
+  |-- 找到對應 story_id 的 worktree → [DISPATCH-SKIP] 跳過，不重複派遣
+  |     輸出：[DISPATCH-SKIP] Story #{id} 已有 worktree 存在（branch: {branch_name}），跳過重複派遣
+  +-- 未找到 → 繼續後續派遣流程（OOM 上限檢查 → Claim → 派遣）
+```
+
+**重複偵測指令**：
+
+```bash
+# 偵測指定 story_id 是否已有 worktree 執行中
+STORY_ID="537"  # 替換為實際 story_id
+git worktree list --porcelain | grep -E "branch refs/heads/sprint-[0-9]+/${STORY_ID}-"
+# 有輸出 → 重複，輸出 [DISPATCH-SKIP]；無輸出 → 可繼續派遣
+```
+
+**處理規則**：
+
+| 情境 | 行為 |
+|------|------|
+| 偵測到同 Story worktree 存在 | `[DISPATCH-SKIP]` — 自動跳過（不重複派遣），記錄 WARN 日誌 |
+| 未偵測到同 Story worktree | 繼續執行 OOM 上限檢查與後續派遣流程 |
+| `git worktree list` 指令失敗 | 靜默忽略唯一性檢查，繼續派遣（保守策略：不阻塞） |
+
+> **設計意圖**：自動跳過而非要求人工確認，避免在 `project_level=low` 的全自動場景中阻塞流程。若需手動清理殘留 worktree，參見 `references/worktree-cleanup.md`。
+
 ### Cruise Auto-Shoot 同任務防護
 
 Cruise Auto-Shoot 派工前，必須先確認同任務 subagent 是否還在跑（重派前確認）：
@@ -77,6 +111,7 @@ Cruise Auto-Shoot 派工前，必須先確認同任務 subagent 是否還在跑�
 [MAX-PARALLEL-DEFAULT] SHIKIGAMI_MAX_PARALLEL 未設定，使用預設值 2（OOM 防護）
 [OOM-WARN] 現存 worktree 已達上限（{E}/{N}），等待釋放後繼續
 [OOM-SKIP] Story #{id} 已有 worktree 執行中，跳過重派
+[DISPATCH-SKIP] Story #{id} 已有 worktree 存在（branch: {branch_name}），跳過重複派遣
 ```
 
 ## Git Worktree 隔離（#379）


### PR DESCRIPTION
## Summary

- `parallel-safety.md` 新增「Worktree 唯一性檢查（#537）」段落，定義派遣前掃描同 Story ID worktree 的邏輯
- 有存在 → `[DISPATCH-SKIP]` 自動跳過；未找到 → 繼續；指令失敗 → 靜默忽略（保守策略）
- `SKILL.md §2.2` HARD-GATE 說明更新，明確唯一性檢查為必要前置步驟（#537）
- `SKILL.md §3` 執行流程在 Claim Story 前新增唯一性檢查節點

## AC 對照

- [x] AC1: Sprint Execution SKILL.md 加入 worktree 唯一性檢查步驟（§2.2 + §3）
- [x] AC2: 提供明確的重複偵測指令（`git worktree list --porcelain | grep -E "branch refs/heads/sprint-[0-9]+/${STORY_ID}-"`）
- [x] AC3: 重複時的處理規則文件化（`[DISPATCH-SKIP]` 自動跳過；`project_level=low` 全自動不阻塞）

## Test plan

- [x] `bash scripts/validate-skills.sh` 全 29 個 Skill PASS

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)