### PR TITLE
shoot: #598 測試腳本 grep 語法規範 — 禁止 grep -l 與 && echo found 混用

### DIFF
--- a/skills/sprint-execution/developer-prompt.md
+++ b/skills/sprint-execution/developer-prompt.md
@@ -312,6 +312,7 @@ LLM 輔助確認：{確認或補充說明，動態 import 漏報標注}
 - [ ] 測試之間互相獨立，無順序依賴
 - [ ] 使用 Arrange-Act-Assert 模式
 - [ ] Mock / Stub 使用適當，不過度 mock
+- [ ] Shell 測試腳本中「存在性偵測」使用 `grep -q`（quiet mode），禁止 `grep -l` 與 `&& echo found` 混用（`grep -l` 會輸出檔案路徑污染比對結果）
 
 ### 安全性
 - [ ] 使用者輸入已做 sanitization


### PR DESCRIPTION
## Summary

- developer-prompt.md 測試品質 checklist 新增 `grep -q` 規範條目
- 明確禁止 Shell 測試腳本中 `grep -l` 與 `&& echo found` 混用（`grep -l` 會輸出檔案路徑污染比對結果）

## AC 驗證

| # | 條件 | 結果 |
|---|------|------|
| AC1 | TDD 注意事項補充 grep 語法規範 | PASS — developer-prompt.md 測試品質 checklist 含 grep -q 說明 |
| AC2 | 現有測試腳本無 grep -l 與字串比對混用 | PASS — 全量掃描 tests/ + scripts/ 零違規 |

## Test Plan

- [x] `bash tests/test-shoot-skill.sh` — 78 PASS / 0 FAIL
- [x] `bash scripts/validate-skills.sh` — 30/30 PASS
- [x] `grep -rn 'grep -l.*&&.*echo' tests/ scripts/` — 零匹配

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)