### PR TITLE
fix: #563 PO Round 1 AC 完整性硬性 Gate

### DIFF
--- a/skills/sprint-planning/references/po-prompt.md
+++ b/skills/sprint-planning/references/po-prompt.md
@@ -80,6 +80,25 @@ PO 在 Sprint Planning Round 1 掃描 Backlog 時，**必須**確認每個候選
 
 ---
 
+## AC 完整性 Gate（#563，Sprint 132）
+
+<!-- retro: Story AC 完整性前置確認 — Sprint 131 Problem 1 -->
+
+<HARD-RULE id="ac-completeness-gate">
+**PO Round 1 輸出 AC 完整性硬性規則：每個 Story 至少包含 1 條 AC 草稿。**
+
+| 情況 | 處置 |
+|------|------|
+| Story Issue body 包含至少 1 條明確 AC（非「AC 待補」或空白）| 允許進入 Sprint |
+| Story Issue body AC 為空、或僅含「AC 待補」、或 AC 欄位不存在 | PO Round 1 輸出標記「**AC 缺失**」，不得進入 Sprint；PO 必須先補充 AC 後重新評估 |
+
+**目的**：防止 PO Round 1 輸出空 AC，導致 QA 在 Round 3 全部打回 NEEDS_REVISION，增加多輪溝通摩擦（Sprint 131 Problem 1 歷史案例：#388/#386 PO Round 1 AC 全空，QA 打回 4/4 NEEDS_REVISION）。
+
+**成功指標**：下個 Sprint（Sprint 133）PO Round 1 的 AC 通過率 >= 75%（4 Story 中最多 1 個需補充）。
+</HARD-RULE>
+
+---
+
 ## PO Round 2：Sprint 文件產出與最終確認
 
 ### 職責


### PR DESCRIPTION
## Summary

- 在 po-prompt.md 加入 HARD-RULE id="ac-completeness-gate"
- 規定每個 Story 進入 Sprint 前必須包含至少 1 條 AC 草稿
- AC 缺失則標記「AC 缺失」不得進入 Sprint

## 來源

Sprint 131 Retro Problem 1（#388/#386 PO Round 1 AC 全空）

## AC 驗收

- [x] AC1: po-prompt.md 已更新，硬性 Gate 明確
- [x] AC2: 成功指標記錄在文件中（Sprint 133 通過率 >= 75%）
- [x] AC3: version bump 隨 #564 統一執行

Closes #563