### PR TITLE
#565 主 session 派遣 PO 巡邏禁止自行撰寫 Step 5

### DIFF
--- a/skills/cruise/SKILL.md
+++ b/skills/cruise/SKILL.md
@@ -289,6 +289,8 @@ while 檢查 flag file 存在:
   # SHOOT_FLAG 殘留防護：>30 分鐘強制清除，寫 auto-shoot-stale-cleared log
   # Auto-shoot（依 project_level）— 詳見 references/auto-shoot.md
   # Sprint Planning 觸發已移至 PO 巡邏直接執行（#352）
+  # Step 5（Sprint Planning 觸發）必須由 PO subagent 自行 Read `references/po-patrol.md` Step 5 執行，
+  # 主 session prompt 中禁止包含觸發條件描述（HARD-GATE，見 po-patrol.md Step 5）
 
   sleep ${INTERVAL_SECONDS}
   if flag file 不存在: break

--- a/skills/cruise/references/po-patrol.md
+++ b/skills/cruise/references/po-patrol.md
@@ -348,6 +348,9 @@ project_level=${PROJECT_LEVEL}，請確認是否轉送。
 # actionable_issues: 供主 loop invoke shikigami:shoot 派遣（必須走完整 shoot 流程）
 
 # ── Step 5：Sprint Planning 觸發（#352：PO 直接執行，不經主 loop）──
+# <HARD-GATE>
+# 主 session 派遣 PO subagent 時，Step 5（Sprint Planning 觸發判斷）段落僅允許指向本檔案的 Read 指令（如「嚴格依照 skills/cruise/references/po-patrol.md Step 5 執行」），禁止包含觸發條件的描述、判斷語句或任何規則外的引導語（如「不建議」「冷卻期」「priority:must 才觸發」等）。PO subagent 必須自行 Read 本檔案取得完整觸發規則。
+# </HARD-GATE>
 # PO 巡邏完所有 Issue 後，自己檢查 sprint-candidate 觸發條件
 # 讀取 project_level 從 .claude/shikigami.local.md（步驟 4.5 已定義讀取方式）
 CONFIG_FILE=".claude/shikigami.local.md"

--- a/tests/test-cruise-skill.sh
+++ b/tests/test-cruise-skill.sh
@@ -621,6 +621,37 @@ if [[ -f "$SKILL_FILE" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# TC-38：#565 PO subagent Step 5 HARD-GATE 驗證
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TC-38：PO subagent Step 5 HARD-GATE 驗證 ---"
+
+PO_PATROL_FILE_565="${SKILL_DIR}/references/po-patrol.md"
+
+if [[ -f "$PO_PATROL_FILE_565" ]]; then
+  assert_contains "$PO_PATROL_FILE_565" '主 session 派遣 PO subagent 時' \
+    "TC-38a: po-patrol.md Step 5 含 HARD-GATE（主 session 派遣 PO subagent 時）"
+  assert_contains "$PO_PATROL_FILE_565" 'HARD-GATE' \
+    "TC-38b: po-patrol.md Step 5 含 HARD-GATE 標記"
+  assert_contains "$PO_PATROL_FILE_565" '禁止包含觸發條件的描述' \
+    "TC-38c: po-patrol.md HARD-GATE 明確禁止觸發條件描述"
+else
+  fail "TC-38a: po-patrol.md 不存在（${PO_PATROL_FILE_565}）"
+  fail "TC-38b: po-patrol.md 不存在"
+  fail "TC-38c: po-patrol.md 不存在"
+fi
+
+if [[ -f "$SKILL_FILE" ]]; then
+  assert_contains "$SKILL_FILE" 'Step 5.*PO subagent.*Read|PO subagent.*自行 Read.*po-patrol' \
+    "TC-38d: SKILL.md §6b 標注 Step 5 須由 PO subagent 自行 Read po-patrol.md"
+  assert_contains "$SKILL_FILE" 'HARD-GATE.*po-patrol|po-patrol.*HARD-GATE' \
+    "TC-38e: SKILL.md §6b 引用 po-patrol.md HARD-GATE"
+else
+  fail "TC-38d: SKILL.md 不存在"
+  fail "TC-38e: SKILL.md 不存在"
+fi
+
+# ---------------------------------------------------------------------------
 # 結果摘要
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary
- po-patrol.md Step 5 新增 HARD-GATE，禁止主 session 在派遣 PO subagent 時包含觸發條件描述或判斷語句
- cruise SKILL.md §6b 同步更新，標注 Step 5 必須由 PO subagent 自行 Read po-patrol.md 執行
- tests/test-cruise-skill.sh 新增 TC-38（5 個 assertions）驗證 HARD-GATE 規則文字存在

Closes #565