### PR TITLE
feat: #617 docs/schema/ 新增 GAD workflow JSON Schema Contract 範例檔案

### DIFF
--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -81,6 +81,16 @@ docs/schema/
 
 ---
 
+## 範例檔案
+
+| 範例 | 路徑 | 說明 |
+|------|------|------|
+| GAD Agent Contract 範例 | [`examples/gad-agent-contract.example.json`](examples/gad-agent-contract.example.json) | Claude tool use JSON Schema Draft 2020-12 格式的完整範例，包含 name / description / input_schema 欄位定義，附兩個真實 Agent contract 案例（sprint_planning_trigger / issue_triage） |
+
+> **使用方式**：複製此範例，依實際 Agent tool 需求修改 `name`、`description`、`input_schema.properties`，存至 `sprint-<N>/` 目錄，命名規則見上方「命名規範」。
+
+---
+
 ## 參考
 
 - ADR-036：`docs/adr/ADR-036-schema-first-api-contract.md`

--- a/docs/schema/examples/gad-agent-contract.example.json
+++ b/docs/schema/examples/gad-agent-contract.example.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/kctw-dev/shikigami/docs/schema/examples/gad-agent-contract.example.json",
+  "title": "GAD Agent Contract Example",
+  "description": "Shikigami GAD（Group Agent Development）工作流程中，Agent function calling 的 JSON Schema Contract 範例。依 ADR-036 Schema-first 規範建立，供 Architect 設計 API Contract 時參考格式。",
+  "type": "object",
+  "required": ["name", "description", "input_schema"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Agent tool 名稱（對應 Claude tool use 的 name 欄位）。使用 snake_case。",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "examples": ["sprint_planning_trigger", "issue_triage", "shoot_story"]
+    },
+    "description": {
+      "type": "string",
+      "description": "Agent tool 的用途描述（對應 Claude tool use 的 description 欄位）。應清楚說明何時使用此 tool、預期的輸入與輸出。",
+      "minLength": 10,
+      "examples": [
+        "觸發 Sprint Planning 流程。當 sprint-candidate issues 數量達到閾值時調用。回傳 sprint_number 與選入的 stories 清單。"
+      ]
+    },
+    "input_schema": {
+      "type": "object",
+      "description": "Agent tool 的輸入參數定義（對應 Claude tool use 的 input_schema 欄位）。使用 JSON Schema Draft 2020-12 格式。",
+      "$ref": "#/$defs/input_schema_definition",
+      "examples": [
+        {
+          "type": "object",
+          "required": ["repo", "sprint_candidates"],
+          "properties": {
+            "repo": {
+              "type": "string",
+              "description": "目標 repo（格式：owner/repo）",
+              "pattern": "^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$"
+            },
+            "sprint_candidates": {
+              "type": "array",
+              "description": "sprint-candidate issue 編號清單",
+              "items": {"type": "integer", "minimum": 1},
+              "minItems": 1
+            },
+            "capacity_pts": {
+              "type": "integer",
+              "description": "Sprint 容量（points），預設 6",
+              "minimum": 1,
+              "maximum": 8,
+              "default": 6
+            }
+          }
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "input_schema_definition": {
+      "type": "object",
+      "description": "JSON Schema 定義物件，描述 tool 的輸入參數。",
+      "required": ["type", "properties"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "object"
+        },
+        "required": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "必填參數名稱清單"
+        },
+        "properties": {
+          "type": "object",
+          "description": "參數定義，每個 key 為參數名稱，value 為其 JSON Schema 定義",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["type", "description"],
+            "properties": {
+              "type": {"type": "string"},
+              "description": {"type": "string"}
+            }
+          }
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "name": "sprint_planning_trigger",
+      "description": "觸發 Sprint Planning 流程。當 sprint-candidate issues 數量達到閾值時調用。回傳 sprint_number 與選入的 stories 清單。",
+      "input_schema": {
+        "type": "object",
+        "required": ["repo", "sprint_candidates"],
+        "properties": {
+          "repo": {
+            "type": "string",
+            "description": "目標 repo（格式：owner/repo）",
+            "pattern": "^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$"
+          },
+          "sprint_candidates": {
+            "type": "array",
+            "description": "sprint-candidate issue 編號清單",
+            "items": {"type": "integer", "minimum": 1},
+            "minItems": 1
+          },
+          "capacity_pts": {
+            "type": "integer",
+            "description": "Sprint 容量（points），預設 6",
+            "minimum": 1,
+            "maximum": 8,
+            "default": 6
+          }
+        }
+      }
+    },
+    {
+      "name": "issue_triage",
+      "description": "對新開 GitHub Issue 執行自動分類（Triage）。識別 issue 類型（bug / feature-request / question / enhancement），加上對應 label，並補充缺失資訊請求。",
+      "input_schema": {
+        "type": "object",
+        "required": ["issue_number", "repo"],
+        "properties": {
+          "issue_number": {
+            "type": "integer",
+            "description": "GitHub Issue 編號",
+            "minimum": 1
+          },
+          "repo": {
+            "type": "string",
+            "description": "目標 repo（格式：owner/repo）"
+          },
+          "auto_label": {
+            "type": "boolean",
+            "description": "是否自動套用分類 label，預設 true",
+            "default": true
+          }
+        }
+      }
+    }
+  ],
+  "_meta": {
+    "schema_version": "1.0.0",
+    "created_at": "2026-03-24",
+    "created_by": "Sprint 137 #617",
+    "adr_reference": "ADR-036",
+    "usage": "此為範例檔案，供 Architect 設計 GAD Agent function calling contract 時參考格式。實際 contract 請建立於 docs/schema/sprint-N/ 或 docs/schema/locked/ 目錄。"
+  }
+}


### PR DESCRIPTION
## Summary

Sprint 136 建立了 docs/schema/ 命名規範（#406），但未提供具體的 GAD workflow JSON Schema 範例檔案。本 PR 補充此缺口。

## Changes

- 新增 docs/schema/examples/gad-agent-contract.example.json
  - 格式：JSON Schema Draft 2020-12（符合 Claude tool use 規範）
  - 包含 name / description / input_schema 三個必要欄位及其 schema 定義
  - 附兩個真實 Agent contract 案例：sprint_planning_trigger / issue_triage
- 更新 docs/schema/README.md：在「參考」前新增「範例檔案」表格，連結至此範例

## AC 確認

- AC1: PASS — examples/gad-agent-contract.example.json 存在，properties 包含 name/description/input_schema
- AC2: PASS — $schema 欄位為 https://json-schema.org/draft/2020-12/schema
- AC3: PASS — README.md 連結至範例檔案
- AC4: PASS — 路徑存在性驗證 PASS

Closes #617
