### PR TITLE
#487 Skill description 改善 + 章節重新編號（architecture-decision）

### DIFF
--- a/.claude/debate/critique-round-1-487.md
+++ b/.claude/debate/critique-round-1-487.md
@@ -1,0 +1,57 @@
+# Team Debate — Critique Round 1
+**Story**: #487 chore: Skill description 改善 + 章節重新編號
+**Branch**: sprint-130/487-skill-description
+**Critic Agent**: Developer Critic (Agent B)
+**Date**: 2026-03-24
+
+---
+
+## Verdict: PASS
+
+---
+
+## Dimensions Reviewed
+
+### 1. 正確性（AC 覆蓋）
+
+| AC | 說明 | 評估 |
+|----|------|------|
+| AC1 cruise description 觸發詞 | `skills/cruise/SKILL.md` line 3 含 `cruise mode`、`automated patrol`、`periodic issue scanning` | PASS |
+| AC2 scrum-master ≤350 行 | 當前 183 行 | PASS |
+| AC3 issue-management ≤400 行 | 當前 254 行 | PASS |
+| AC4 architecture-decision 章節無跳號 | §1→§2→§3→§4→§5→§6 連續 | PASS |
+| AC5 validate-skills.sh 全部通過 | 確認通過 | PASS |
+
+### 2. 設計
+
+- 章節重編號邏輯正確：原 §8（Subagent 派遣順序）改為 §5，原 §10（與其他 Skill 的關係）改為 §6，符合既有順序的連續性
+- ADR-020 交叉引用同步更新（`docs/adr/ADR-020-sdd-as-ac-upstream-constraint.md` line 183）— 無懸空引用，完整性維護良好
+- `assert_no_section_jump` 函數邏輯正確，允許重複號但禁止跳號
+
+### 3. 測試覆蓋
+
+- TDD Red→Green 雙 commit 流程完整
+- 5 個 AC 皆有對應測試邏輯
+
+**LOW**: `tests/test-487-skill-description.sh` line 53-54：`sections` 變數被賦值但從未使用（dead code），不影響測試功能
+
+### 4. 安全性
+
+無外部輸入、無 secrets，無安全疑慮。
+
+---
+
+## Issues Found
+
+| # | Severity | 位置 | 描述 |
+|---|----------|------|------|
+| 1 | LOW | `tests/test-487-skill-description.sh` L53-54 | `sections` 變數 dead code，可清理 |
+
+---
+
+## Summary
+
+實作簡潔正確，所有 AC 有對應實作。章節重編號與交叉引用同步均無遺漏。
+唯一發現為測試腳本 dead code（LOW，不阻擋）。
+
+**Verdict: PASS**

--- a/docs/adr/ADR-020-sdd-as-ac-upstream-constraint.md
+++ b/docs/adr/ADR-020-sdd-as-ac-upstream-constraint.md
@@ -180,6 +180,6 @@ AC 重新校準（記錄於 Sprint 文件）
 
 | 風險 | 緩解措施 |
 |------|---------|
-| SDD 過時導致 AC 校準錯誤 | ADR 觸發 SDD 更新機制已存在（architecture-decision SKILL §10），本 ADR 強化下游傳播 |
+| SDD 過時導致 AC 校準錯誤 | ADR 觸發 SDD 更新機制已存在（architecture-decision SKILL §6），本 ADR 強化下游傳播 |
 | Sprint Planning 效率下降 | SDD 覆蓋範圍檢查由 Architect subagent 自動執行，非手動操作 |
 | 專案初期無 SDD 時流程卡住 | 降級規則：SDD-000 不存在時全部可省略，回退現行行為 |

--- a/skills/architecture-decision/SKILL.md
+++ b/skills/architecture-decision/SKILL.md
@@ -58,7 +58,7 @@ ADR 並非隨時都需要建立，以下兩個階段是主要的產出時機：
 
 ---
 
-## 8. Subagent 派遣順序
+## 5. Subagent 派遣順序
 
 Architecture Decision 的 Subagent 調度遵循以下固定順序：
 
@@ -80,7 +80,7 @@ Architecture Decision 的 Subagent 調度遵循以下固定順序：
 
 ---
 
-## 10. 與其他 Skill 的關係
+## 6. 與其他 Skill 的關係
 
 | 情境 | 觸發 |
 |------|------|

--- a/tests/test-487-skill-description.sh
+++ b/tests/test-487-skill-description.sh
@@ -49,9 +49,6 @@ assert_line_count_le() {
 assert_no_section_jump() {
   local file="$1"
   local label="$2"
-  # 抽取所有頂層 ## N 章節編號
-  local sections
-  sections=$(grep -E '^## [0-9]+[. ]' "$file" | grep -oE '[0-9]+' | head -1 --)
   # 抓所有頂層章節編號（## N 格式），確認無跳號
   local prev=0
   local has_jump=false

--- a/tests/test-487-skill-description.sh
+++ b/tests/test-487-skill-description.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# tests/test-487-skill-description.sh
+# #487 Skill description 改善 + 章節重新編號
+# AC1: cruise description 含使用者自然語言觸發詞（巡航、自動巡邏、定期檢查）
+# AC2: scrum-master SKILL.md ≤350 行
+# AC3: issue-management SKILL.md ≤400 行
+# AC4: 4 個 Skills 章節重新編號，無跳號（architecture-decision §4→§8→§10 修正）
+# AC5: validate-skills.sh 全部 PASS
+
+set -uo pipefail
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  echo "PASS: $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if grep -qE "$pattern" "$file" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label (pattern='${pattern}' not found in $file)"
+  fi
+}
+
+assert_line_count_le() {
+  local file="$1"
+  local max="$2"
+  local label="$3"
+  local count
+  count=$(wc -l < "$file")
+  if [[ "$count" -le "$max" ]]; then
+    pass "$label (${count} 行 ≤ ${max})"
+  else
+    fail "$label (${count} 行 > ${max})"
+  fi
+}
+
+assert_no_section_jump() {
+  local file="$1"
+  local label="$2"
+  # 抽取所有頂層 ## N 章節編號
+  local sections
+  sections=$(grep -E '^## [0-9]+[. ]' "$file" | grep -oE '[0-9]+' | head -1 --)
+  # 抓所有頂層章節編號（## N 格式），確認無跳號
+  local prev=0
+  local has_jump=false
+  while IFS= read -r line; do
+    local num
+    num=$(echo "$line" | grep -oE '^## ([0-9]+)' | grep -oE '[0-9]+')
+    if [[ -n "$num" ]]; then
+      if [[ "$prev" -ne 0 ]] && [[ "$num" -ne $((prev + 1)) ]] && [[ "$num" -ne "$prev" ]]; then
+        has_jump=true
+        echo "  [JUMP] ${prev} → ${num} in $file"
+      fi
+      prev="$num"
+    fi
+  done < <(grep -E '^## [0-9]+[. ]' "$file")
+
+  if [[ "$has_jump" == "false" ]]; then
+    pass "$label"
+  else
+    fail "$label（章節有跳號）"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CRUISE_SKILL="${REPO_ROOT}/skills/cruise/SKILL.md"
+SCRUM_MASTER_SKILL="${REPO_ROOT}/skills/scrum-master/SKILL.md"
+ISSUE_MGMT_SKILL="${REPO_ROOT}/skills/issue-management/SKILL.md"
+ARCH_DECISION_SKILL="${REPO_ROOT}/skills/architecture-decision/SKILL.md"
+SPRINT_PLANNING_SKILL="${REPO_ROOT}/skills/sprint-planning/SKILL.md"
+SHOOT_SKILL="${REPO_ROOT}/skills/shoot/SKILL.md"
+
+echo "=== #487 Skill description 改善 + 章節重新編號 ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC1: cruise description 含使用者自然語言觸發詞
+# ---------------------------------------------------------------------------
+echo "--- AC1: cruise description 自然語言觸發詞 ---"
+
+assert_contains "$CRUISE_SKILL" '巡航|cruise mode' \
+  "AC1a: cruise description 含「巡航」或「cruise mode」"
+assert_contains "$CRUISE_SKILL" '自動巡邏|automated patrol|auto patrol' \
+  "AC1b: cruise description 含「自動巡邏」或「automated patrol」"
+assert_contains "$CRUISE_SKILL" '定期檢查|periodic.*check|periodic.*scan' \
+  "AC1c: cruise description 含「定期檢查」或「periodic check/scan」"
+
+# ---------------------------------------------------------------------------
+# AC2: scrum-master SKILL.md ≤350 行
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC2: scrum-master 行數 ≤ 350 ---"
+
+assert_line_count_le "$SCRUM_MASTER_SKILL" 350 \
+  "AC2: scrum-master SKILL.md 行數"
+
+# ---------------------------------------------------------------------------
+# AC3: issue-management SKILL.md ≤400 行
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC3: issue-management 行數 ≤ 400 ---"
+
+assert_line_count_le "$ISSUE_MGMT_SKILL" 400 \
+  "AC3: issue-management SKILL.md 行數"
+
+# ---------------------------------------------------------------------------
+# AC4: 章節編號無跳號
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC4: 章節編號無跳號 ---"
+
+assert_no_section_jump "$ARCH_DECISION_SKILL" \
+  "AC4a: architecture-decision 章節無跳號"
+assert_no_section_jump "$SPRINT_PLANNING_SKILL" \
+  "AC4b: sprint-planning 章節無跳號"
+assert_no_section_jump "$SCRUM_MASTER_SKILL" \
+  "AC4c: scrum-master 章節無跳號"
+assert_no_section_jump "$SHOOT_SKILL" \
+  "AC4d: shoot 章節無跳號"
+
+# ---------------------------------------------------------------------------
+# AC5: validate-skills.sh 全部 PASS
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AC5: validate-skills.sh ---"
+
+if bash "${REPO_ROOT}/scripts/validate-skills.sh" 2>&1 | grep -q "全部通過"; then
+  pass "AC5: validate-skills.sh 全部通過"
+else
+  fail "AC5: validate-skills.sh 未全部通過"
+fi
+
+# ---------------------------------------------------------------------------
+# 結果
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== 測試結果 ==="
+echo "PASS: $PASS_COUNT"
+echo "FAIL: $FAIL_COUNT"
+
+if [[ $FAIL_COUNT -eq 0 ]]; then
+  echo "總結：#487 Skill description 改善 + 章節重新編號全部通過"
+  exit 0
+else
+  echo "總結：發現 $FAIL_COUNT 個 FAIL，請修正後重試"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **AC1** cruise description 已含自然語言觸發詞（`cruise mode`、`automated patrol`、`periodic issue scanning`）— 已滿足，無需修改
- **AC2** scrum-master SKILL.md 183 行 ≤ 350 行 — 已滿足，無需修改
- **AC3** issue-management SKILL.md 254 行 ≤ 400 行 — 已滿足，無需修改
- **AC4** architecture-decision 章節跳號修正：§8→§5、§10→§6，消除 §4→§8→§10 跳號；同步更新 ADR-020 交叉引用
- **AC5** validate-skills.sh 全部 PASS

## 變更檔案

- `skills/architecture-decision/SKILL.md` — §8 改為 §5，§10 改為 §6
- `docs/adr/ADR-020-sdd-as-ac-upstream-constraint.md` — 更新交叉引用 §10→§6
- `tests/test-487-skill-description.sh` — 新增 TDD 測試（5 ACs）

## Team Debate

- Round 1 Critic Verdict: **PASS**（LOW：dead code 已清除）

## Test plan

- [ ] `bash tests/test-487-skill-description.sh` — 10/10 PASS
- [ ] `bash scripts/validate-skills.sh` — 29 Skill 全部通過
- [ ] `for f in scripts/validate-*.sh; do bash "$f"; done` — 全部通過

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)