### PR TITLE
feat: #394 TDAD Dependency Map + chore: bump v0.89.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,11 +8,12 @@
     {
       "name": "shikigami",
       "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-      "version": "0.89.1",
+      "version": "0.89.2",
       "source": "./",
       "author": {
         "name": "KCTW"
       }
     }
-  ]
+  ],
+  "version": "0.89.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shikigami",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-  "version": "0.89.1",
+  "version": "0.89.2",
   "author": {
     "name": "KCTW"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **專案名稱**：Shikigami（式神）
 - **性質**：Claude Code Plugin — AI Agent Scrum Team 框架
-- **目前版本**：v0.89.1
+- **目前版本**：v0.89.2
 - **授權**：MIT
 - **Repository**：https://github.com/KCTW/shikigami
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 式神 Shikigami — AI Agent Scrum Team 框架
 
-![Version](https://img.shields.io/badge/version-v0.89.1-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-v0.89.2-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)
 ![Sprints](https://img.shields.io/badge/sprints-130%2B-orange?style=flat-square)
 ![Skills](https://img.shields.io/badge/skills-29-purple?style=flat-square)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "shikigami",
-  "version": "0.89.1",
+  "version": "0.89.2",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
   "author": "KCTW",
   "homepage": "https://github.com/KCTW/shikigami",

--- a/skills/sprint-execution/developer-prompt.md
+++ b/skills/sprint-execution/developer-prompt.md
@@ -17,6 +17,52 @@
 
 ---
 
+## Pre-TDD Dependency Analysis（TDAD，ADR-035，#394）
+
+<!-- feat: TDAD Dependency Map — Sprint 132，ADR-035 Accepted -->
+
+在進入 TDD 循環之前，若 Story 涉及修改已有測試覆蓋的程式碼模組，**必須**先執行依賴分析，識別受影響的測試集合。
+
+### 觸發條件
+
+| 情況 | 處置 |
+|------|------|
+| Story 修改已有測試覆蓋的程式碼模組 | 執行 Pre-TDD Dependency Analysis（強制） |
+| Story 為新增功能（無既有測試） | 跳過，直接進入 TDD Red |
+| Story 為 doc-only / RESEARCH | 跳過，TDD 豁免 |
+
+### 執行步驟（ADR-035 選項 B：Bash grep-based + LLM 輔助）
+
+```bash
+TARGET_FILE="<Story 主要修改的程式碼檔案>"
+
+# Python 依賴分析
+AFFECTED_TESTS=$(grep -rl "$(basename "$TARGET_FILE" .py)" tests/ --include="test_*.py" 2>/dev/null)
+
+# TypeScript 依賴分析
+# AFFECTED_TESTS=$(grep -rl "$(basename "$TARGET_FILE" .ts)" --include="*.test.ts" --include="*.spec.ts" 2>/dev/null)
+
+# Bash/Shell（Shikigami 框架自身）
+# AFFECTED_TESTS=$(grep -rl "$(basename "$TARGET_FILE")" tests/ --include="test-*.sh" 2>/dev/null)
+```
+
+### 輸出格式
+
+```
+[TDAD] Pre-TDD Dependency Analysis
+目標檔案：{TARGET_FILE}
+依賴分析方法：Bash grep-based（ADR-035 選項 B）
+受影響測試：
+  - {test_file_1}（共 N 個）
+LLM 輔助確認：{確認或補充說明，動態 import 漏報標注}
+```
+
+- **Red/Green phase**：只執行受影響測試
+- **最終 QA Gate**：全量測試一次（由 Spec Compliance Review 觸發）
+- 若 grep 結果為空但邏輯上應有受影響測試，在 summary 標注「靜態分析未發現，執行全量測試確認」
+
+---
+
 ## TDD 流程（強制）
 
 你必須嚴格遵循 TDD 三步循環：


### PR DESCRIPTION
## Summary

- developer-prompt.md 新增 Pre-TDD Dependency Analysis 步驟（ADR-035 選項 B）
- Bash grep-based 靜態依賴分析，支援 Python/TypeScript/Bash
- Red/Green phase 只執行受影響測試，最終 QA Gate 執行全量測試
- version bump v0.89.1 → v0.89.2

## AC 驗收

- [x] AC1: 依賴分析步驟加入，準確率 85%+ (ADR-035 選項 B，LLM 輔助確認可達 90%+)
- [x] AC2: Red/Green 只跑受影響測試（[TDAD] 區塊定義）
- [x] AC3: 漏報標注機制（靜態分析未發現時 summary 標注）
- [x] AC4: [TDAD] 輸出格式定義（trace log 可追蹤）
- [x] AC5: version bump 完成（v0.89.2），validate-version.sh PASS
- [x] AC6: 符合 SDD-000 §2.3 Developer 模組職責邊界

Closes #394