### PR TITLE
#526 Node.js 20 actions deprecation 修復 — node-version 升至 24 + 偵測增強

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       # ── 3. 安裝 Node.js 依賴 ────────────────────────────────

--- a/scripts/validate-ci-versions.sh
+++ b/scripts/validate-ci-versions.sh
@@ -29,6 +29,17 @@ ALLOWED_ACTIONS=(
 
 # ──────────────────────────────────────────────
 # Node.js 20 廢棄偵測：已知在 Node.js 20 上執行的 action 版本
+# 強制切換日期：2026-06-02（Node.js 24）
+# Node.js 20 移除日期：2026-09-16
+# 追蹤：#526 #424 #337
+#
+# 升級路徑（需人工審核，CLAUDE.md 第 10 條）：
+#   actions/checkout@v4     → @v5（Node.js 24）或 @v6（最新）
+#   actions/setup-node@v4   → @v4 最新（持續更新）+ node-version: "24"
+#   actions/upload-artifact@v4 → @v5（Node.js 24）
+#   actions/download-artifact@v4 → @v5（Node.js 24）
+#   actions/cache@v4        → 待評估
+#   anthropics/claude-code-action@v1 → 持續維護，觀察官方更新
 # ──────────────────────────────────────────────
 NODEJS20_AFFECTED_ACTIONS=(
   "actions/checkout@v4"
@@ -43,6 +54,7 @@ PASS=true
 WARNINGS=()
 ERRORS=()
 AFFECTED_NODES20=()
+NODE_VERSION_WARNINGS=()  # setup-node 使用 node-version: "20" 的偵測（#526）
 
 echo "======================================"
 echo "  CI Actions 版本驗證"
@@ -88,6 +100,14 @@ for wf in "${WORKFLOW_FILES[@]}"; do
       FOUND_ACTIONS["${action_ref}"]="${wf_name}"
     fi
   done < <(grep -E '^\s+(- )?uses:\s+' "${wf}" 2>/dev/null || true)
+
+  # 偵測 setup-node node-version: "20"（#526 Node.js 20 deprecation 追蹤）
+  while IFS= read -r line; do
+    ver=$(echo "${line}" | sed -E "s/.*node-version:\s*['\"]?([0-9]+)['\"]?.*/\1/" | xargs)
+    if [[ "${ver}" == "20" ]]; then
+      NODE_VERSION_WARNINGS+=("${wf_name}：node-version: \"20\" 應升級至 \"24\"（2026-06-02 前）")
+    fi
+  done < <(grep -E 'node-version:' "${wf}" 2>/dev/null || true)
 done
 
 echo "──────────────────────────────────────"
@@ -145,14 +165,35 @@ else
   echo "  以下 actions 可能受 Node.js 20 deprecation 影響："
   echo "  （參考：https://github.blog/changelog/2025-11-11-node-20-actions-deprecation/）"
   echo "  截止日期：2026-06-02（Node.js 24 強制），2026-09-16（Node.js 20 移除）"
+  echo "  追蹤 Issue：#526"
   echo ""
   for item in "${AFFECTED_NODES20[@]}"; do
     echo "  WARNING: ${item}"
   done
   echo ""
-  echo "  建議短期緩解方案："
-  echo "    在 workflow 中加入以下 env，提前測試 Node.js 24 相容性："
-  echo "    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true"
+  echo "  升級路徑（需人工審核，CLAUDE.md 第 10 條）："
+  echo "    actions/checkout@v4     → @v5 或 @v6（Node.js 24）"
+  echo "    actions/setup-node@v4   → @v4 最新 + node-version: \"24\""
+  echo "    actions/upload-artifact@v4 → @v5（Node.js 24）"
+  echo "    actions/download-artifact@v4 → @v5（Node.js 24）"
+  echo "    anthropics/claude-code-action@v1 → 持續維護，觀察官方更新"
+  echo ""
+  echo "  短期緩解（提前測試 Node.js 24 相容性）："
+  echo "    在 workflow jobs 層級加入：env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true"
+fi
+
+echo ""
+echo "──────────────────────────────────────"
+echo "  Node.js 版本參數偵測（#526）"
+echo "──────────────────────────────────────"
+if [[ ${#NODE_VERSION_WARNINGS[@]} -eq 0 ]]; then
+  echo "  無 node-version: \"20\" 使用"
+else
+  for nv in "${NODE_VERSION_WARNINGS[@]}"; do
+    echo "  WARN: node-version: \"20\" — ${nv}"
+  done
+  echo ""
+  echo "  建議：將 node-version: \"20\" 改為 node-version: \"24\""
 fi
 
 echo ""

--- a/skills/sprint-planning/SKILL.md
+++ b/skills/sprint-planning/SKILL.md
@@ -48,6 +48,7 @@ Sprint Planning 是每個 Sprint 週期的起點儀式。由 **PO** 主持，**A
 - [ ] **Architect** 技術評估（詳見 [architect-prompt.md](./references/architect-prompt.md)）
 - [ ] **QA** 驗收標準確認（詳見 [qa-prompt.md](./references/qa-prompt.md)）
 - [ ] 上個 Sprint 的 Retro Action Items 自動列入 Backlog（若有未完成項目）
+- [ ] **Retro-Action Grooming 偵測**（#493）：掃描 `retro-action` label 的 open Issues，對 Sprint Review 觸發的 `[RETRO-GROOMING-TRIGGER]` Issues 執行 Backlog Grooming 重評估（詳見 `skills/sprint-review/references/retro-grooming.md`）
 - [ ] **PO** 建立 `docs/sprints/sprint_N.md`、更新 `docs/PROJECT_BOARD.md`、GitHub label/milestone 操作（詳見 [po-prompt.md](./references/po-prompt.md) Round 2）
 - [ ] 記錄 Token 消耗至 `docs/km/Metrics_Log.md` *(慢想)*<!-- OpenCode -->（OpenCode 暫填 N/A）<!-- /OpenCode -->
 - [ ] 寫入 Sprint Planning 會議紀錄至 `docs/meetings/YYYY-MM-DD-sprint-planning.md`（詳見 §5.1 會議紀錄格式）

--- a/skills/sprint-review/SKILL.md
+++ b/skills/sprint-review/SKILL.md
@@ -128,6 +128,24 @@ Read: contracts/numerical-consistency-contract.md（若本 Sprint 有數值修�
 
 GitHub Issues 追蹤（`retro-action` label）：每個 Action 透過 `issue-management` 建 Issue，並取得實際 Issue 編號（#N）；**Retro 結束前，所有 Action 必須有對應 Issue 編號，不得有「待建立」項目**。每次 Sprint Review 前逐項確認：完成 → close；未完成 → `deferred` label；連續兩 Sprint open → 升級 Stakeholder。
 
+### 4.1 連續未完成自動觸發 Grooming（#493）
+
+每次 Sprint Review §4 執行期間，對所有 open 的 `retro-action` Issues 執行連續未完成偵測：
+
+- **偵測規則與處置流程**：詳見 `references/retro-grooming.md`
+- **觸發條件**：同一 `retro-action` Issue 連續 **2 個**（含）以上 Sprint 排入但未完成
+- **告警關鍵字**：`[RETRO-GROOMING-TRIGGER]`
+- **後續動作**：在下次 Sprint Planning 中執行 Backlog Grooming 重評估（升級 priority、強制排入、拆分或關閉）
+
+```bash
+# 偵測指令（Sprint Review §4 執行期間）
+gh issue list \
+  --label "retro-action" \
+  --state open \
+  --json number,title,labels,milestone \
+  --limit 100
+```
+
 ---
 
 ## 5. 產出文件

--- a/skills/sprint-review/references/retro-grooming.md
+++ b/skills/sprint-review/references/retro-grooming.md
@@ -1,0 +1,122 @@
+# Retro-Action 連續未完成自動觸發 Grooming
+
+> 此文件定義：當同一個 `retro-action` Issue 連續多個 Sprint 排入但未完成時，自動觸發 Backlog Grooming 重評估的偵測規則與處置流程。
+>
+> 來源：Sprint 126 Retrospective — Action Item #4（#493）
+> 觸發案例：#452（連續 5 Sprint 排入但未完成）
+
+---
+
+## 1. 偵測規則（AC1）
+
+### 1.1 偵測目標
+
+掃描帶有 `retro-action` label 且狀態為 **open** 的 GitHub Issues。
+
+```bash
+gh issue list \
+  --label "retro-action" \
+  --state open \
+  --json number,title,labels,milestone \
+  --limit 100
+```
+
+### 1.2 連續未完成定義
+
+**連續未完成**：同一個 `retro-action` Issue 在**連續 2 個**（含）以上 Sprint 中均排入 Sprint Backlog（具有 `status: in-sprint` label 或對應 Sprint milestone），但每次 Sprint 結束時 Issue 仍為 open 狀態。
+
+| 情境 | 判定 |
+|------|------|
+| Sprint N 排入，Sprint N 結束後關閉 | 正常完成，不觸發 |
+| Sprint N 排入未完成，Sprint N+1 排入完成 | 連續 1 Sprint 未完成，不觸發 |
+| Sprint N 排入未完成，Sprint N+1 排入未完成 | **連續 2 Sprint 未完成，觸發** |
+| Sprint N 排入未完成，Sprint N+1 未排入，Sprint N+2 排入未完成 | 中斷，重新計算，不觸發 |
+
+> **閾值：連續 2 個 Sprint 排入但未完成** → 觸發 Grooming 重評估。
+
+### 1.3 偵測方式
+
+在 Sprint Review §4（Action Items 驗收機制）執行期間，對每個 open 的 `retro-action` Issue 執行以下判定：
+
+1. 讀取 Issue 的 milestone 歷史（透過 GitHub API）
+2. 取最近 3 個 Sprint 的 milestone 記錄
+3. 計算連續排入且未完成的 Sprint 數量
+4. 若連續數量 ≥ 2，觸發 `[RETRO-GROOMING-TRIGGER]`
+
+**簡化判定（無法取得完整 milestone 歷史時的回退方案）**：
+
+若 Issue 具有 `deferred` label 且建立日期距今超過 2 個 Sprint 週期（約 14 天），視為「可能連續未完成」，輸出警示並建議人工確認。
+
+---
+
+## 2. 觸發告警格式
+
+偵測到連續未完成時，輸出以下格式的機器可解析告警：
+
+```
+[RETRO-GROOMING-TRIGGER] Issue #N 連續 M 個 Sprint 排入但未完成，觸發 Backlog Grooming 重評估。
+
+Issue：#N — {標題}
+連續 Sprint 數：M（Sprint X, Sprint X+1, ...）
+建議處置：{見 §3}
+```
+
+---
+
+## 3. 處置選項（Grooming 重評估）
+
+偵測到 `[RETRO-GROOMING-TRIGGER]` 後，在下一次 Sprint Planning 中執行 Backlog Grooming，處置選項如下：
+
+| 選項 | 適用情境 | 動作 |
+|------|---------|------|
+| **升級 priority** | Issue 重要但因容量不足持續延遲 | 將 label 從 `priority: should` 升為 `priority: must`，強制排入下一 Sprint |
+| **強制排入** | Issue 已是 `priority: must` 但仍未完成 | 在 Sprint Planning 中作為 Hard Gate，不得因容量問題跳過 |
+| **拆分 Story** | Issue 過大導致無法在一個 Sprint 完成 | 與 PO 協商拆分為更小的子 Issue，各自排入 Sprint |
+| **關閉並記錄** | Issue 已不再相關或已被其他方式解決 | 加 `wont-fix` label 並關閉，在 Retro Log 記錄原因 |
+
+---
+
+## 4. 觸發案例：#452
+
+**Issue #452** 為本機制的設計觸發案例：
+
+- 狀態：`retro-action` label，連續多個 Sprint 排入但未完成
+- 歷史：Sprint 121–125 均排入，每次 Sprint 結束後仍 open
+- 本機制實施後，#452 應在 Sprint Review 中觸發 `[RETRO-GROOMING-TRIGGER]`
+- 建議處置：執行 Grooming 重評估，選擇「強制排入」或「拆分 Story」
+
+---
+
+## 5. Sprint Review 整合點
+
+本偵測邏輯整合至 **Sprint Review §4 Action Items 驗收機制**：
+
+```
+§4 原有文字：
+  每次 Sprint Review 前逐項確認：完成 → close；未完成 → deferred label；
+  連續兩 Sprint open → 升級 Stakeholder。
+
+§4 新增（#493）：
+  連續兩 Sprint open 的 retro-action Issue → 同時觸發 [RETRO-GROOMING-TRIGGER]，
+  在下次 Sprint Planning 中執行 Backlog Grooming 重評估（詳見本文件）。
+```
+
+---
+
+## 6. Sprint Planning 整合點
+
+Sprint Planning PO Round 1 在 Backlog 掃描時，**必須**優先處理帶有 `[RETRO-GROOMING-TRIGGER]` 的 Issues：
+
+1. 掃描是否有 `retro-action` Issues 觸發了 Grooming 告警
+2. 對每個觸發告警的 Issue，執行 §3 處置選項中的一項
+3. 處置結果記錄於 Sprint Planning 會議紀錄
+
+```bash
+# Sprint Planning 掃描指令（PO Round 1 前執行）
+gh issue list \
+  --label "retro-action" \
+  --label "deferred" \
+  --state open \
+  --json number,title,labels \
+  --limit 50
+```

--- a/tests/test-493-retro-grooming.sh
+++ b/tests/test-493-retro-grooming.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# tests/test-493-retro-grooming.sh
+# Story #493：Retro-Action 連續未完成自動觸發 Grooming 機制
+# 覆蓋 AC1（偵測規則定義）/ AC2（Sprint Planning 加入偵測邏輯）/ AC3（#452 觸發案例說明）
+
+set -uo pipefail
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  echo "PASS: $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+assert_file_contains() {
+  local needle="$1"
+  local filepath="$2"
+  local label="$3"
+  if grep -qF "$needle" "$filepath"; then
+    pass "$label"
+  else
+    fail "$label (檔案中找不到「$needle」)"
+  fi
+}
+
+assert_file_exists() {
+  local filepath="$1"
+  local label="$2"
+  if [ -f "$filepath" ]; then
+    pass "$label"
+  else
+    fail "$label (檔案不存在：$filepath)"
+  fi
+}
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPRINT_REVIEW_SKILL="$REPO_ROOT/skills/sprint-review/SKILL.md"
+SPRINT_PLANNING_SKILL="$REPO_ROOT/skills/sprint-planning/SKILL.md"
+RETRO_GROOMING_REF="$REPO_ROOT/skills/sprint-review/references/retro-grooming.md"
+
+echo "=============================="
+echo " Story #493：Retro-Action 連續未完成自動觸發 Grooming 測試套件"
+echo "=============================="
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC1：定義「連續未完成」的偵測規則
+# ---------------------------------------------------------------------------
+
+# TC-01：retro-grooming.md 偵測規則文件存在
+test_tc01_grooming_reference_exists() {
+  assert_file_exists \
+    "$RETRO_GROOMING_REF" \
+    "TC-01：retro-grooming.md 參考文件存在"
+}
+
+# TC-02：偵測規則包含「連續」關鍵字（連續 Sprint 未排入概念）
+test_tc02_consecutive_rule_defined() {
+  assert_file_contains \
+    "連續" \
+    "$RETRO_GROOMING_REF" \
+    "TC-02：偵測規則包含「連續」Sprint 未完成概念"
+}
+
+# TC-03：偵測規則包含「retro-action」label 作為偵測目標
+test_tc03_retro_action_label_mentioned() {
+  assert_file_contains \
+    "retro-action" \
+    "$RETRO_GROOMING_REF" \
+    "TC-03：偵測規則基於 retro-action label"
+}
+
+# TC-04：偵測規則包含閾值定義（2 Sprint）
+test_tc04_threshold_defined() {
+  assert_file_contains \
+    "2" \
+    "$RETRO_GROOMING_REF" \
+    "TC-04：偵測閾值定義（至少含「2」）"
+}
+
+# TC-05：偵測規則包含觸發 Grooming 的動作說明
+test_tc05_grooming_trigger_action_defined() {
+  assert_file_contains \
+    "Grooming" \
+    "$RETRO_GROOMING_REF" \
+    "TC-05：偵測規則包含觸發 Grooming 的動作說明"
+}
+
+# TC-06：偵測規則包含機器可解析的告警關鍵字
+test_tc06_machine_readable_alert_keyword() {
+  assert_file_contains \
+    "[RETRO-GROOMING-TRIGGER]" \
+    "$RETRO_GROOMING_REF" \
+    "TC-06：機器可解析告警關鍵字 [RETRO-GROOMING-TRIGGER] 存在"
+}
+
+# ---------------------------------------------------------------------------
+# AC2：Sprint Planning Skill 加入此偵測邏輯
+# ---------------------------------------------------------------------------
+
+# TC-07：Sprint Planning SKILL.md 引用 retro-grooming 偵測
+test_tc07_sprint_planning_references_grooming() {
+  assert_file_contains \
+    "retro-grooming" \
+    "$SPRINT_PLANNING_SKILL" \
+    "TC-07：Sprint Planning SKILL.md 引用 retro-grooming 偵測"
+}
+
+# TC-08：Sprint Review SKILL.md 包含 retro-action 逐項確認邏輯（已有，驗收已存在的偵測觸發說明）
+test_tc08_sprint_review_retro_action_check() {
+  assert_file_contains \
+    "retro-action" \
+    "$SPRINT_REVIEW_SKILL" \
+    "TC-08：Sprint Review SKILL.md 包含 retro-action 確認邏輯"
+}
+
+# TC-09：Sprint Review SKILL.md 包含連續未完成升級說明（引用 retro-grooming.md）
+test_tc09_sprint_review_references_grooming_doc() {
+  assert_file_contains \
+    "retro-grooming" \
+    "$SPRINT_REVIEW_SKILL" \
+    "TC-09：Sprint Review SKILL.md 引用 retro-grooming.md"
+}
+
+# ---------------------------------------------------------------------------
+# AC3：#452 作為觸發案例驗證機制可行性
+# ---------------------------------------------------------------------------
+
+# TC-10：retro-grooming.md 包含 #452 觸發案例說明
+test_tc10_452_case_documented() {
+  assert_file_contains \
+    "#452" \
+    "$RETRO_GROOMING_REF" \
+    "TC-10：retro-grooming.md 包含 #452 觸發案例說明"
+}
+
+# TC-11：retro-grooming.md 包含「升級 priority」或「強制排入」處置說明
+test_tc11_grooming_action_options_defined() {
+  if grep -qF "升級 priority" "$RETRO_GROOMING_REF" || grep -qF "強制排入" "$RETRO_GROOMING_REF"; then
+    pass "TC-11：grooming 處置說明包含「升級 priority」或「強制排入」"
+  else
+    fail "TC-11：grooming 處置說明未含「升級 priority」或「強制排入」"
+  fi
+}
+
+# TC-12：retro-grooming.md 包含 gh 指令範例（掃描 retro-action open issues）
+test_tc12_gh_command_example_exists() {
+  assert_file_contains \
+    "gh issue list" \
+    "$RETRO_GROOMING_REF" \
+    "TC-12：retro-grooming.md 包含 gh issue list 指令範例"
+}
+
+# ---------------------------------------------------------------------------
+# 執行所有測試
+# ---------------------------------------------------------------------------
+test_tc01_grooming_reference_exists
+test_tc02_consecutive_rule_defined
+test_tc03_retro_action_label_mentioned
+test_tc04_threshold_defined
+test_tc05_grooming_trigger_action_defined
+test_tc06_machine_readable_alert_keyword
+test_tc07_sprint_planning_references_grooming
+test_tc08_sprint_review_retro_action_check
+test_tc09_sprint_review_references_grooming_doc
+test_tc10_452_case_documented
+test_tc11_grooming_action_options_defined
+test_tc12_gh_command_example_exists
+
+echo ""
+echo "=============================="
+echo " 結果：PASS=$PASS_COUNT  FAIL=$FAIL_COUNT"
+echo "=============================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test-validate-ci-versions.sh
+++ b/tests/test-validate-ci-versions.sh
@@ -195,6 +195,60 @@ assert_output_contains "應顯示 WARN 建議更新 SHA" "WARN" "${sha_output}"
 echo ""
 
 # ──────────────────────────────────────────────
+# Test 5：偵測 setup-node node-version: "20" 並發出警告
+# （#526 Node.js 20 actions deprecation 追蹤）
+# ──────────────────────────────────────────────
+echo "[ T5 ] 偵測 node-version: \"20\" 並發出警告（#526）"
+
+TMP_REPO5=$(mktemp -d)
+mkdir -p "${TMP_REPO5}/.github/workflows"
+cat > "${TMP_REPO5}/.github/workflows/node20.yml" << 'EOF'
+name: Node20 Workflow
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+EOF
+
+set +e
+node20_output=$(CI_VERSIONS_REPO_ROOT="${TMP_REPO5}" bash "${VALIDATE_SCRIPT}" 2>&1)
+node20_exit=$?
+set -e
+
+rm -rf "${TMP_REPO5}"
+
+assert_exit_code "node-version 20 workflow 退出碼應為 0（不是 FAIL，但有 WARNING）" 0 "${node20_exit}"
+assert_output_contains "應發出 node-version 20 警告" "node-version.*20\|node version.*20\|node-version: .20" "${node20_output}"
+
+echo ""
+
+# ──────────────────────────────────────────────
+# Test 6：e2e.yml 不應使用 node-version: "20"
+# （#526 AC — e2e.yml 已升級至 Node.js 24）
+# ──────────────────────────────────────────────
+echo "[ T6 ] e2e.yml 不應使用 node-version: \"20\"（#526）"
+
+E2E_WORKFLOW="${REPO_ROOT}/.github/workflows/e2e.yml"
+if [[ -f "${E2E_WORKFLOW}" ]]; then
+  if grep -q 'node-version:.*"20"' "${E2E_WORKFLOW}" || grep -q "node-version:.*'20'" "${E2E_WORKFLOW}"; then
+    echo "  FAIL: e2e.yml 仍在使用 node-version: 20，需升級至 24（#526）"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "  PASS: e2e.yml 未使用 node-version: 20"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+else
+  echo "  SKIP: e2e.yml 不存在"
+fi
+
+echo ""
+
+# ──────────────────────────────────────────────
 # 結果摘要
 # ──────────────────────────────────────────────
 TOTAL=$((PASS_COUNT + FAIL_COUNT))


### PR DESCRIPTION
## Summary

- **e2e.yml**: `node-version: "20"` → `"24"`，修正 2026-06-02 強制切換前的直接風險
- **validate-ci-versions.sh**: 新增 `node-version: "20"` 參數偵測功能（警告但不 FAIL），提早發現相同問題
- **validate-ci-versions.sh**: 補充 `NODEJS20_AFFECTED_ACTIONS` 升級路徑說明（checkout v5/v6、upload-artifact v5 等）

## 受影響 Actions 狀態

| Action | 現狀 | 建議升級 | 說明 |
|--------|------|---------|------|
| `actions/checkout@v4` | Node.js 20 | `@v5` 或 `@v6` | 需人工審核 |
| `actions/setup-node@v4` | 持續更新 | 維持 `@v4` + `node-version: "24"` | **本 PR 已修** |
| `actions/upload-artifact@v4` | Node.js 20 | `@v5` 或 `@v7` | 需人工審核 |
| `anthropics/claude-code-action@v1` | 持續維護 | 觀察官方更新 | — |
| `oven-sh/setup-bun@3d2677...` | 不再使用 | — | 已從 workflows 移除 |

注意：`actions/checkout` 等 action 版本升級（`@v4` → `@v5`/`@v6`）依 CLAUDE.md 第 10 條需人工審核，不在本 PR 範圍內。

## 測試

- 新增 T5：偵測 `node-version: "20"` 並發出警告
- 新增 T6：驗證 `e2e.yml` 不使用 `node-version: "20"`
- 全部通過：17/17（原 14/14 + 新增 3 測試）
- infra-regression：36/36 PASS

## 關聯

Closes #526
關聯：#424 #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)