### PR TITLE
#556 CI 升級確認時機明確化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@
    - `project_level=low`：**所有操作自動執行，禁止停下來問使用者**。包括但不限於：Sprint Planning 完成後自動 Sprint Execution、Sprint Execution 完成後自動 Sprint Review、auto-shoot 發現 actionable 自動派工、Feedback Routing 自動轉送、需要 compact 直接 compact 再繼續。
    - `project_level=medium`：高風險操作（Sprint Planning 啟動、Sprint Execution 啟動）留言通知等使用者確認；日常低風險操作自動執行。
    - `project_level=high`：每個重要步驟都必須等人確認，只標記不自動觸發。
-10. **CI Actions 版本釘定**：所有 GitHub Actions 統一使用 `@v4`，升級需先確認 self-hosted runner 相容性，並經人工審核後才能更新版本號。新增或修改 workflow 時執行 `bash scripts/validate-ci-versions.sh` 驗證。
+10. **CI Actions 版本釘定**：所有 GitHub Actions 統一使用 `@v4`，升級需先確認 self-hosted runner 相容性，並經人工審核後才能更新版本號。新增或修改 workflow 時執行 `bash scripts/validate-ci-versions.sh` 驗證。**升級確認時機**：INFRA Story 涉及 CI Actions 版本升級時，確認須在 Sprint Planning 前完成，避免 Sprint 中途因版本不相容而阻塞。
 11. **GitHub URL 可讀取**：遇到 GitHub URL（含 attachment），帶 `gh auth token` 認證直接讀取，不要報「無法讀取」。
 12. **平行 Worktree OOM 防護**：平行 worktree subagent 過多會 OOM（Sprint 127 歷史案例：4 個 worktree 觸發 core dump）。`SHIKIGAMI_MAX_PARALLEL` 預設 2，**未設定時亦視為 2，不得無限平行**。派遣前必須執行 `git worktree list` 計算現存數量；重派前必須確認同任務 agent 是否還在跑，避免重複派遣。詳見 `skills/sprint-execution/references/parallel-safety.md`。
 

--- a/skills/sprint-planning/SKILL.md
+++ b/skills/sprint-planning/SKILL.md
@@ -45,6 +45,7 @@ Sprint Planning 是每個 Sprint 週期的起點儀式。由 **PO** 主持，**A
 - [ ] **PO Round 1 ADR 自動納入**（#456）：PO 選取 Story 後，掃描 Architect 技術評估的 ADR 欄位；若有標注「已補建 #N（RESEARCH）」的 ADR Story，自動將該 ADR RESEARCH Story 一併選入同一 Sprint（AC2）
 - [ ] 檢查選入 Story 是否標注「需要 ADR」— 若需要，ADR 必須已 Accepted 或已在本 Sprint 納入 ADR RESEARCH Story
 - [ ] **複雜度影響評估**（#462）：對每個新增功能 Story，執行 `bash scripts/measure-complexity.sh` 評估複雜度影響；若預計新增 Skill/Agent，須同步評估是否刪減等量舊功能（見 §13 複雜度預算）
+- [ ] 確認 INFRA Story 涉及的 CI Actions 版本升級已完成人工審核確認（未完成者須退回 Backlog 或延至下一 Sprint）
 - [ ] **Architect** 技術評估（詳見 [architect-prompt.md](./references/architect-prompt.md)）
 - [ ] **QA** 驗收標準確認（詳見 [qa-prompt.md](./references/qa-prompt.md)）
 - [ ] 上個 Sprint 的 Retro Action Items 自動列入 Backlog（若有未完成項目）


### PR DESCRIPTION
## Summary
- CLAUDE.md 開發紅線第 10 條補充「升級確認時機」：INFRA Story 涉及 CI Actions 版本升級時，確認須在 Sprint Planning 前完成
- Sprint Planning SKILL.md §2 流程 Checklist 新增「確認 INFRA Story 涉及的 CI Actions 版本升級已完成人工審核確認」項目

## AC Status
- AC1: PASS — CLAUDE.md 第 10 條已補充升級確認時機說明
- AC2: PASS — Sprint Planning Checklist 已新增 INFRA CI 版本確認前置項目

Closes #556