### PR TITLE
retro: #581 Sprint 133 — 並行 worktree 版本衝突預防機制

### DIFF
--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -94,6 +94,13 @@ team_debate: true                          # 可選：是否啟用 Team Debate�
 衝突偵測：確認修改檔案清單無平行 Story 競態（參照 developer-prompt.md §同檔案衝突偵測）
   |
   v
+Worktree 同步（#581，Sprint 134 Retro Action）：在 story branch 建立前強制同步最新 main
+  git fetch origin main
+  git rebase origin/main
+  |-- rebase 成功 → 繼續（worktree 基於最新 main，降低並行版本衝突機率）
+  +-- rebase 有衝突 → 解決衝突後繼續（衝突應極少，worktree 初始狀態幾乎無本地修改）
+  |
+  v
 story_type 路由：
   |-- story_type=DESIGN --> DESIGN 路徑（§4.5）→ 派遣 UI/UX Designer subagent
   |     ├─ 確認 Design Foundation 就緒（Design System、Tokens、Component Library）


### PR DESCRIPTION
## Story

#581 retro: Sprint 133 — 並行 worktree 版本衝突預防機制

## 變更內容

在 `skills/sprint-execution/story-lifecycle-prompt.md` 執行流程中，衝突偵測後新增「Worktree 同步」步驟：
```
git fetch origin main
git rebase origin/main
```
確保 Story worktree 基於最新 main 分支出發，降低並行 worktree 版本衝突機率。

## AC 驗收

- AC1 ✓：story-lifecycle-prompt.md 新增 worktree 建立前 rebase 步驟
- AC2：觀察性指標，下 Sprint 觀察並行 worktree conflict 率

## 背景

Sprint 133 #407 worktree 因基於舊 main（v0.89.3），PR #576（#397）先合併升版至 v0.89.4，導致版本衝突需人工 rebase。

Sprint 134 | Batch 1 | S(1pt)