### PR TITLE
fix: #610 retro — CLAUDE.md --body-file 規範 + oauth-token-monitor 更新

### DIFF
--- a/.github/workflows/oauth-token-monitor.yml
+++ b/.github/workflows/oauth-token-monitor.yml
@@ -59,22 +59,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           DETECTED_TIME=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-          {
-            echo "ISSUE_BODY<<ISSUE_EOF"
-            echo "OAuth Token Alert - Detected: ${DETECTED_TIME}"
-            echo ""
-            echo "CLAUDE_CODE_OAUTH_TOKEN has expired (HTTP 401)."
-            echo "Affected workflows: New Issue Intake, Sprint Dispatch"
-            echo ""
-            echo "Fix: run claude auth login, update CLAUDE_CODE_OAUTH_TOKEN secret."
-            echo "Ref: ADR-030 OAuth Token Watchdog, Issue #597"
-            echo "ISSUE_EOF"
-          } >> $GITHUB_ENV
+          # --body-file 模式：避免多行 body 含特殊字符導致 YAML parse error（CLAUDE.md 規範 13）
+          BODY_FILE=$(mktemp /tmp/token-alert-body-XXXXXX.txt)
+          printf '%s\n' \
+            "OAuth Token Alert - Detected: ${DETECTED_TIME}" \
+            "" \
+            "CLAUDE_CODE_OAUTH_TOKEN has expired (HTTP 401)." \
+            "Affected workflows: New Issue Intake, Sprint Dispatch" \
+            "" \
+            "Fix: run claude auth login, update CLAUDE_CODE_OAUTH_TOKEN secret." \
+            "Ref: ADR-030 OAuth Token Watchdog, Issue 597" \
+            > "${BODY_FILE}"
           gh issue create \
             --title "[TOKEN-ALERT] CLAUDE_CODE_OAUTH_TOKEN expired - update required" \
-            --body "${ISSUE_BODY}" \
+            --body-file "${BODY_FILE}" \
             --label "retro-action" \
             --label "priority: must"
+          rm -f "${BODY_FILE}"
           echo "[TOKEN-ALERT] Alert issue created"
 
       - name: Summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,14 @@
 10. **CI Actions 版本釘定**：所有 GitHub Actions 統一使用 `@v4`，升級需先確認 self-hosted runner 相容性，並經人工審核後才能更新版本號。新增或修改 workflow 時執行 `bash scripts/validate-ci-versions.sh` 驗證。**升級確認時機**：INFRA Story 涉及 CI Actions 版本升級時，確認須在 Sprint Planning 前完成，避免 Sprint 中途因版本不相容而阻塞。
 11. **GitHub URL 可讀取**：遇到 GitHub URL（含 attachment），帶 `gh auth token` 認證直接讀取，不要報「無法讀取」。
 12. **平行 Worktree OOM 防護**：平行 worktree subagent 過多會 OOM（Sprint 127 歷史案例：4 個 worktree 觸發 core dump）。`SHIKIGAMI_MAX_PARALLEL` 預設 2，**未設定時亦視為 2，不得無限平行**。派遣前必須執行 `git worktree list` 計算現存數量；重派前必須確認同任務 agent 是否還在跑，避免重複派遣。詳見 `skills/sprint-execution/references/parallel-safety.md`。
+13. **Workflow issue body 一律使用 `--body-file` 模式**：GitHub Actions workflow 中建立或更新 Issue body 時，禁止直接以 `--body "..."` 傳入多行字串。body 內容必須寫入暫存檔案後以 `--body-file <file>` 引用，避免 body 含冒號（`:`）、星號（`*`）、引號等 YAML 特殊字符導致 workflow YAML parse error（Sprint 135 歷史案例：#597）。範例：
+    ```bash
+    # 正確（--body-file 模式）
+    printf '%s\n' "Issue body content" "可安全使用：冒號、*星號*" > /tmp/issue-body.txt
+    gh issue create --title "..." --body-file /tmp/issue-body.txt
+    # 錯誤（直接 --body，禁止）
+    gh issue create --title "..." --body "含冒號：或 *星號* 的內容"
+    ```
 
 ## 目錄結構
 


### PR DESCRIPTION
## Story

Closes #610

## 變更摘要

- `CLAUDE.md` 新增開發紅線第 13 條：workflow issue body 一律使用 `--body-file` 模式
- `.github/workflows/oauth-token-monitor.yml` 將 `--body "${ISSUE_BODY}"` 更新為 `--body-file` 模式

## AC 確認

- [x] AC1: CLAUDE.md 新增 `--body-file` 規範說明（規則 13）
- [x] AC2: oauth-token-monitor.yml 更新為 `--body-file` 模式
- [x] AC3: CI versions validate PASS

## Story Type

INFRA（doc-only + workflow fix，TDD 豁免）