### PR TITLE
#385 GAD Delivery Phase — 雙 Team 視覺對比 Gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,12 +8,12 @@
     {
       "name": "shikigami",
       "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-      "version": "0.89.6",
+      "version": "0.89.7",
       "source": "./",
       "author": {
         "name": "KCTW"
       }
     }
   ],
-  "version": "0.89.6"
+  "version": "0.89.7"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shikigami",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-  "version": "0.89.6",
+  "version": "0.89.7",
   "author": {
     "name": "KCTW"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **專案名稱**：Shikigami（式神）
 - **性質**：Claude Code Plugin — AI Agent Scrum Team 框架
-- **目前版本**：v0.89.6
+- **目前版本**：v0.89.7
 - **授權**：MIT
 - **Repository**：https://github.com/KCTW/shikigami
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 式神 Shikigami — AI Agent Scrum Team 框架
 
-![Version](https://img.shields.io/badge/version-v0.89.6-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-v0.89.7-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)
 ![Sprints](https://img.shields.io/badge/sprints-130%2B-orange?style=flat-square)
 ![Skills](https://img.shields.io/badge/skills-29-purple?style=flat-square)

--- a/agents/qa-engineer.md
+++ b/agents/qa-engineer.md
@@ -230,3 +230,47 @@ color: yellow
 - D3 Advocate 論述階段結束後，進入 FREE-MAD 協議（#397）
 - QA 挑戰時需明確反證才可撤回（同 Challenge Protocol 標準）
 - D3 Deliberate 階段的 Architect（Jury）對 Advocate 論述提出交叉質詢，QA 依 FREE-MAD 韌性原則回應
+
+## Delivery Phase 視覺對比 Gate 操作（#385）
+
+<!-- #385 GAD Delivery Phase 視覺對比 Gate — Sprint 133 -->
+<!-- 依賴：ADR-034 browser-automation tool selection（Accepted，PR#560） -->
+
+在 Sprint Execution §4.7 視覺對比 Gate 觸發時，QA Engineer 擔任 **Agent B（Vision Critic）**，負責執行雙 Team 視覺對比並輸出結構化差異報告。
+
+### 操作步驟
+
+1. **截圖 Agent 實作**：
+   ```
+   agent-browser open {impl-url}
+   agent-browser screenshot /tmp/visual-gate/{story-id}-impl.png
+   ```
+
+2. **取得 Figma 設計截圖**：使用 `talk-to-figma` MCP 或 Figma Export 取得對應 Frame 截圖，存至 `/tmp/visual-gate/{story-id}-figma.png`
+
+3. **執行 Vision Critic 評分**：呼叫 `skills/vision-critic/SKILL.md` 進行分數評估（0-100）
+
+4. **輸出結構化差異報告**：
+
+```
+[VISUAL-GATE-REPORT] story={id} 時間={timestamp}
+截圖路徑：
+  - 實作：/tmp/visual-gate/{story-id}-impl.png
+  - 設計：/tmp/visual-gate/{story-id}-figma.png
+Vision Critic 分數：{score}/100
+差異項目：
+  - {差異描述 1}（元件：{名稱}，位置偏差：{px}）
+  - {差異描述 2}
+判定：PASS / FAIL
+```
+
+### 判定標準
+
+| 分數 | 判定 | 後續動作 |
+|------|------|---------|
+| ≥ 80 | PASS | 輸出 `[VISUAL-GATE-PASS]`，繼續 gh pr merge |
+| < 80 | FAIL | 輸出 `[VISUAL-GATE-FAIL]`，阻擋 merge，通知 Developer 修復 |
+
+**FAIL 時的錯誤訊息必須包含**（NFR1）：具體差異元件名稱、位置偏差量、顏色/尺寸不符項目，讓 Developer 能直接定位問題。
+
+**降級**：`agent-browser` 或 `talk-to-figma` 不可用時，輸出 `[VISUAL-GATE-DEGRADED]`，不阻擋 merge，PR description 標記「需人工視覺確認」。

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "shikigami",
-  "version": "0.89.6",
+  "version": "0.89.7",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
   "author": "KCTW",
   "homepage": "https://github.com/KCTW/shikigami",

--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -322,6 +322,47 @@ DESIGN Story 優先執行，依賴其 Contract 的 FEATURE Story 須等 Contract
 
 ---
 
+## 4.7 Delivery Phase 雙 Team 視覺對比 Gate（#385 / ADR-034）
+
+<!-- #385 GAD Delivery Phase 視覺對比 Gate — Sprint 133 -->
+<!-- 依賴：ADR-034 browser-automation tool selection（Accepted，PR#560） -->
+
+**適用條件**：Story 為 frontend FEATURE（AC 含有 Figma Prototype URL），Story-Lifecycle subagent 完成 Code Review 通過後、執行 `gh pr merge` 之前觸發。
+
+**跳過條件（AC5）**：後端 / Infra / DESIGN / RESEARCH Story 自動跳過（判斷：AC 或 issue body 中無 Figma Prototype URL）。跳過時輸出 `[VISUAL-GATE-SKIP] 非前端 Story，跳過視覺對比 Gate`。
+
+### 執行流程
+
+```
+[VISUAL-GATE-START] story={id} 時間={timestamp}
+
+1. 取得 Figma Prototype URL（從 issue body 或 DESIGN Contract）
+   |-- 找不到 URL → [VISUAL-GATE-SKIP] 跳過
+   |-- 找到 URL → 繼續
+
+2. Agent B（Vision Critic）執行雙 Team 視覺對比：
+   a. 截圖 Agent 實作結果（agent-browser screenshot）
+   b. 截圖 Figma Prototype（Figma Export / talk-to-figma）
+   c. 呼叫 skills/vision-critic/SKILL.md 執行分數評估
+
+3. 產出結構化差異報告（AC3）：
+   - 截圖路徑：/tmp/visual-gate/{story-id}-impl.png + {story-id}-figma.png
+   - Vision Critic 分數：{0-100}
+   - 差異項目清單：{具體差異描述}
+   - 判定：PASS（分數 ≥ 80）/ FAIL（分數 < 80）
+
+4. 判定結果（AC4）：
+   |-- PASS（Vision Critic ≥ 80） → [VISUAL-GATE-PASS] 繼續 gh pr merge
+   +-- FAIL（Vision Critic < 80） → [VISUAL-GATE-FAIL] 阻擋 merge
+         - 輸出具體差異描述（NFR1 要求：包含足夠資訊讓 Developer 定位問題）
+         - 差異報告含截圖對比路徑 + 量化分數（NFR2）
+         - 通知 Developer 修復後重新觸發
+```
+
+**降級（agent-browser 或 talk-to-figma 不可用）**：輸出 `[VISUAL-GATE-DEGRADED] 視覺對比工具不可用，降級為人工確認`，不阻擋 merge，但在 PR description 標記「需人工視覺確認」。
+
+---
+
 ## 5. Hard Gates
 
 <HARD-GATE>


### PR DESCRIPTION
## Summary

- 更新 `skills/sprint-execution/SKILL.md`：新增 §4.7 Delivery Phase 雙 Team 視覺對比 Gate（AC2）
  - 前端 FEATURE Story 在 Code Review 通過後、merge 前自動觸發
  - Vision Critic 分數 < 80 → FAIL，阻擋 merge（AC4）
  - 後端/Infra Story 自動跳過（無 Figma URL 判斷，AC5）
  - 降級模式：工具不可用時標記「需人工視覺確認」
- 更新 `agents/qa-engineer.md`：新增視覺對比 Gate 操作說明（Agent B 職責、結構化差異報告格式 AC3、PASS/FAIL 判定標準）
- Bump v0.89.6 → v0.89.7

## Acceptance Criteria

- [x] AC1: ADR-034 狀態已在 Sprint 133 Batch 0 修正為 Accepted（PR#560 補文件已完成）
- [x] AC2: `skills/sprint-execution/SKILL.md` §4.7 新增雙 Team 視覺對比 Gate 步驟
- [x] AC3: Agent B 輸出結構化差異報告（截圖路徑、Vision Critic 分數、PASS/FAIL）
- [x] AC4: Vision Critic < 80 → FAIL，明確輸出 `[VISUAL-GATE-FAIL]` + 差異描述，阻擋 merge
- [x] AC5: 後端/Infra Story 自動跳過（`[VISUAL-GATE-SKIP]` 輸出，判斷條件：無 Figma URL）
- [x] AC6: `bash scripts/validate-skills.sh` 通過（30 個 Skill）

## Test plan

- [ ] 確認 skills/sprint-execution/SKILL.md §4.7 段落存在且包含正確格式
- [ ] 確認 agents/qa-engineer.md 視覺對比 Gate 操作說明段落存在
- [ ] 確認 [VISUAL-GATE-PASS] / [VISUAL-GATE-FAIL] / [VISUAL-GATE-SKIP] 格式正確定義
- [ ] validate-skills.sh 全部通過（30 Skills）
- [ ] validate-agents.sh 全部通過（8 Agents）
- [ ] validate-version.sh 通過（v0.89.7 一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)