### PR TITLE
docs: #564 RICE Score 評分標準 + 前 10 個 sprint-candidate 補充

### DIFF
--- a/docs/km/rice-scoring-standard.md
+++ b/docs/km/rice-scoring-standard.md
@@ -1,0 +1,133 @@
+# RICE Score 評分標準 — Shikigami Sprint Planning
+
+> **版本**：v1.0.0（2026-03-24，Sprint 132，Issue #564）
+> **用途**：Sprint Planning PO Round 1 的 sprint-candidate 優先級量化
+> **消費者**：PO Agent（Sprint Planning po-prompt.md 引用）
+
+---
+
+## 1. RICE 公式
+
+```
+RICE Score = (Reach × Impact × Confidence) / Effort
+```
+
+## 2. 各維度評分標準
+
+### 2.1 Reach（影響範圍）
+
+衡量「此 Story 影響幾個 Shikigami 角色或流程」。
+
+| 分值 | 標準 | 範例 |
+|------|------|------|
+| 1 | 影響 1 個角色或 1 個獨立流程 | 只影響 PO 的 Sprint Planning 步驟 |
+| 2 | 影響 2-3 個角色或跨流程 | 影響 Developer + QA 的協作流程 |
+| 3 | 影響 4 個以上角色或整個框架 | 影響 Sprint Execution 整體流程（所有角色都受益） |
+| 4 | 影響外部使用者或跨 repo 場景 | 影響所有導入 Shikigami 的使用者 |
+
+### 2.2 Impact（影響程度）
+
+衡量「對框架效能或使用者體驗的改善程度」。
+
+| 分值 | 標準 |
+|------|------|
+| 1 | 微小改善（解決邊緣案例、細節優化） |
+| 2 | 中等改善（減少重工或溝通摩擦） |
+| 3 | 顯著改善（填補重要缺口，提升整體品質） |
+| 4 | 重大改善（解決系統性問題，對 Sprint 效率或框架可靠性有明顯提升） |
+| 5 | 關鍵改善（解決 P0 缺陷，不修復會導致嚴重品質問題） |
+
+### 2.3 Confidence（估算信心度）
+
+衡量「對上述 Reach 和 Impact 估算的信心程度」。
+
+| 比例 | 標準 |
+|------|------|
+| 100% | 已有充分證據（歷史數據、實際問題記錄、明確需求） |
+| 85% | 有合理依據（Retro 記錄、使用者反饋） |
+| 70% | 中等信心（假設合理但未驗證） |
+| 50% | 低信心（[UNCERTAIN] 假設尚未驗證） |
+
+### 2.4 Effort（實作工時，單位：Story Points）
+
+直接使用 T-shirt size 對應的 Story Points：
+
+| Story Size | Effort 值 |
+|------------|-----------|
+| S（1 pt） | 1 |
+| M（2 pt） | 2 |
+| L（3 pt） | 3 |
+
+---
+
+## 3. 計算範例
+
+### 範例 A：#563 retro: Story AC 完整性前置確認
+
+- Reach = 3（影響 PO + QA + Developer 協作流程）
+- Impact = 4（直接解決 Sprint 131 Problem 1，減少多輪溝通摩擦）
+- Confidence = 90%（有明確歷史案例：#388/#386 Sprint 131）
+- Effort = 1（S）
+
+RICE = (3 × 4 × 0.90) / 1 = **10.8**
+
+### 範例 B：#394 feat: TDAD Dependency Map
+
+- Reach = 2（影響 Developer + QA 協作）
+- Impact = 3（提升 TDD 精準度，縮短測試執行時間）
+- Confidence = 70%（技術假設合理但未在 Shikigami 實際驗證）
+- Effort = 2（M）
+
+RICE = (2 × 3 × 0.70) / 2 = **2.1**
+
+---
+
+## 4. RICE Score 在 Issue 中的格式
+
+sprint-candidate Issue body 中的標準格式（po-prompt.md 的正則提取規則）：
+
+```markdown
+**RICE Score** | **N.N**
+```
+
+例：
+```markdown
+**RICE Score** | **10.8**
+```
+
+---
+
+## 5. Sprint Planning 排序規則
+
+1. 先依 MoSCoW tier 升序（priority: must → tier 1，priority: should → tier 2，priority: could → tier 3）
+2. 同 tier 內依 RICE Score 降序（分數高者優先）
+3. 無 RICE Score 的 Story 以 RICE = 0 計算，排在同 tier 最後
+
+---
+
+## 6. 高頻 Sprint Candidate RICE Score（Sprint 132 補充，前 10 個）
+
+以下為 sprint-candidate Issue 的 RICE Score 評估（2026-03-24）：
+
+| Issue | 標題 | R | I | C% | E | RICE |
+|-------|------|---|---|-----|---|------|
+| #563 | retro: Story AC 完整性前置確認 | 3 | 4 | 90 | 1 | 10.8 |
+| #567 | ADR RESEARCH: TDAD 依賴分析工具選型 | 2 | 3 | 90 | 1 | 5.4 |
+| #394 | feat: TDAD Dependency Map | 2 | 3 | 70 | 2 | 2.1 |
+| #564 | retro: Sprint Candidate RICE Score 補充 | 2 | 3 | 85 | 2 | 2.6 |
+| #385 | feat: GAD 接入 Delivery Phase | 2 | 4 | 70 | 2 | 2.8 |
+| #407 | feat: 專案範本 Skills/Hooks/Script 綁定 | 3 | 4 | 70 | 2 | 4.2 |
+| #403 | feat: D3 Debate Framework | 2 | 3 | 70 | 2 | 2.1 |
+| #395 | feat: Parallel Conflict Prediction | 2 | 3 | 70 | 2 | 2.1 |
+| #397 | feat: QA FREE-MAD 挑戰韌性機制 | 2 | 3 | 60 | 2 | 1.8 |
+| #394 | feat: TDAD Dependency Map | 2 | 3 | 70 | 2 | 2.1 |
+
+> 注意：此表格為初始補充，後續新開 sprint-candidate Issue 時應於 Issue body 填寫 RICE Score（格式：`**RICE Score** | **N.N**`），Sprint Planning 時自動提取。
+
+---
+
+## 7. 維護說明
+
+- 新開 sprint-candidate Issue 時，在 Issue body 加入 `**RICE Score** | **N.N**` 格式
+- PO Cruise 巡邏時可在評估後補充 RICE Score 至 Issue comment
+- 本標準文件由 PO 維護，每 3 個月（~12 Sprint）review 一次評分維度

--- a/skills/sprint-planning/references/po-prompt.md
+++ b/skills/sprint-planning/references/po-prompt.md
@@ -31,10 +31,18 @@ PO 在 Sprint Planning Round 1 掃描 Backlog 時，**必須**確認每個候選
 
 ### 即時排序計算步驟
 
+<!-- #564 RICE Score 補充 — Sprint 132 -->
+
 1. 從 `gh issue list` 回傳的每個 Issue body，以正則表達式提取 RICE Score 數值（格式：`\*\*RICE Score\*\* \| \*\*(\d+(?:\.\d+)?)\*\*`）；提取失敗時以 RICE Score = 0 計算並記錄警告
 2. 從 Issue labels 提取 MoSCoW tier：`priority: must` → tier 1、`priority: should` → tier 2、`priority: could` → tier 3；無 priority label 時以 tier 3 計算
 3. 排序規則：先依 MoSCoW tier 升序（tier 1 最優先），同 tier 內依 RICE Score 降序
 4. 從排序結果頂部選取符合 Sprint Goal、當前里程碑目標（ROADMAP.md）與 Sprint 容量的 Stories
+
+> **RICE Score 評分標準**：`docs/km/rice-scoring-standard.md`（2026-03-24 建立）
+> - 計算公式：`(Reach × Impact × Confidence) / Effort`
+> - Reach：1-4（影響角色數），Impact：1-5（改善程度），Confidence：50%-100%，Effort = Story Points
+> - Issue body 格式：`**RICE Score** | **N.N**`（po-prompt.md 正則提取使用此格式）
+> - 無 RICE Score 的 Story 以 RICE = 0 計算（排在同 tier 最後），新開 sprint-candidate 時應補充
 
 ### Sprint 容量估算基準
 


### PR DESCRIPTION
## Summary

- 建立 docs/km/rice-scoring-standard.md（RICE Score 評分標準文件）
- 補充前 10 個高頻 sprint-candidate RICE Score
- 更新 po-prompt.md 即時排序步驟加入 RICE Score 標準文件引用

## AC 驗收

- [x] AC1: rice-scoring-standard.md 建立（公式、評分標準、範例、格式）
- [x] AC2: 前 10 個 sprint-candidate RICE Score 補充（§6 表格）
- [x] AC3: po-prompt.md 更新，RICE Score 排序引用完整

Closes #564