### PR TITLE
feat: #406 Schema 先行 — API Contract 統一定義（ADR-036）

### DIFF
--- a/.claude/debate/critique-round-1.md
+++ b/.claude/debate/critique-round-1.md
@@ -1,76 +1,28 @@
-# Team Debate — Critic Round 1 批判結果
+# Critique Round 1 — #406 feat: Schema 先行 — API Contract 統一定義
 
-**Story**：#493 — Retro-Action 連續未完成自動觸發 Grooming 機制
-**Branch**：sprint-130/493-retro-grooming
-**Critic Agent**：Developer Critic（Agent B）
-**Date**：2026-03-24
-
----
-
-## Verdict: FAIL
-
----
-
-## 批判維度評估
-
-### 1. 正確性（AC 覆蓋度）
-
-| AC | 說明 | 評估 |
-|----|------|------|
-| AC1 偵測規則 | retro-grooming.md §1 定義連續 2 Sprint 閾值、情境表格、偵測指令 | PASS |
-| AC2 Sprint Planning 整合 | SKILL.md checklist 第 51 行加入偵測步驟並引用 retro-grooming.md | PASS |
-| AC3 #452 觸發案例 | retro-grooming.md §4 有 #452 的完整說明 | PASS |
-
-所有 3 項 AC 均有對應實作，覆蓋完整。
-
-### 2. 設計（SOLID / 耦合度 / 命名）
-
-**問題 1（MED）**：`skills/sprint-review/references/retro-grooming.md` 第 41-42 行：
-
-§1.3 偵測方式提到「讀取 Issue 的 milestone 歷史（透過 GitHub API）」，但 `gh issue list` 不直接提供 milestone 歷史（只能看當前 milestone），也未給出具體 API endpoint（如 `gh api repos/{owner}/{repo}/issues/{n}/timeline`）。Agent 依此指引執行時可能無法實際完成偵測，陷入無法操作的狀態。
-
-**問題 2（MED）**：`skills/sprint-review/SKILL.md` §4（第 129 行）原文「連續兩 Sprint open → 升級 Stakeholder」，與 §4.1（第 136-138 行）新增「連續 2 個 Sprint → 觸發 [RETRO-GROOMING-TRIGGER]」並存，兩者觸發條件相同但動作不同，關係（並且/取代）未明確說明，可能導致 Agent 執行不一致。
-
-### 3. 測試覆蓋
-
-- 12 項 TC 覆蓋所有 AC 關鍵詞存在性，符合此類 Skill 文件測試慣例
-- TC-04（第 80-85 行）測試「包含 '2'」過於寬鬆，數字 2 可能出現於任何位置（LOW）
-- 缺少測試覆蓋「升級 Stakeholder 與 RETRO-GROOMING-TRIGGER 並存關係」但屬文件層級測試局限，可接受
-
-### 4. 安全性
-
-- 無外部輸入處理，無硬編碼金鑰。安全性無問題。
-
----
+## Verdict: PASS
 
 ## Issues Found
 
-### Issue 1
-- **SEVERITY: MED**
-- **位置**：`skills/sprint-review/references/retro-grooming.md` 第 41-44 行
-- **描述**：偵測方式依賴「milestone 歷史 API」但未提供具體指引，實際執行時 Agent 可能無法取得連續排入的歷史資料，導致偵測機制形同虛設
-- **建議**：補充具體 GitHub API 路徑，或明確說明以 `deferred` label 回退方案為主要判定方式
+- [SEVERITY: LOW] docs/schema/README.md 說明 Sprint_N.md 記錄格式，但未提供一個 draft-state 範例 JSON Schema 檔案於 docs/schema/sprint-136/ 下。AC 未要求此項，但對 Architect 實際使用有幫助。
+  - 位置：docs/schema/README.md
+  - 建議：可在後續 Sprint 補充範例檔案，非阻塞
+  
+- [SEVERITY: LOW] tests/test-schema-first.sh 未測試 architect-prompt.md 中「locked 目錄移動」的欄位描述是否存在（AC2 範圍較廣）。
+  - 位置：tests/test-schema-first.sh
+  - 建議：可以新增 grep check for "locked" in architect-prompt.md，但現有 AC 已滿足
 
-### Issue 2
-- **SEVERITY: MED**
-- **位置**：`skills/sprint-review/SKILL.md` §4（第 129 行）與 §4.1（第 136-138 行）
-- **描述**：「升級 Stakeholder」與「觸發 [RETRO-GROOMING-TRIGGER]」觸發條件相同但動作並存，關係未明確，可能導致 Agent 雙重執行或執行不一致
-- **建議**：在 §4.1 明確說明兩者並存關係（如：同時觸發，GROOMING 處理技術面，Stakeholder 升級處理管理面）
+- [SEVERITY: LOW] sprint_136.md 的 Schema Contracts 表格中 docs/schema/README.md 標記為 locked，但依 ADR-036 定義 locked 狀態是「實際 Contract 檔案」而非命名規範文件。語義有輕微不精確。
+  - 位置：docs/sprints/sprint_136.md
+  - 建議：Schema Contracts 表格可標記為 `reference`（命名規範文件），而非 locked
 
-### Issue 3
-- **SEVERITY: LOW**
-- **位置**：`tests/test-493-retro-grooming.sh` 第 80-85 行（TC-04）
-- **描述**：測試「包含 '2'」過於寬鬆，無法精確驗證閾值語義
-- **建議**：改為測試「連續 2 個」或「閾值：連續 2」等更具語義的字串
+## Assessment
 
----
+所有 AC 均有對應實作：
+- AC1 PASS：docs/schema/ 建立，README.md 有命名規範
+- AC2 PASS：architect-prompt.md 新增 Schema Contract 定義章節，含格式表、生命週期、sprint_N.md 記錄格式
+- AC3 PASS：sprint_136.md 新增 Schema Contracts 區塊
+- AC4 PASS：tests/test-schema-first.sh 建立，6/6 測試通過
 
-## Summary
-
-Worker 覆蓋了全部 3 項 AC，基本框架設計合理。
-
-2 個 MED 問題需修復：
-1. milestone 歷史偵測方式缺乏可行性指引
-2. 新舊兩個觸發動作的並存關係未明確
-
-1 個 LOW 問題可選修。
+設計合理：JSON Schema 主 / OpenAPI 輔的混合策略與 ADR-036 完全一致。
+無安全疑慮（純文件與測試腳本）。

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -1,0 +1,88 @@
+# Schema Contract 目錄
+
+**建立日期**：2026-03-24
+**決策依據**：ADR-036（Schema-first API Contract 統一定義）
+**觸發 Story**：#406 feat: Schema 先行 — API Contract 統一定義
+
+---
+
+## 目的
+
+此目錄存放 Shikigami GAD（Group Agent Development）工作流程中各 Sprint 的 API Contract 定義檔案，作為多 Agent Group 並行開發的介面協定基礎。
+
+---
+
+## 格式規範
+
+### 使用格式（依 ADR-036 決策）
+
+| 場景 | 格式 |
+|------|------|
+| Agent function calling contract | JSON Schema（Draft 2020-12，`.json`）|
+| Agent-to-Agent 資料交換 | JSON Schema（`.json`）|
+| HTTP REST API 文件 | OpenAPI 3.0（`.yaml`）|
+| 不確定場景 | JSON Schema（預設）|
+
+---
+
+## 命名規範（kebab-case）
+
+```
+docs/schema/
+├── README.md                          # 本文件
+├── sprint-<N>/                        # 每個 Sprint 的 schema 工作目錄
+│   ├── <story-id>-<description>.json  # JSON Schema Contract（draft 狀態）
+│   └── <story-id>-<description>.yaml  # OpenAPI Contract（若為 HTTP 場景）
+└── locked/                            # 已鎖定（不可修改）的 Contract
+    └── <story-id>-<description>.json
+```
+
+**命名規則**：
+- 目錄與檔名均使用 **kebab-case**（全小寫，單字以連字號分隔）
+- 檔名前綴為 Story ID（如 `406-gad-agent-contract.json`）
+- JSON Schema 副檔名：`.json`
+- OpenAPI 副檔名：`.yaml`
+
+**範例**：
+- `docs/schema/sprint-136/406-gad-agent-contract.json`
+- `docs/schema/locked/406-gad-agent-contract.json`（鎖定後移至此）
+
+---
+
+## Contract 生命週期狀態
+
+| 狀態 | 說明 | 修改權限 | 存放位置 |
+|------|------|---------|---------|
+| `draft` | 起草中，隨 Story 開發演進 | 任何 Agent 可修改 | `sprint-<N>/` |
+| `review` | Sprint Planning / Architect 審查中 | 僅 Architect 可修改 | `sprint-<N>/` |
+| `locked` | 凍結，各組以此為實作依據 | 禁止修改，需新建版本 | `locked/` |
+
+---
+
+## 鎖定流程（Sprint Planning 中）
+
+1. Architect 完成技術評估後，將本 Sprint 使用的 Contract 狀態設為 `locked`
+2. 將 Contract 檔案從 `sprint-<N>/` 複製至 `locked/`
+3. 在 `sprint_N.md` 的「Schema Contracts」區塊記錄 locked schema 路徑
+
+---
+
+## Sprint_N.md 記錄格式
+
+在每個 Sprint 文件中，新增以下區塊：
+
+```markdown
+## Schema Contracts（#406 Schema 先行）
+
+| Contract | 路徑 | 狀態 | 使用 Story |
+|---------|------|------|-----------|
+| GAD Agent Contract | docs/schema/locked/N-description.json | locked | #N |
+```
+
+---
+
+## 參考
+
+- ADR-036：`docs/adr/ADR-036-schema-first-api-contract.md`
+- JSON Schema 規格：https://json-schema.org/draft/2020-12
+- OpenAPI 3.0 規格：https://spec.openapis.org/oas/v3.0.3

--- a/docs/sprints/sprint_136.md
+++ b/docs/sprints/sprint_136.md
@@ -106,6 +106,14 @@
 
 ---
 
+## Schema Contracts（ADR-036 Schema 先行）
+
+| Contract | 路徑 | 狀態 | 使用 Story |
+|---------|------|------|-----------|
+| GAD Schema-first 命名規範 | docs/schema/README.md | reference | #406 |
+
+---
+
 ## DoD（Definition of Done）
 
 - [ ] 所有 AC 通過

--- a/skills/sprint-planning/references/architect-prompt.md
+++ b/skills/sprint-planning/references/architect-prompt.md
@@ -48,6 +48,57 @@ Architect 在技術評估時，必須檢查每個 Story 是否涉及 SDD 定義�
 
 ---
 
+## Schema Contract 定義（ADR-036，#406 Schema 先行）
+
+<!-- ADR-036 Schema-first API Contract — Sprint 136 #406 -->
+
+**觸發條件**：Story AC 涉及 Agent-to-Agent 資料交換、function calling 介面、或 HTTP REST API 文件時，Architect 必須在技術評估中產出對應的 Schema Contract。
+
+### Schema Contract 輸出規則
+
+| Story 涉及場景 | 格式 | 輸出路徑 |
+|--------------|------|---------|
+| Agent function calling / A2A 資料交換 | JSON Schema（Draft 2020-12，`.json`）| `docs/schema/sprint-<N>/<story-id>-<description>.json` |
+| HTTP REST API 文件 | OpenAPI 3.0（`.yaml`）| `docs/schema/sprint-<N>/<story-id>-<description>.yaml` |
+| 不確定場景 | JSON Schema（預設）| 同上 |
+| RESEARCH / DESIGN / doc-only Story | 豁免，不需產出 | — |
+
+**命名規範（kebab-case）**：
+- 目錄與檔名均使用 kebab-case（全小寫，連字號分隔）
+- 前綴為 Story ID（如 `406-gad-agent-contract.json`）
+- 詳見 `docs/schema/README.md`
+
+### Schema Contract 生命週期
+
+| 狀態 | 說明 | 時機 |
+|------|------|------|
+| `draft` | 起草中 | Architect 技術評估時建立 |
+| `review` | 審查中 | Sprint Planning 期間 |
+| `locked` | 凍結（不可修改）| Architect 完成技術評估後，移至 `docs/schema/locked/` |
+
+**鎖定動作**：Architect 完成技術評估後，將本 Sprint 涉及的 Contract 複製至 `docs/schema/locked/`，並在 `sprint_N.md` 新增「Schema Contracts」區塊記錄 locked 路徑。
+
+### Sprint_N.md 記錄格式
+
+```markdown
+## Schema Contracts（ADR-036 Schema 先行）
+
+| Contract | 路徑 | 狀態 | 使用 Story |
+|---------|------|------|-----------|
+| {描述} | docs/schema/locked/{filename} | locked | #{N} |
+```
+
+### 技術評估輸出表格（新增 Schema Contract 欄位）
+
+```markdown
+| Story | T-shirt | ADR 需求 | API 契約 | Schema Contract | Related SDDs | 說明 |
+|-------|---------|---------|---------|----------------|-------------|------|
+| US-#N | M | 無需 ADR | **有** | docs/schema/sprint-N/N-desc.json（draft）| — | {說明} |
+| US-#M | S | 無需 ADR | **不適用** | 豁免（RESEARCH）| — | doc-only |
+```
+
+---
+
 ## 平行分群建議
 
 <!-- #451 並行安全規則矩陣 — Sprint 123 -->

--- a/tests/test-schema-first.sh
+++ b/tests/test-schema-first.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# tests/test-schema-first.sh
+# Story #406: Schema 先行 — API Contract 統一定義
+# AC4: 驗證 docs/schema/ 目錄存在且命名規範檔案存在
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+run_test() {
+  local desc="$1"
+  local result="$2"
+  if [[ "$result" == "PASS" ]]; then
+    echo "  [PASS] ${desc}"
+    PASS=$((PASS + 1))
+  else
+    echo "  [FAIL] ${desc}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "========================================"
+echo "  test-schema-first.sh"
+echo "  Story #406: Schema-first API Contract"
+echo "========================================"
+
+# AC1: docs/schema/ 目錄存在
+test -d "${REPO_ROOT}/docs/schema" \
+  && run_test "docs/schema/ 目錄存在" "PASS" \
+  || run_test "docs/schema/ 目錄存在" "FAIL"
+
+# AC1: docs/schema/README.md 存在（命名規範）
+test -f "${REPO_ROOT}/docs/schema/README.md" \
+  && run_test "docs/schema/README.md 存在（命名規範）" "PASS" \
+  || run_test "docs/schema/README.md 存在（命名規範）" "FAIL"
+
+# AC2: architect-prompt.md 包含 Schema Definition 階段指引
+grep -q "Schema\|schema" "${REPO_ROOT}/skills/sprint-planning/references/architect-prompt.md" \
+  && run_test "architect-prompt.md 包含 Schema 定義關鍵字" "PASS" \
+  || run_test "architect-prompt.md 包含 Schema 定義關鍵字" "FAIL"
+
+grep -q "Schema Contract\|schema-contract\|schema_contract\|Schema Definition" \
+  "${REPO_ROOT}/skills/sprint-planning/references/architect-prompt.md" \
+  && run_test "architect-prompt.md 包含 Schema Contract / Schema Definition 指引" "PASS" \
+  || run_test "architect-prompt.md 包含 Schema Contract / Schema Definition 指引" "FAIL"
+
+# AC1: docs/schema/README.md 包含命名規範說明（kebab-case）
+if test -f "${REPO_ROOT}/docs/schema/README.md"; then
+  grep -q "kebab-case\|命名\|naming" "${REPO_ROOT}/docs/schema/README.md" \
+    && run_test "docs/schema/README.md 包含命名規範說明" "PASS" \
+    || run_test "docs/schema/README.md 包含命名規範說明" "FAIL"
+else
+  run_test "docs/schema/README.md 包含命名規範說明" "FAIL"
+fi
+
+# AC3: sprint_136.md 包含 Schema Contract locked 狀態記錄（或相關欄位）
+SPRINT_FILE="${REPO_ROOT}/docs/sprints/sprint_136.md"
+if test -f "${SPRINT_FILE}"; then
+  grep -q "Schema\|schema" "${SPRINT_FILE}" \
+    && run_test "sprint_136.md 包含 Schema 相關記錄" "PASS" \
+    || run_test "sprint_136.md 包含 Schema 相關記錄" "FAIL"
+else
+  run_test "sprint_136.md 包含 Schema 相關記錄" "FAIL"
+fi
+
+echo ""
+echo "========================================"
+echo "  結果：PASS ${PASS} / FAIL ${FAIL}"
+if [[ ${FAIL} -eq 0 ]]; then
+  echo "  全部通過"
+  echo "========================================"
+  exit 0
+else
+  echo "  有測試失敗"
+  echo "========================================"
+  exit 1
+fi


### PR DESCRIPTION
## Story

Closes #406

## 變更摘要

依 ADR-036（Schema-first API Contract，JSON Schema 主 / OpenAPI 3.0 輔）落地 Schema 先行工作流程：

- `docs/schema/README.md` — 目錄結構、命名規範（kebab-case）、格式選擇表、生命週期狀態
- `skills/sprint-planning/references/architect-prompt.md` — 新增「Schema Contract 定義」章節（觸發條件、輸出規則、鎖定流程、sprint_N.md 記錄格式）
- `docs/sprints/sprint_136.md` — Schema Contracts 區塊記錄
- `tests/test-schema-first.sh` — 6 項 AC 驗證測試，全部 PASS

## AC 確認

- [x] AC1: `docs/schema/` 目錄建立，`README.md` 有命名規範說明
- [x] AC2: `architect-prompt.md` 新增 Schema Definition 階段指引
- [x] AC3: `sprint_136.md` 新增 Schema Contracts 記錄區塊
- [x] AC4: `tests/test-schema-first.sh` 建立，6/6 測試通過

## Team Debate

- Round 1 Verdict: **PASS**
- 1 LOW severity issue accepted（sprint_136.md schema 狀態語義修正 reference vs locked）

## Story Type

FEATURE / M size（TDD: Red→Green→Refactor 完成，Team Debate 完成）