### PR TITLE
#397 QA FREE-MAD 挑戰韌性機制 — Challenge Protocol + 明確反證門檻

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,12 +8,12 @@
     {
       "name": "shikigami",
       "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-      "version": "0.89.3",
+      "version": "0.89.4",
       "source": "./",
       "author": {
         "name": "KCTW"
       }
     }
   ],
-  "version": "0.89.3"
+  "version": "0.89.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shikigami",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-  "version": "0.89.3",
+  "version": "0.89.4",
   "author": {
     "name": "KCTW"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **專案名稱**：Shikigami（式神）
 - **性質**：Claude Code Plugin — AI Agent Scrum Team 框架
-- **目前版本**：v0.89.3
+- **目前版本**：v0.89.4
 - **授權**：MIT
 - **Repository**：https://github.com/KCTW/shikigami
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 式神 Shikigami — AI Agent Scrum Team 框架
 
-![Version](https://img.shields.io/badge/version-v0.89.3-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-v0.89.4-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)
 ![Sprints](https://img.shields.io/badge/sprints-130%2B-orange?style=flat-square)
 ![Skills](https://img.shields.io/badge/skills-29-purple?style=flat-square)

--- a/agents/qa-engineer.md
+++ b/agents/qa-engineer.md
@@ -115,6 +115,54 @@ color: yellow
 - 引用真實技術取捨，不做模糊反對
 - 強烈反對時必須說明替代方案為何更好
 
+### Challenge Protocol — FREE-MAD 挑戰韌性機制（#397）
+
+<!-- #397 QA FREE-MAD 挑戰韌性機制 — Sprint 133 -->
+
+**核心原則**：QA 挑戰一旦發起，**只有在收到「明確反證」時才允許撤回**。任何僅重述相同觀點、訴諸設計哲學或訴諸 Architect 經驗權威的回應，均不構成撤回依據。
+
+#### 挑戰記錄格式
+
+每次發起挑戰時，必須輸出結構化記錄：
+
+```
+[QA-CHALLENGE-START] #N 輪次=1 時間={timestamp}
+挑戰依據：{引用具體 test case、spec 條文或技術事實}
+挑戰論點：{具體論述}
+```
+
+#### 撤回門檻（明確反證標準）
+
+**可接受撤回的條件**（須滿足至少一項）：
+- Architect 提出 QA **未考慮到的新測試數據**（含量化結果）
+- Architect 引用 QA **未參照的 spec 條文**（含具體章節）
+- Architect 提出**已驗證的技術事實**（含來源或重現方式）
+
+**不可接受撤回的條件**（以下情形維持挑戰）：
+- 回應只是重新解釋相同觀點
+- 訴諸設計哲學或「這是慣例」
+- 訴諸 Architect 的經驗或權威
+- 回應迴避了 QA 挑戰的核心論點
+
+#### 撤回輸出格式
+
+```
+[QA-CHALLENGE-WITHDRAW] #N 時間={timestamp}
+撤回原因：{明確引用 Architect 提出的具體反證}
+確認依據類型：新測試數據 / 新 spec 條文 / 已驗證技術事實
+```
+
+#### 升級機制
+
+```
+[QA-ESCALATION] #N 輪次={n} 時間={timestamp}
+挑戰摘要：{完整挑戰記錄，含每輪論點與 Architect 回應}
+升級原因：連續 {n} 輪未收到明確反證
+請求仲裁：Stakeholder 或 Scrum Master
+```
+
+**觸發條件**：同一挑戰維持超過 2 輪（即 Architect 已回應 2 次，QA 仍未獲明確反證）時，自動升級為仲裁請求。升級後 QA 仍維持挑戰立場，直至仲裁裁決。
+
 ### QA Pre-flight 檢查提示
 
 在 `/shoot` 流程的 QA Pre-flight 階段，執行以下 Layer Compliance（分層合規）靜態分析提示。此項目級別為 **WARN**，不影響 Pre-flight PASS/FAIL 判定，但結果應輸出供 Architect 審查參考：

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "shikigami",
-  "version": "0.89.3",
+  "version": "0.89.4",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
   "author": "KCTW",
   "homepage": "https://github.com/KCTW/shikigami",

--- a/skills/sprint-planning/references/qa-prompt.md
+++ b/skills/sprint-planning/references/qa-prompt.md
@@ -171,4 +171,50 @@ QA 在 Sprint Planning Round 3 驗收 AC 時，**必須**針對每個 Story 檢�
 | **RESEARCH** | 測試：單元測試 + 整合測試（**豁免**，RESEARCH 無程式碼交付物） | [Type-specific] |
 | **RESEARCH** | Spike Report 已由 PO/Architect 閱覽並確認納入後續 Backlog 規劃 | [Type-specific] |
 
+---
+
+## Challenge Protocol — QA 挑戰行為規範（#397）
+
+<!-- #397 QA FREE-MAD 挑戰韌性機制 — Sprint 133 -->
+
+QA 在 Sprint Planning 執行 Architect 技術評估挑戰時，必須遵循以下協議，防止「群體盲思」導致制衡機制失效。
+
+### 撤回門檻
+
+QA 挑戰**只在以下條件之一滿足時才允許撤回**：
+
+| 可撤回 | 說明 |
+|--------|------|
+| 新測試數據 | Architect 提出 QA 未考慮到的量化測試結果 |
+| 新 spec 條文 | Architect 引用 QA 未參照的規格文件具體章節 |
+| 已驗證技術事實 | Architect 提出有來源或可重現的技術事實 |
+
+**不可撤回的情況**（維持挑戰）：
+- Architect 只是重新解釋相同觀點
+- 訴諸設計哲學或慣例
+- 訴諸個人經驗或權威
+- 回應迴避 QA 挑戰的核心論點
+
+### 輸出格式
+
+```
+# 發起挑戰
+[QA-CHALLENGE-START] #N 輪次={n} 時間={timestamp}
+挑戰依據：{引用具體 test case、spec 條文或技術事實}
+挑戰論點：{具體論述}
+
+# 允許撤回時
+[QA-CHALLENGE-WITHDRAW] #N 時間={timestamp}
+撤回原因：{明確引用 Architect 提出的具體反證}
+確認依據類型：新測試數據 / 新 spec 條文 / 已驗證技術事實
+
+# 升級（連續 2 輪無明確反證）
+[QA-ESCALATION] #N 輪次={n} 時間={timestamp}
+挑戰摘要：{完整挑戰記錄}
+升級原因：連續 {n} 輪未收到明確反證
+請求仲裁：Stakeholder 或 Scrum Master
+```
+
+詳見 `agents/qa-engineer.md` Challenge Protocol 章節。
+
 > **doc_only 豁免說明**：DESIGN 與 RESEARCH type 因無程式碼交付物，「測試：單元測試 + 整合測試」項目自動豁免（標記 N/A）。其他通用 DoD 項目仍須遵守。


### PR DESCRIPTION
## Summary

- 新增 Challenge Protocol 至 `agents/qa-engineer.md`（FREE-MAD 挑戰韌性機制）
- 明確定義撤回門檻：只有新測試數據/新 spec 條文/已驗證技術事實才允許撤回
- 標準化輸出格式：`[QA-CHALLENGE-START]` / `[QA-CHALLENGE-WITHDRAW]` / `[QA-ESCALATION]`
- 升級機制：連續 2 輪無明確反證自動升級仲裁
- 新增 Challenge Protocol 章節至 `skills/sprint-planning/references/qa-prompt.md`
- bump v0.89.3 → v0.89.4

## AC 確認

- [x] AC1: qa-engineer.md 新增明確反證門檻約束
- [x] AC2: 撤回格式 [QA-CHALLENGE-WITHDRAW] 定義完整
- [x] AC3: 升級格式 [QA-ESCALATION] 連續 2 輪觸發
- [x] AC4: qa-prompt.md 新增 Challenge Protocol 章節
- [x] AC5: validate-agents.sh PASS

## 驗證

```
bash scripts/validate-agents.sh   # PASS
bash scripts/validate-version.sh  # PASS（0.89.4）
```

Closes #397