### PR TITLE
#388 /shoot 進化版 — test→review→PR 一鍵串接

### DIFF
--- a/skills/shoot/SKILL.md
+++ b/skills/shoot/SKILL.md
@@ -142,10 +142,35 @@ Story ID 需**精確比對**（`US-#N` 格式優先，大小寫不敏感）。�
 - 外部獨立審查：`skills/shoot/references/external-review.md`
 - pr-review-toolkit：`skills/shoot/references/pr-review-integration.md`
 - 文件產出：`skills/shoot/references/doc-output.md`
+- **test → review → PR 管道**：`skills/shoot/references/pipeline.md`
 
 ### 明確跳過項目（Sprint 儀式）
 
 `/shoot` 跳過：Sprint Planning、Sprint Review、Sprint Retro、Sprint Metrics（不計算 Velocity）
+
+---
+
+## 7.1 test → review → PR 一鍵管道（#388）
+
+<!-- Story #388 — /shoot 進化版：test → review → PR 一鍵串接 -->
+
+實作完成後自動進入三階段品質管道（完整規則見 `skills/shoot/references/pipeline.md`）：
+
+```
+[test]   bash tests/test-*.sh
+  ↓ PASS
+[review] 外部獨立審查 + pr-review-toolkit（步驟 5.3 + 5.4）
+  ↓ PASS
+[PR]     gh pr create + squash merge（步驟 6）
+```
+
+**test 失敗中止（AC2）**：test FAIL → 觸發 systematic-debugging，修復重試；仍 FAIL → 管道中止，exit code 非 0，不進入 review，不建立 PR。
+
+**review 回退修復（AC3）**：review 發現 CRITICAL/HIGH → 回退至實作修復，修復後重跑 test + review；二審仍 CRITICAL/HIGH → 升級 Architect，管道中止。
+
+<HARD-GATE>
+**test → review → PR 管道 Hard Gate**：任一階段 FAIL 且無法修復，後續階段跳過，exit code 非 0。
+</HARD-GATE>
 
 ---
 

--- a/skills/shoot/references/pipeline.md
+++ b/skills/shoot/references/pipeline.md
@@ -1,0 +1,118 @@
+# shoot test → review → PR 管道規則
+
+本文件定義 `/shoot` 的 test → review → PR 完整管道，由 `skills/shoot/SKILL.md` §7.1 按需載入。
+
+關聯 Story：#388
+
+---
+
+## 管道概覽
+
+`/shoot #N`（或任意觸發模式）實作完成後，自動進入三階段品質管道：
+
+```
+[test]  → bash tests/test-*.sh（步驟 4.5）
+  ↓ PASS
+[review] → pr-review-toolkit 外部獨立審查（步驟 5.3 + 5.4）
+  ↓ PASS
+[PR]    → gh pr create + squash merge（步驟 6.4 + 6.6）
+```
+
+各階段 FAIL 時立即中止，不進入下一階段。
+
+---
+
+## 階段 1：test（步驟 4.5）
+
+執行 `bash tests/test-*.sh` 及其他本地測試。
+
+**PASS** → 進入 review 階段。
+
+**FAIL** → 觸發 `invoke shikigami:systematic-debugging`，修復後重試。
+- 重試仍 FAIL → **管道中止**，exit code 非 0，不進入 review，不建立 PR。
+- 輸出：`[ERROR] test 失敗，管道中止。請修復後重新執行 /shoot`
+
+<HARD-GATE>
+**test Hard Gate（/shoot pipeline）**：test 失敗且修復後仍失敗 → 管道中止，exit code 非 0，禁止進入 review 與 PR 階段。
+</HARD-GATE>
+
+---
+
+## 階段 2：review（步驟 5.3 + 5.4）
+
+test PASS 後，依序執行：
+1. 外部獨立審查（步驟 5.3）— 規則見 `references/external-review.md`
+2. pr-review-toolkit 補充審查（步驟 5.4）— 規則見 `references/pr-review-integration.md`
+
+**回退修復機制**（AC3）：
+
+review 發現 CRITICAL/HIGH 問題時：
+1. 標記問題，回退至實作修復
+2. 修復完成後，重新執行 **test + review**（從階段 1 重跑）
+3. 二審仍有 CRITICAL/HIGH → 升級 Architect，管道中止
+
+```
+review FAIL
+  └─→ [回退] 修復問題（實作修正）
+       └─→ [重跑] bash tests/test-*.sh
+            ├─→ test FAIL → 管道中止
+            └─→ test PASS → 重新 review
+                 ├─→ 仍 CRITICAL/HIGH → 升級 Architect，管道中止
+                 └─→ PASS → 進入 PR 階段
+```
+
+<HARD-GATE>
+**review 回退 Hard Gate（/shoot pipeline）**：二審仍 CRITICAL/HIGH → 升級 Architect，exit code 非 0，管道中止，禁止建立 PR。
+</HARD-GATE>
+
+---
+
+## 階段 3：PR 建立（步驟 6）
+
+review PASS 後，自動執行：
+
+```bash
+# 6.1 建立 branch
+git checkout -b shoot/<issue-or-desc>
+
+# 6.2 commit
+git commit -m "shoot: <任務標題>"
+
+# 6.3 push
+git push
+
+# 6.4 PR 建立
+gh pr create --title "<任務標題>" --body "Closes #N"
+
+# 6.5 Code Review Loop（pr-review-toolkit）
+# 6.55 Self-Review（shoot.self_review=true 時）
+
+# 6.6 squash merge（shoot.skip_merge=false 時）
+gh pr merge --squash --delete-branch
+```
+
+PR 建立後的 merge 行為受 `shoot.skip_merge` 配置控制（詳見 SKILL.md §1）。
+
+---
+
+## 管道狀態輸出
+
+每個階段結束後輸出管道狀態：
+
+```
+── /shoot 管道狀態 ──────────────────────
+  [PASS] test        bash tests/test-*.sh 全部通過
+  [PASS] review      外部獨立審查 + pr-review-toolkit PASS
+  [PASS] PR          #<PR_NUMBER> 建立完成，squash merged
+```
+
+任一階段 FAIL：
+
+```
+── /shoot 管道狀態 ──────────────────────
+  [PASS] test        bash tests/test-*.sh 全部通過
+  [FAIL] review      code-reviewer 發現 HIGH issue（已中止）
+  [SKIP] PR          review 未通過，不建立 PR
+
+[ERROR] /shoot 管道中止於 review 階段
+```

--- a/tests/test-shoot-skill.sh
+++ b/tests/test-shoot-skill.sh
@@ -389,6 +389,69 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 區段 9：test → review → PR 管道驗證（Story #388 AC1-AC3）
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== 區段 9：test → review → PR 管道（#388 AC1-AC3）==="
+
+PIPELINE_REF="${PROJECT_DIR}/skills/shoot/references/pipeline.md"
+assert_file_exists "$PIPELINE_REF" "skills/shoot/references/pipeline.md 存在"
+
+if [ -f "$SHOOT_SKILL_MD" ]; then
+  SKILL_CONTENT=$(cat "$SHOOT_SKILL_MD")
+
+  # 9.1 AC1：SKILL.md 含管道段落（§7.1）
+  assert_contains "$SKILL_CONTENT" "test → review → PR" "SKILL.md 含 test → review → PR 管道說明"
+
+  # 9.2 AC1：含自動串接的三個階段
+  assert_contains "$SKILL_CONTENT" "bash tests/test-*.sh" "SKILL.md 含 test 階段指令"
+
+  # 9.3 AC1：含 PR 建立
+  assert_contains "$SKILL_CONTENT" "gh pr create" "SKILL.md 含 gh pr create"
+
+  # 9.4 AC1：含 squash merge
+  assert_contains "$SKILL_CONTENT" "squash merge" "SKILL.md 含 squash merge 說明"
+
+  # 9.5 AC2：test 失敗中止
+  assert_contains "$SKILL_CONTENT" "test 失敗中止" "SKILL.md 含 test 失敗中止說明（AC2）"
+
+  # 9.6 AC2：不進入 review
+  assert_contains "$SKILL_CONTENT" "不進入 review" "SKILL.md 含 test FAIL 不進入 review 說明"
+
+  # 9.7 AC2：不建立 PR
+  assert_contains "$SKILL_CONTENT" "不建立 PR" "SKILL.md 含 test FAIL 不建立 PR 說明"
+
+  # 9.8 AC3：review 回退修復
+  assert_contains "$SKILL_CONTENT" "review 回退修復" "SKILL.md 含 review 回退修復說明（AC3）"
+
+  # 9.9 AC3：含升級 Architect 說明
+  assert_contains "$SKILL_CONTENT" "升級 Architect" "SKILL.md 含升級 Architect 說明"
+
+  # 9.10 AC4：SKILL.md 行數不超過 350 行
+  LINE_COUNT=$(wc -l < "$SHOOT_SKILL_MD")
+  if [ "$LINE_COUNT" -le 350 ]; then
+    pass "AC4 SKILL.md 行數 ${LINE_COUNT} <= 350 行"
+  else
+    fail "AC4 SKILL.md 行數 ${LINE_COUNT} 超過 350 行限制"
+  fi
+
+else
+  fail "#388 管道測試跳過（SKILL.md 不存在）"
+fi
+
+# 9.11 pipeline.md 含管道三階段
+if [ -f "$PIPELINE_REF" ]; then
+  PIPELINE_CONTENT=$(cat "$PIPELINE_REF")
+  assert_contains "$PIPELINE_CONTENT" "階段 1：test" "pipeline.md 含 test 階段"
+  assert_contains "$PIPELINE_CONTENT" "階段 2：review" "pipeline.md 含 review 階段"
+  assert_contains "$PIPELINE_CONTENT" "階段 3：PR" "pipeline.md 含 PR 階段"
+  assert_contains "$PIPELINE_CONTENT" "HARD-GATE" "pipeline.md 含 HARD-GATE 宣告"
+  assert_contains "$PIPELINE_CONTENT" "回退修復機制" "pipeline.md 含回退修復機制說明"
+else
+  fail "#388 pipeline.md 內容測試跳過（檔案不存在）"
+fi
+
+# ---------------------------------------------------------------------------
 # 總結
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary
- 新增 §7.1 test→review→PR 三階段品質管道，讓 `/shoot #N` 執行完成後自動串接 test → QA review → PR 建立
- test 失敗自動中止管道（不進入 review、不建立 PR），並觸發 systematic-debugging
- review 發現 CRITICAL/HIGH 自動回退修復，修復後重跑 test+review；二審仍失敗升級 Architect
- 新增 `skills/shoot/references/pipeline.md` 詳細管道規則與 HARD-GATE 宣告
- SKILL.md 332 行（符合 AC4 <= 350 行）

## AC Status
- AC1: PASS — test → QA review → PR 完整串接
- AC2: PASS — test FAIL 中止管道，不進入 review，不建立 PR
- AC3: PASS — review CRITICAL/HIGH 回退修復機制
- AC4: PASS — SKILL.md 332 行 <= 350 行

## Test Plan
- [ ] `bash tests/test-shoot-skill.sh` — 78/78 PASS（含新增區段 9 共 16 個 #388 專屬測試）
- [ ] `bash scripts/validate-skills.sh` — PASS
- [ ] `bash scripts/validate-xrefs.sh` — PASS
- [ ] `bash scripts/validate-json.sh` — PASS

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)