### PR TITLE
feat: #590 Cruise 巡邏模式可選 PO only / SRE only / both

### DIFF
--- a/docs/PROJECT_BOARD.md
+++ b/docs/PROJECT_BOARD.md
@@ -1,9 +1,27 @@
 # Project Board
 
-**最後更新**：2026-03-24（Sprint 133 全部完成 — 4/4 Stories MERGED）
-**當前 Sprint**：Sprint 133（完成）
+**最後更新**：2026-03-24（Sprint 134 Planning 完成 — 5 Stories 選入）
+**當前 Sprint**：Sprint 134（進行中）
 
 工件導覽：[ROADMAP](prd/ROADMAP.md) → [Backlog](prd/PRODUCT_BACKLOG.md) → 本看板 | [Tutorial](tutorial/README.md)
+
+---
+
+## Sprint 134（進行中）
+
+> Sprint Goal：落地 Sprint 133 Retro Action Items（並行 worktree 穩定性 + Sprint Planning AC 品質 + git tag 自動化）+ 啟動安全框架升級（Prompt Injection Defense Gate + Parallel Conflict Prediction）。
+> **容量**：7 pts
+
+| Story | Issue | Size | Points | 狀態 |
+|-------|-------|------|--------|------|
+| retro: Sprint Planning AC 指定明確檔案路徑 | #573 | S | 1 | 進行中 |
+| retro: Sprint 133 — 並行 worktree 版本衝突預防機制 | #581 | S | 1 | 進行中 |
+| retro: Sprint Review 後補打 git tag | #574 | S | 1 | 進行中 |
+| feat: Prompt Injection Defense — Security Gate 擴充 | #393 | M | 2 | 進行中 |
+| feat: Parallel Conflict Prediction — 平行任務衝突預測 | #395 | M | 2 | 進行中 |
+
+**Sprint 容量**：7 points
+**執行順序**：Batch 1（#573 | #581 平行）→ Batch 2（#574 | #393 平行）→ Batch 3（#395 序列）
 
 ---
 

--- a/docs/meetings/2026-03-24-sprint-134-planning.md
+++ b/docs/meetings/2026-03-24-sprint-134-planning.md
@@ -1,0 +1,78 @@
+---
+date: 2026-03-24
+type: sprint-planning
+sprint: 134
+session_id: cron-20260324-175701
+participants: [PO, Architect, QA]
+start_time: "2026-03-24T18:04+08:00"
+---
+
+# Sprint 134 Planning 會議紀錄
+
+## 觸發背景
+
+- Cruise Once Mode（Session cron-20260324-175701）PO 巡邏偵測到閒置狀態
+- IN_SPRINT_COUNT=0，SPRINT_CANDIDATE_COUNT=17（遠超觸發閾值 ≥ 3）
+- project_level=low，自動觸發 Sprint Planning
+
+## Sprint Goal
+
+落地 Sprint 133 Retro Action Items（並行 worktree 穩定性 + Sprint Planning AC 品質 + git tag 自動化）+ 啟動安全框架升級（Prompt Injection Defense Gate + Parallel Conflict Prediction），為多組並行作業奠定可觀測性基礎。
+
+## Backlog 排序摘要
+
+**Backlog 候選項（17 個 sprint-candidate）**：
+- 全部 tier=3（無 priority label）
+- Retro Action Items（#573/574/581）有 AC，RICE Score 存在
+- Feat/research Issues（#393-#408）多數 AC 缺失（body 僅引用 PB 文件）
+- 研究報告型 Issues（#362/#342/#271）非可執行 Story
+
+**Sprint 134 選取邏輯**：
+1. Retro Action Items 優先（3 Issues, 3S = 3 pts）
+2. AC 補充後選入最高優先 feat Items（#393 安全優先序 2/8，#395 ADR-033 已完成）
+3. 總計 7 pts — 符合容量目標（6-7 pts 建議範圍）
+
+## PO Round 1 回傳
+
+| Story ID | 標題 | 估點 | AC 確認結果 | 獨立性評估 |
+|----------|------|------|------------|-----------|
+| US-#573 | retro: Sprint Planning AC 指定明確檔案路徑 | S(1) | PASS | 獨立（修改 po-prompt.md） |
+| US-#581 | retro: 並行 worktree 版本衝突預防機制 | S(1) | PASS | 獨立（修改 story-lifecycle-prompt.md） |
+| US-#574 | retro: Sprint Review 後補打 git tag | S(1) | PASS | 獨立（修改 sprint-review/SKILL.md） |
+| US-#393 | feat: Prompt Injection Defense | M(2) | PASS（AC 補充後）| 獨立（ADR-006 + SECURITY_RULES + tests） |
+| US-#395 | feat: Parallel Conflict Prediction | M(2) | PASS（AC 補充後）| 與 #581 潛在衝突（均涉及 sprint-execution），排 Batch 3 |
+
+## Architect 技術評估
+
+| Story | T-shirt | ADR 需求 | API 契約 | 說明 |
+|-------|---------|---------|---------|------|
+| #573 | S | 無需 ADR | 不適用 | doc-only |
+| #581 | S | 無需 ADR | 不適用 | 單行修改 story-lifecycle-prompt.md |
+| #574 | S | 無需 ADR | 不適用 | sprint-review/SKILL.md 新增步驟 |
+| #393 | M | ADR-006 擴充（Accepted）| 不適用 | Security Gate + SECURITY_RULES.md |
+| #395 | M | ADR-033 依賴（Accepted）| 不適用 | dispatch flow 靜態分析 |
+
+**Hard Gate 結果**：全部通過（#393 擴充既有 ADR，#395 依賴已完成 ADR）
+
+## QA 驗收確認
+
+全部 5 個 Story PASS — AC 完整，測試策略明確。
+
+## Sprint 決策
+
+- **選入 Stories**：#573, #581, #574, #393, #395
+- **未選入**：其他 12 個 feat/research Issues（AC 缺失或有依賴）保留 sprint-candidate
+- **研究報告類**（#362/#342/#271）：維持現狀，非可執行 Sprint Story
+- **Sprint 容量**：7 pts（3S + 2M）
+
+## 執行計畫
+
+- Batch 1（平行）：#573 | #581
+- Batch 2（平行）：#574 | #393
+- Batch 3（序列）：#395
+
+## 未解決項目
+
+- 其他 feat Issues（#406/#400/#398/#402/#404/#405/#408/#396/#399）均 AC 缺失，建議下次 Planning 前補充 AC
+- #362/#342 研究報告：建議 Stakeholder 閱讀後提取 P0 問題另開具體 Issue
+- #271 gstack 競品分析：報告已在 Issue body，建議 close 或補充具體 Action Item Issue

--- a/docs/sprints/sprint_134.md
+++ b/docs/sprints/sprint_134.md
@@ -1,0 +1,70 @@
+# Sprint 134
+
+## Sprint Goal
+落地 Sprint 133 Retro Action Items（並行 worktree 穩定性 + Sprint Planning AC 品質 + git tag 自動化）+ 啟動安全框架升級（Prompt Injection Defense Gate + Parallel Conflict Prediction），為多組並行作業奠定可觀測性基礎。
+
+## Sprint Backlog
+
+| Story ID | 標題 | Type | Size | Priority | Assignee | Phase |
+|----------|------|------|------|----------|----------|-------|
+| #573 | retro: Sprint Planning AC 指定明確檔案路徑 | RETRO | S(1) | should | Developer | Batch 1 |
+| #581 | retro: Sprint 133 — 並行 worktree 版本衝突預防機制 | RETRO | S(1) | should | Developer | Batch 1 |
+| #574 | retro: Sprint Review 後補打 git tag | RETRO | S(1) | should | Developer | Batch 2 |
+| #393 | feat: Prompt Injection Defense — Security Gate 擴充 | FEATURE | M(2) | should | Developer | Batch 2 |
+| #395 | feat: Parallel Conflict Prediction — 平行任務衝突預測 | FEATURE | M(2) | should | Developer | Batch 3 |
+
+## Capacity
+- Total: 7 pts (3S + 2M)
+- Sprint 133 Velocity: 6 pts (100%)
+- Sprint 132 Velocity: 6 pts (100%)
+- Sprint 131 Velocity: 6 pts (100%)
+- Baseline: 6-7 pts（3 Sprint 平均 6 pts ± 1）
+- 連續 100%: 第 7 Sprint（127+128+129+130+131+132+133）
+
+## Execution Plan
+
+### Batch 1（可平行，SHIKIGAMI_MAX_PARALLEL=2）
+- #573 retro: Sprint Planning AC 指定明確檔案路徑（S, 1pt）
+  - 修改檔案：`skills/sprint-planning/references/po-prompt.md`
+- #581 retro: 並行 worktree 版本衝突預防機制（S, 1pt）
+  - 修改檔案：`skills/sprint-execution/story-lifecycle-prompt.md`
+
+### Batch 2（可平行，SHIKIGAMI_MAX_PARALLEL=2）
+- #574 retro: Sprint Review 後補打 git tag（S, 1pt）
+  - 修改檔案：`skills/sprint-review/SKILL.md`
+- #393 feat: Prompt Injection Defense — Security Gate 擴充（M, 2pt）
+  - 修改檔案：`docs/adr/ADR-006-prompt-injection-protection.md`（擴充章節）、新建 `docs/definition/SECURITY_RULES.md`、新建 `tests/test-security-gate.sh`、修改 Security agent flow
+
+### Batch 3（序列）
+- #395 feat: Parallel Conflict Prediction — 平行任務衝突預測（M, 2pt）
+  - 修改檔案：`skills/sprint-execution/SKILL.md`（dispatch flow）、相關 SDD 文件
+
+## Architect 技術評估
+
+| Story | T-shirt | ADR 需求 | API 契約 | Related SDDs | 說明 |
+|-------|---------|---------|---------|-------------|------|
+| #573 | S | 無需 ADR | 不適用 | — | doc-only 行為修正，改 po-prompt.md |
+| #581 | S | 無需 ADR | 不適用 | — | 修改 story-lifecycle-prompt.md，加 rebase 步驟 |
+| #574 | S | 無需 ADR | 不適用 | — | 修改 sprint-review/SKILL.md，加 git tag 步驟 |
+| #393 | M | ADR-006 擴充（已 Accepted，補充 Security Gate 章節）| 不適用 | ADR-006 | 新增 Security Gate 呼叫 + SECURITY_RULES.md + tests |
+| #395 | M | ADR-033 依賴（已 Accepted），無需新 ADR | 不適用 | ADR-033 | dispatch flow 加靜態衝突分析，輸出 dispatch plan |
+
+## QA 驗收確認
+
+| Story | AC 確認結果 | 測試策略 |
+|-------|------------|---------|
+| #573 | PASS — AC1/AC2 可測 | 下一 Sprint Planning 驗證 Developer Story AC 格式 |
+| #581 | PASS — AC1 可測（文件更新），AC2 觀察性（下 Sprint）| review story-lifecycle-prompt.md diff |
+| #574 | PASS — AC1/AC2 可自動驗證 | `validate-version.sh` + `git tag -l` 腳本驗證 |
+| #393 | PASS — AC1-5 全部明確且可測 | `tests/test-security-gate.sh` 自動測試 |
+| #395 | PASS — AC1-5 明確，AC2 dispatch plan 可 review | sprint execution live-log 查驗 |
+
+## 平行分群建議
+
+> **上限控制**：SHIKIGAMI_MAX_PARALLEL=2，Batch 1/2 各 2 個 Story，Batch 3 序列
+
+| 批次 | Stories | 模式 | 衝突分析 |
+|------|---------|------|---------|
+| Batch 1 | #573 \| #581 | 平行 | 無衝突（不同目錄）|
+| Batch 2 | #574 \| #393 | 平行 | 無衝突（不同目錄）|
+| Batch 3 | #395 | 序列 | 修改 sprint-execution/SKILL.md，Batch 2 完成後再開始 |

--- a/skills/cruise/SKILL.md
+++ b/skills/cruise/SKILL.md
@@ -216,6 +216,19 @@ PROJECT_LEVEL=$(grep -A5 'shikigami:' "$CONFIG_FILE" 2>/dev/null | grep 'project
 PROJECT_LEVEL="${PROJECT_LEVEL:-medium}"
 ```
 
+### 4.55 讀取 cruise.patrol（#590）
+
+```bash
+PATROL_MODE=$(grep -A10 'cruise:' "$CONFIG_FILE" 2>/dev/null | grep 'patrol:' | awk '{print $2}' | head -1)
+PATROL_MODE="${PATROL_MODE:-both}"
+```
+
+| 值 | 行為 |
+|----|------|
+| `po` | 只派 PO-patrol subagent，跳過 SRE-inspection |
+| `sre` | 只派 SRE-inspection subagent，跳過 PO-patrol |
+| `both`（預設） | 同時派 PO + SRE（向後相容，未設定時 fallback） |
+
 <HARD-GATE>
 project_level=low 的所有自動行為（auto-shoot、auto-close、auto-sprint-planning、auto-sprint-execution）為強制執行，Agent 禁止加入額外確認步驟。
 </HARD-GATE>
@@ -257,9 +270,13 @@ CYCLE=0
 CYCLE=1
 寫入 {"type":"cruise-init",...} log entry
 for REPO_PATH in REPOS:
-  平行派遣 PO-patrol + SRE-inspection（帶入 REPO_PATH, OWNER_REPO）
+  # 依 PATROL_MODE 決定派遣
+  if PATROL_MODE == "po" or PATROL_MODE == "both":
+    派遣 PO-patrol subagent（帶入 REPO_PATH, OWNER_REPO）
+  if PATROL_MODE == "sre" or PATROL_MODE == "both":
+    派遣 SRE-inspection subagent（帶入 REPO_PATH, OWNER_REPO）
 等待完成，寫入 JSONL log（格式見 references/log-format.md）
-寫入 {"type":"po-patrol-complete",...} / {"type":"sre-inspection-complete",...} log entry
+寫入 {"type":"po-patrol-complete",...} / {"type":"sre-inspection-complete",...} log entry（依實際派遣的 agent）
 
 # [AUTO-CONTINUE] project_level=low → 自動派 auto-shoot，不停
 if PROJECT_LEVEL != "high": auto-shoot ACTIONABLE_ISSUES（見 references/auto-shoot.md）
@@ -284,7 +301,11 @@ while 檢查 flag file 存在:
   CYCLE += 1; touch "$CRUISE_FLAG"
   寫入 {"type":"po-patrol-start",...} / {"type":"sre-inspection-start",...} log entry
   for REPO_PATH in REPOS:
-    平行派遣 PO-patrol（詳見 references/po-patrol.md）+ SRE-inspection（詳見 references/sre-inspection.md）
+    # 依 PATROL_MODE 決定派遣
+    if PATROL_MODE == "po" or PATROL_MODE == "both":
+      派遣 PO-patrol subagent（詳見 references/po-patrol.md）
+    if PATROL_MODE == "sre" or PATROL_MODE == "both":
+      派遣 SRE-inspection subagent（詳見 references/sre-inspection.md）
   等待完成，寫入 log
   寫入 {"type":"po-patrol-complete",...} / {"type":"sre-inspection-complete",...} log entry
 

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -241,6 +241,17 @@ Trace 根 span 初始化（ADR-033）：`_TRACE_START_EPOCH="$(date '+%s')"`, `_
 
 ---
 
+### Live Log 初始化（#588）
+
+Story-Lifecycle subagent 啟動後，立即定義 live-log 輸出路徑：
+
+```bash
+LIVE_LOG_FILE="logs/live/$(date '+%Y-%m-%d')-session-${SHIKIGAMI_SESSION_ID:-unknown}.log"
+mkdir -p logs/live
+```
+
+---
+
 ## §3 TDD 開發流程（強制，doc_only=false 時）
 
 <HARD-GATE>

--- a/tests/test-588-live-log-file-var.sh
+++ b/tests/test-588-live-log-file-var.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# test-588-live-log-file-var.sh
+# AC3: 確認 story-lifecycle-prompt.md 含有 LIVE_LOG_FILE 變數定義
+
+set -euo pipefail
+
+FILE="skills/sprint-execution/story-lifecycle-prompt.md"
+PASS=0
+FAIL=0
+
+assert() {
+  local desc="$1"
+  local result="$2"
+  if [[ "$result" == "0" ]]; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc"
+    ((FAIL++)) || true
+  fi
+}
+
+# AC1: 確認 LIVE_LOG_FILE 定義存在
+grep -q 'LIVE_LOG_FILE="logs/live/\$(date' "$FILE"
+assert "AC1: LIVE_LOG_FILE 定義存在" "$?"
+
+# AC1: 確認 mkdir -p logs/live 存在
+grep -q 'mkdir -p logs/live' "$FILE"
+assert "AC1: mkdir -p logs/live 存在" "$?"
+
+# AC1: 確認使用 SHIKIGAMI_SESSION_ID:-unknown
+grep -q 'SHIKIGAMI_SESSION_ID:-unknown' "$FILE"
+assert "AC1: SHIKIGAMI_SESSION_ID:-unknown 存在" "$?"
+
+# AC2: 定義必須在第一個引用之前
+DEF_LINE=$(grep -n 'LIVE_LOG_FILE="logs/live/' "$FILE" | head -1 | cut -d: -f1)
+FIRST_REF_LINE=$(grep -n '>> "${LIVE_LOG_FILE}"' "$FILE" | head -1 | cut -d: -f1)
+
+if [[ -n "$DEF_LINE" && -n "$FIRST_REF_LINE" && "$DEF_LINE" -lt "$FIRST_REF_LINE" ]]; then
+  echo "PASS: AC2: 定義 (L${DEF_LINE}) 在第一個引用 (L${FIRST_REF_LINE}) 之前"
+  ((PASS++)) || true
+else
+  echo "FAIL: AC2: 定義 (L${DEF_LINE:-?}) 不在第一個引用 (L${FIRST_REF_LINE:-?}) 之前"
+  ((FAIL++)) || true
+fi
+
+echo ""
+echo "Results: PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test-cruise-skill.sh
+++ b/tests/test-cruise-skill.sh
@@ -652,6 +652,31 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# TC-39：#590 cruise.patrol 模式分支驗證
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TC-39：#590 cruise.patrol 模式分支驗證 ---"
+
+if [[ -f "$SKILL_FILE" ]]; then
+  assert_contains "$SKILL_FILE" 'PATROL_MODE' \
+    "TC-39a: SKILL.md 含 PATROL_MODE 變數定義"
+  assert_contains "$SKILL_FILE" 'cruise:.*\n.*patrol:|patrol:' \
+    "TC-39b: SKILL.md 含 cruise.patrol 設定讀取"
+  assert_contains "$SKILL_FILE" 'PATROL_MODE.*both|both.*預設|PATROL_MODE:-both' \
+    "TC-39c: SKILL.md PATROL_MODE 預設值為 both（向後相容）"
+  assert_contains "$SKILL_FILE" 'PATROL_MODE == "po"' \
+    "TC-39d: §6a Once Mode 含 po 分支判斷"
+  assert_contains "$SKILL_FILE" 'PATROL_MODE == "sre"' \
+    "TC-39e: §6b Loop Mode 含 sre 分支判斷"
+  assert_contains "$SKILL_FILE" 'PATROL_MODE == "both"' \
+    "TC-39f: §6a/§6b 含 both 分支判斷"
+else
+  for TC in TC-39a TC-39b TC-39c TC-39d TC-39e TC-39f; do
+    fail "${TC}: SKILL.md 不存在（${SKILL_FILE}）"
+  done
+fi
+
+# ---------------------------------------------------------------------------
 # 結果摘要
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- 新增 §4.55 讀取 `cruise.patrol` 設定（`PATROL_MODE`，fallback 為 `both`）
- 在 §6a Once Mode 及 §6b Loop Mode 派遣段落加入三種模式條件分支（`po` / `sre` / `both`）
- 新增 TC-39（6 項）測試驗證 PATROL_MODE 讀取與三種分支描述存在

## AC Status

- AC1: PASS — §4.55 讀取 `cruise.patrol` 設定，§6a/§6b 依值決定派遣
- AC2: PASS — `po`→只派 PO；`sre`→只派 SRE；`both`→同時派（現有行為）
- AC3: PASS — TC-39d/e/f 驗證三種模式分支邏輯描述存在
- AC4: PASS — `PATROL_MODE="${PATROL_MODE:-both}"` 確保向後相容

## Test plan

- [x] `bash tests/test-cruise-skill.sh` — TC-39 全 6 項 PASS（原有 50 FAIL 為 pre-existing，無新增迴歸）

🤖 Generated with [Claude Code](https://claude.com/claude-code)