### PR TITLE
#407 專案範本 — Skills/Hooks/Script 綁定（templates/project/）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,12 +8,12 @@
     {
       "name": "shikigami",
       "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-      "version": "0.89.4",
+      "version": "0.89.5",
       "source": "./",
       "author": {
         "name": "KCTW"
       }
     }
   ],
-  "version": "0.89.4"
+  "version": "0.89.5"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shikigami",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-  "version": "0.89.4",
+  "version": "0.89.5",
   "author": {
     "name": "KCTW"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **專案名稱**：Shikigami（式神）
 - **性質**：Claude Code Plugin — AI Agent Scrum Team 框架
-- **目前版本**：v0.89.4
+- **目前版本**：v0.89.5
 - **授權**：MIT
 - **Repository**：https://github.com/KCTW/shikigami
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 式神 Shikigami — AI Agent Scrum Team 框架
 
-![Version](https://img.shields.io/badge/version-v0.89.4-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-v0.89.5-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)
 ![Sprints](https://img.shields.io/badge/sprints-130%2B-orange?style=flat-square)
 ![Skills](https://img.shields.io/badge/skills-29-purple?style=flat-square)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "shikigami",
-  "version": "0.89.4",
+  "version": "0.89.5",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
   "author": "KCTW",
   "homepage": "https://github.com/KCTW/shikigami",

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -1,0 +1,61 @@
+# Shikigami 專案範本
+
+本範本提供使用 Shikigami AI Agent Scrum Team 框架的快速啟動配置。
+
+## 快速開始
+
+在新專案目錄執行以下指令，5 分鐘內完成初始化：
+
+```bash
+# 1. 複製範本到新專案
+cp -r path/to/shikigami/templates/project/. ./
+
+# 2. 初始化 Shikigami 配置
+bash scripts/init-project.sh
+
+# 3. 驗證配置完整性
+bash scripts/validate-json.sh
+bash scripts/validate-skills.sh
+```
+
+## 範本內容
+
+```
+templates/project/
+├── README.md              # 本文件
+├── hooks.json             # 預設 Hook 配置（SessionStart / SessionEnd / Stop）
+├── skills/                # 推薦 Skill 清單（符號連結說明）
+│   └── README.md          # Skill 連結設定指引
+└── scripts/               # 常用腳本範本
+    └── init-project.sh    # 一鍵初始化腳本
+```
+
+## 配置說明
+
+### hooks.json
+
+預設 Hook 配置包含：
+- `SessionStart`：session 啟動時執行 session-start hook（日誌、出勤紀錄）
+- `SessionEnd`：session 結束時 release claim 鎖
+- `Stop`：緊急停止處理
+
+複製到專案根目錄後修改 `CLAUDE_PLUGIN_ROOT` 指向實際 Shikigami 安裝路徑。
+
+### skills/ 目錄
+
+建議透過符號連結使用 Shikigami 官方 Skills，確保版本同步更新：
+
+```bash
+# 建立 skill 符號連結（以 sprint-planning 為例）
+ln -s path/to/shikigami/skills/sprint-planning skills/sprint-planning
+```
+
+### 版本同步
+
+範本與 Shikigami 主框架版本保持同步。版本 bump 時一同更新。
+
+## 相關文件
+
+- [Shikigami 框架 CLAUDE.md](../../CLAUDE.md)
+- [Hook 配置說明](../../hooks/)
+- [Skills 目錄](../../skills/)

--- a/templates/project/hooks.json
+++ b/templates/project/hooks.json
@@ -1,0 +1,76 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-start",
+            "async": false
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/session-end-release.sh'",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "檢查你剛才的回應：如果 .claude/shikigami.local.md 中 project_level 為 low，你的回應不應包含任何確認性問句（如「還是」「要不要」「是否」「嗎？」「shall I」「should I」等）。如果包含了，請移除確認語句並改為陳述句直接執行。project_level=low 代表全自動模式，禁止停下來等使用者回覆。"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "WebSearch|WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/exploration-record.sh'",
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'if echo \"$CLAUDE_TOOL_INPUT\" | grep -qP \"git\\s+commit\"; then REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); VALIDATE_SCRIPT=\"$REPO_ROOT/scripts/validate-version.sh\"; if [ -f \"$VALIDATE_SCRIPT\" ]; then if ! bash \"$VALIDATE_SCRIPT\" > /dev/null 2>&1; then echo \"[US-264 警告] 版號不一致！請先執行 bash scripts/validate-version.sh 修正版號後再 commit。\"; fi; fi; fi'"
+          },
+          {
+            "type": "command",
+            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/protect-main.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/pr-merge-gate.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/branch-gate.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/push-main-gate.sh'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/templates/project/scripts/init-project.sh
+++ b/templates/project/scripts/init-project.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# init-project.sh — Shikigami 專案快速初始化腳本
+# 使用方式：bash scripts/init-project.sh [SHIKIGAMI_ROOT]
+# 來源：templates/project/scripts/init-project.sh
+
+set -euo pipefail
+
+SHIKIGAMI_ROOT="${1:-$(dirname "$0")/../../..}"
+PROJECT_ROOT="$(pwd)"
+
+echo "==============================="
+echo " Shikigami 專案初始化"
+echo "==============================="
+echo "Shikigami 路徑：${SHIKIGAMI_ROOT}"
+echo "專案路徑：${PROJECT_ROOT}"
+echo ""
+
+# 步驟 1：複製 hooks.json
+if [ ! -f "${PROJECT_ROOT}/hooks.json" ]; then
+    cp "${SHIKIGAMI_ROOT}/templates/project/hooks.json" "${PROJECT_ROOT}/hooks.json"
+    echo "[OK] hooks.json 已複製"
+else
+    echo "[SKIP] hooks.json 已存在，跳過"
+fi
+
+# 步驟 2：建立 skills/ 目錄與符號連結
+mkdir -p "${PROJECT_ROOT}/skills"
+for skill in sprint-planning sprint-execution sprint-review shoot health-check issue-management; do
+    if [ -d "${SHIKIGAMI_ROOT}/skills/${skill}" ]; then
+        if [ ! -L "${PROJECT_ROOT}/skills/${skill}" ]; then
+            ln -s "${SHIKIGAMI_ROOT}/skills/${skill}" "${PROJECT_ROOT}/skills/${skill}"
+            echo "[OK] 建立 skills/${skill} 符號連結"
+        else
+            echo "[SKIP] skills/${skill} 符號連結已存在"
+        fi
+    else
+        echo "[WARN] skills/${skill} 在 Shikigami 路徑中不存在，跳過"
+    fi
+done
+
+# 步驟 3：複製 CLAUDE.md.template（若不存在）
+if [ ! -f "${PROJECT_ROOT}/.claude/CLAUDE.md" ] && [ ! -f "${PROJECT_ROOT}/CLAUDE.md" ]; then
+    mkdir -p "${PROJECT_ROOT}/.claude"
+    cp "${SHIKIGAMI_ROOT}/templates/CLAUDE.md.template" "${PROJECT_ROOT}/CLAUDE.md"
+    echo "[OK] CLAUDE.md 已從範本複製"
+else
+    echo "[SKIP] CLAUDE.md 已存在，跳過"
+fi
+
+echo ""
+echo "==============================="
+echo " 初始化完成，驗證配置..."
+echo "==============================="
+
+# 步驟 4：驗證
+VALIDATE_OK=true
+if [ -f "${PROJECT_ROOT}/scripts/validate-json.sh" ]; then
+    bash "${PROJECT_ROOT}/scripts/validate-json.sh" && echo "[PASS] validate-json.sh" || { echo "[FAIL] validate-json.sh"; VALIDATE_OK=false; }
+fi
+
+if [ "$VALIDATE_OK" = "true" ]; then
+    echo ""
+    echo "[完成] 專案初始化成功！"
+    echo "下一步：設定 .claude/shikigami.local.md 中的 project_level 和其他配置"
+else
+    echo ""
+    echo "[警告] 部分驗證失敗，請手動修正後重新執行驗證腳本"
+fi

--- a/templates/project/skills/README.md
+++ b/templates/project/skills/README.md
@@ -1,0 +1,35 @@
+# Skills 連結設定指引
+
+## 推薦做法：符號連結
+
+透過符號連結使用 Shikigami 官方 Skills，確保版本同步更新：
+
+```bash
+# 設定 SHIKIGAMI_ROOT 為 Shikigami 安裝路徑
+SHIKIGAMI_ROOT=path/to/shikigami
+
+# 建立核心 Skill 符號連結
+ln -s ${SHIKIGAMI_ROOT}/skills/sprint-planning      skills/sprint-planning
+ln -s ${SHIKIGAMI_ROOT}/skills/sprint-execution     skills/sprint-execution
+ln -s ${SHIKIGAMI_ROOT}/skills/sprint-review        skills/sprint-review
+ln -s ${SHIKIGAMI_ROOT}/skills/shoot                skills/shoot
+ln -s ${SHIKIGAMI_ROOT}/skills/health-check         skills/health-check
+ln -s ${SHIKIGAMI_ROOT}/skills/issue-management     skills/issue-management
+ln -s ${SHIKIGAMI_ROOT}/skills/cruise               skills/cruise
+```
+
+## 推薦 Skill 清單（最小集合）
+
+| Skill | 用途 | 必要性 |
+|-------|------|--------|
+| sprint-planning | Sprint 週期起點，Backlog 排序與 Story 選取 | 必要 |
+| sprint-execution | Story 開發執行，TDD + 審查 + PR | 必要 |
+| sprint-review | Sprint 驗收與 Retro | 必要 |
+| shoot | 快速單一 Story 交付 | 建議 |
+| health-check | 框架完整性自我診斷 | 建議 |
+| issue-management | Issue 生命週期管理 | 建議 |
+| cruise | 定期 PO 巡邏 + 背景監控 | 可選 |
+
+## 版本同步
+
+Skills 透過符號連結指向 Shikigami 安裝目錄，版本 bump 時自動同步，無需手動更新。


### PR DESCRIPTION
## Summary

- 新建 `templates/project/` 目錄，提供 Shikigami 新專案快速啟動範本
- `README.md`：Getting Started 說明，一個 `bash scripts/init-project.sh` 指令完成初始化
- `hooks.json`：預設 Hook 配置（SessionStart/SessionEnd/Stop/PreToolUse）
- `skills/README.md`：Skill 符號連結設定指引（7 個核心 Skill）
- `scripts/init-project.sh`：一鍵初始化腳本
- bump v0.89.3 → v0.89.5

## AC 確認

- [x] AC1: templates/project/ 含 hooks.json + skills/README.md + scripts/init-project.sh
- [x] AC2: README.md 有一個 bash 指令完成初始化說明
- [x] AC3: hooks.json JSON 格式正確，與現有 hooks/ 結構一致
- [x] AC4: validate-skills.sh PASS（29 Skill 無 orphan）

## 驗證

```
python3 -c "import json; json.load(open('templates/project/hooks.json'))"  # PASS
bash scripts/validate-skills.sh   # PASS
bash scripts/validate-version.sh  # PASS（0.89.5）
```

Closes #407