### PR TITLE
feat: #609 retro — 新增 ci-yamllint.yml YAML lint CI

### DIFF
--- a/.github/workflows/ci-yamllint.yml
+++ b/.github/workflows/ci-yamllint.yml
@@ -1,0 +1,32 @@
+name: YAML Lint
+
+# Sprint 136 #609 retro: 新增 GitHub Actions workflow YAML lint CI 步驟
+# 防止 workflow YAML parse error 進入 main branch（Sprint 135 歷史案例 #597）
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+jobs:
+  yamllint:
+    name: Lint GitHub Actions Workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Run yamllint on workflows
+        run: |
+          yamllint \
+            -d '{extends: default, rules: {line-length: {max: 200}, truthy: {allowed-values: ["true", "false", "on", "off"]}, comments: {min-spaces-from-content: 1}}}' \
+            .github/workflows/*.yml
+          echo "[YAMLLINT-PASS] All workflow YAML files passed lint"


### PR DESCRIPTION
## Story

Closes #609

## 變更摘要

新增 `.github/workflows/ci-yamllint.yml`：
- PR 觸發時對 `.github/workflows/*.yml` 執行 yamllint
- lint 失敗時 PR check 顯示 FAIL，阻擋合併
- 現有所有 workflow 檔案通過 YAML 語法驗證

## AC 確認

- [x] AC1: `.github/workflows/ci-yamllint.yml` 建立，對 workflows 執行 yamllint
- [x] AC2: PR 觸發時自動執行，失敗阻擋合併
- [x] AC3: 現有所有 workflow 檔案通過 yamllint / js-yaml 驗證

## Story Type

INFRA（新增 CI workflow，TDD 豁免）