### PR TITLE
feat: #606 PostToolUse hook 自動記錄 subagent 派遣/完成動態至 live-log

### DIFF
--- a/docs/PROJECT_BOARD.md
+++ b/docs/PROJECT_BOARD.md
@@ -1,23 +1,24 @@
 # Project Board
 
-**最後更新**：2026-03-24（Sprint 135 啟動 — Context Engineering JIT + Agent Skills 評估 + CI 修復，6 pts）
-**當前 Sprint**：Sprint 135（進行中）
+**最後更新**：2026-03-24（Sprint 135 完成 — 4/4 Stories PASS，6 pts）
+**當前 Sprint**：Sprint 135（已完成）
 
 工件導覽：[ROADMAP](prd/ROADMAP.md) → [Backlog](prd/PRODUCT_BACKLOG.md) → 本看板 | [Tutorial](tutorial/README.md)
 
 ---
 
-## Sprint 135（進行中）
+## Sprint 135（完成）
 
 > Sprint Goal：推進 Context Engineering 基礎架構（ADR-037 + JIT Retrieval 實作），研究 Agent Skills 開放標準對齊可行性，並修復 CI OAuth token 認證失效。
+> **結果**：Goal 達成（4/4 Stories PASS）。Velocity 6 pts，完成率 100%。連續第 9 Sprint 100%（127+128+129+130+131+132+133+134+135）。
 > **容量**：6 pts
 
 | Story | Issue | Size | Points | 狀態 |
 |-------|-------|------|--------|------|
-| RESEARCH: ADR-037 — Context Engineering JIT 架構決策 | #602 | S | 1 | 進行中 |
-| retro: 修復 CI New Issue Intake OAuth token 認證失效 | #597 | S | 1 | 進行中 |
-| research: Agent Skills 開放標準對齊評估 | #396 | M | 2 | 進行中 |
-| feat: Context Engineering — Just-in-Time Retrieval | #400 | M | 2 | 待開始（依賴 #602） |
+| RESEARCH: ADR-037 — Context Engineering JIT 架構決策 | #602 | S | 1 | 已完成 (#603) |
+| retro: 修復 CI New Issue Intake OAuth token 認證失效 | #597 | S | 1 | 已完成 (#604) |
+| research: Agent Skills 開放標準對齊評估 | #396 | M | 2 | 已完成 (#605) |
+| feat: Context Engineering — Just-in-Time Retrieval | #400 | M | 2 | 已完成 (#607) |
 
 **Sprint 容量**：6 points
 **執行順序**：ADR Phase（#602）→ Batch 1（#597 | #396 平行）→ Batch 2（#400 序列）

--- a/docs/sprints/sprint-checkpoint.json
+++ b/docs/sprints/sprint-checkpoint.json
@@ -1,12 +1,11 @@
 {
-  "sprint": 134,
+  "sprint": 135,
   "stories": [
-    {"id": "#573", "status": "completed", "pr": "#592"},
-    {"id": "#581", "status": "completed", "pr": "#593"},
-    {"id": "#574", "status": "completed", "pr": "#594"},
-    {"id": "#393", "status": "completed", "pr": "#595"},
-    {"id": "#395", "status": "completed", "pr": "#596"}
+    {"id": "#602", "status": "completed", "pr": "#603"},
+    {"id": "#597", "status": "completed", "pr": "#604"},
+    {"id": "#396", "status": "completed", "pr": "#605"},
+    {"id": "#400", "status": "completed", "pr": "#607"}
   ],
-  "current_step": "all-completed",
-  "updated_at": "2026-03-24T18:30+08:00"
+  "current_step": "all-complete",
+  "updated_at": "2026-03-24T19:23+08:00"
 }

--- a/docs/sprints/sprint_135.md
+++ b/docs/sprints/sprint_135.md
@@ -14,10 +14,10 @@
 
 | Story | Issue | Size | Points | Type | 負責人 | 狀態 |
 |-------|-------|------|--------|------|--------|------|
-| RESEARCH: ADR-037 — Context Engineering JIT 架構決策 | #602 | S | 1 | RESEARCH | Architect | 待開始 |
-| retro: 修復 CI New Issue Intake OAuth token 認證失效 | #597 | S | 1 | INFRA | SRE | 待開始 |
-| research: Agent Skills 開放標準對齊評估 | #396 | M | 2 | RESEARCH | Architect | 待開始 |
-| feat: Context Engineering — Just-in-Time Retrieval | #400 | M | 2 | FEATURE | Developer | 待開始（依賴 #602 ADR-037 Accepted） |
+| RESEARCH: ADR-037 — Context Engineering JIT 架構決策 | #602 | S | 1 | RESEARCH | Architect | 已完成 (#603) |
+| retro: 修復 CI New Issue Intake OAuth token 認證失效 | #597 | S | 1 | INFRA | SRE | 已完成 (#604) |
+| research: Agent Skills 開放標準對齊評估 | #396 | M | 2 | RESEARCH | Architect | 已完成 (#605) |
+| feat: Context Engineering — Just-in-Time Retrieval | #400 | M | 2 | FEATURE | Developer | 已完成 (#607) |
 
 **Sprint 容量**：6 points
 
@@ -126,9 +126,9 @@
 ## Definition of Done
 
 所有 Story 完成條件：
-- [ ] 所有 Acceptance Criteria 通過
-- [ ] 單元測試 / 整合測試全部通過（0 failed）（RESEARCH 豁免）
-- [ ] 無硬編碼金鑰，配置透過環境變數管理
+- [x] 所有 Acceptance Criteria 通過
+- [x] 單元測試 / 整合測試全部通過（0 failed）（RESEARCH 豁免）
+- [x] 無硬編碼金鑰，配置透過環境變數管理
 - [ ] Metrics_Log.md 本 Sprint 數據已更新
-- [ ] 既有測試全部仍然通過
-- [ ] PR merged，Issue closed
+- [x] 既有測試全部仍然通過
+- [x] PR merged，Issue closed


### PR DESCRIPTION
## Summary

- 新增 `hooks/posttooluse-agent-livelog.sh`：PostToolUse Agent 事件觸發時，非同步寫入 `logs/live/<date>-session-<id>.log`
- 更新 `hooks/hooks.json`：新增 PostToolUse 陣列，matcher=Agent，async=true
- 新增 `tests/test-606-agent-livelog-hook.sh`：驗證 5 個 AC 全部通過

## AC Status

- AC1: PASS — posttooluse-agent-livelog.sh 存在且可執行
- AC2: PASS — hooks.json 包含 matcher=Agent 的 PostToolUse entry
- AC3: PASS — 使用 resolve-session-id.sh 確保 session 隔離
- AC4: PASS — async: true，不阻塞主流程，所有寫入 `|| true` 容錯
- AC5: PASS — 測試腳本驗證 hook 配置存在

## Test plan

- [x] `bash tests/test-606-agent-livelog-hook.sh` — 5/5 PASS
- [x] `bash scripts/validate-json.sh` — 通過
- [x] `bash scripts/validate-version.sh` — 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)