### PR TITLE
fix: #588 定義 LIVE_LOG_FILE 變數，修復 live-log 靜默失敗

### DIFF
--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -241,6 +241,17 @@ Trace 根 span 初始化（ADR-033）：`_TRACE_START_EPOCH="$(date '+%s')"`, `_
 
 ---
 
+### Live Log 初始化（#588）
+
+Story-Lifecycle subagent 啟動後，立即定義 live-log 輸出路徑：
+
+```bash
+LIVE_LOG_FILE="logs/live/$(date '+%Y-%m-%d')-session-${SHIKIGAMI_SESSION_ID:-unknown}.log"
+mkdir -p logs/live
+```
+
+---
+
 ## §3 TDD 開發流程（強制，doc_only=false 時）
 
 <HARD-GATE>

--- a/tests/test-588-live-log-file-var.sh
+++ b/tests/test-588-live-log-file-var.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# test-588-live-log-file-var.sh
+# AC3: 確認 story-lifecycle-prompt.md 含有 LIVE_LOG_FILE 變數定義
+
+set -euo pipefail
+
+FILE="skills/sprint-execution/story-lifecycle-prompt.md"
+PASS=0
+FAIL=0
+
+assert() {
+  local desc="$1"
+  local result="$2"
+  if [[ "$result" == "0" ]]; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc"
+    ((FAIL++)) || true
+  fi
+}
+
+# AC1: 確認 LIVE_LOG_FILE 定義存在
+grep -q 'LIVE_LOG_FILE="logs/live/\$(date' "$FILE"
+assert "AC1: LIVE_LOG_FILE 定義存在" "$?"
+
+# AC1: 確認 mkdir -p logs/live 存在
+grep -q 'mkdir -p logs/live' "$FILE"
+assert "AC1: mkdir -p logs/live 存在" "$?"
+
+# AC1: 確認使用 SHIKIGAMI_SESSION_ID:-unknown
+grep -q 'SHIKIGAMI_SESSION_ID:-unknown' "$FILE"
+assert "AC1: SHIKIGAMI_SESSION_ID:-unknown 存在" "$?"
+
+# AC2: 定義必須在第一個引用之前
+DEF_LINE=$(grep -n 'LIVE_LOG_FILE="logs/live/' "$FILE" | head -1 | cut -d: -f1)
+FIRST_REF_LINE=$(grep -n '>> "${LIVE_LOG_FILE}"' "$FILE" | head -1 | cut -d: -f1)
+
+if [[ -n "$DEF_LINE" && -n "$FIRST_REF_LINE" && "$DEF_LINE" -lt "$FIRST_REF_LINE" ]]; then
+  echo "PASS: AC2: 定義 (L${DEF_LINE}) 在第一個引用 (L${FIRST_REF_LINE}) 之前"
+  ((PASS++)) || true
+else
+  echo "FAIL: AC2: 定義 (L${DEF_LINE:-?}) 不在第一個引用 (L${FIRST_REF_LINE:-?}) 之前"
+  ((FAIL++)) || true
+fi
+
+echo ""
+echo "Results: PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- `story-lifecycle-prompt.md` 在 §3 TDD 之前加入 Live Log 初始化區塊（#588）
- 定義 `LIVE_LOG_FILE="logs/live/$(date '+%Y-%m-%d')-session-${SHIKIGAMI_SESSION_ID:-unknown}.log"`
- 加入 `mkdir -p logs/live` 確保目錄存在
- 定義位置 L249，在所有 `>> "${LIVE_LOG_FILE}"` 引用（L266/287/315）之前

## AC Status

- AC1: PASS — LIVE_LOG_FILE 定義存在，含 mkdir -p logs/live
- AC2: PASS — 定義 (L249) 在第一個引用 (L266) 之前
- AC3: PASS — 測試 `tests/test-588-live-log-file-var.sh` 全部通過（4/4）

## Test plan

- [x] `bash tests/test-588-live-log-file-var.sh` — PASS=4 FAIL=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)