### PR TITLE
feat: #402 Token Cost Routing — Risk-based Model 分級（ADR-039 Phase 1 落地）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 
 1. **版號同步**：bump 版本時必須同時更新 `plugin.json`、`marketplace.json`、`gemini-extension.json`、`CLAUDE.md`、`README.md` badge
 2. **語言慣例**：Skill / Agent 內容使用中文，檔名使用英文 kebab-case
-3. **Agent model**：所有 agent 統一使用 `model: sonnet`
+3. **Agent model**：基準模型為 `model: sonnet`。Agent 定義中若未明確指定 model，預設使用 sonnet。Sprint Planning / Execution 中可依 ADR-039（Token Cost Routing）的風險評分規則路由至 haiku（分數 4-6）或 opus（分數 10-12）。路由決策必須記錄（log action：`model-route #N tier=X score=Y`）。靜態例外（不參與動態路由）：Architect subagent 固定 `opus`、QA subagent 固定 `opus`、Security self-review 固定 `opus`。
 4. **禁止幻覺**：非發散階段（Discovery 以外）禁止生成未定義內容，遇未定義情況應回退詢問
 5. **TDD 雙重驗證**：寫不出測試代表需求不清，必須回退釐清而非強行實作
 6. **日期來源**：所有日期時間必須用 `date` 指令取得系統時間，不可靠 agent 推斷

--- a/docs/km/Metrics_Log.md
+++ b/docs/km/Metrics_Log.md
@@ -363,3 +363,27 @@ shikigami 專案對應目錄：`~/.claude/projects/-home-kevin-shikigami/`
 與實際可存取的 JSONL 結構完全一致，無需修改。
 
 **ADR-003 適用性**：不適用（分支 A 一致，SKILL.md 無需修改；豁免理由已記錄）
+
+---
+
+## Model Routing Log（ADR-039 Token Cost Routing）
+
+<!-- #402 ADR-039 Token Cost Routing 實作 — Sprint 138 -->
+
+Sprint Execution 中各 Story 的 model 路由決策記錄。格式：`model-route #{story_id} tier={1|2|3} score={4-12} model={haiku|sonnet|opus} reason={說明}`
+
+### Sprint 138 Model Routing
+
+| Story | Model Used | Tier | Risk Score | 路由原因 |
+|-------|-----------|------|-----------|---------|
+| #622  | haiku     | 1    | 5          | doc-only 調查（R=1, S=1, C=2, N=1）— 唯讀分析無副作用 |
+| #618  | sonnet    | 2    | 7          | CI workflow fix，影響 production CI，半範本（R=2, S=2, C=2, N=1） |
+| #398  | sonnet    | 2    | 8          | 新建 hooks/ script，影響框架行為，半範本（R=2, S=2, C=2, N=2） |
+| #402  | sonnet    | 2    | 8          | CLAUDE.md + skill 修改，影響所有 agent 行為，半範本（R=2, S=2, C=2, N=2） |
+
+### 說明
+
+- Sprint 138 為 ADR-039 Token Cost Routing 首次應用 Sprint
+- #622 為 Tier 1（haiku）首次套用案例：SRE 調查唯讀任務，風險分數 5
+- 其餘三 Story 均 Tier 2（sonnet），均為有實際框架修改的 FEATURE/INFRA 類
+- 後續 Sprint 從此 log 追蹤路由準確率與成本節省趨勢

--- a/docs/km/rice-scoring-standard.md
+++ b/docs/km/rice-scoring-standard.md
@@ -131,3 +131,33 @@ sprint-candidate Issue body 中的標準格式（po-prompt.md 的正則提取規
 - 新開 sprint-candidate Issue 時，在 Issue body 加入 `**RICE Score** | **N.N**` 格式
 - PO Cruise 巡邏時可在評估後補充 RICE Score 至 Issue comment
 - 本標準文件由 PO 維護，每 3 個月（~12 Sprint）review 一次評分維度
+
+---
+
+## Model Routing 決策規則（ADR-039 Token Cost Routing）
+
+<!-- #402 ADR-039 Token Cost Routing 實作 — Sprint 138 -->
+
+在 RICE Score 基礎上，Sprint 138 新增 **Model Routing** 決策：Story 進入 Sprint Execution 前，依 ADR-039 四維度風險評分選擇適當 model tier。
+
+### 風險評分 → Model Tier 對應
+
+| 風險分數 | Tier | Model | 適用場景 |
+|---------|------|-------|---------|
+| 4–6 | 1 | `haiku` | doc-only 文件修改、格式轉換、retro-action 文件類 |
+| 7–9 | 2 | `sonnet` | 一般功能實作、CI 修復、Backlog 分析（預設） |
+| 10–12 | 3 | `opus` | ADR 架構決策、安全審查、L-size Story |
+
+### RICE Score 與 Model Routing 的關係
+
+- RICE Score 決定 **Backlog 排序優先序**（選哪些 Story 進 Sprint）
+- Risk Score 決定 **執行時 model tier**（用哪個 model 執行）
+- 兩者獨立計算，高 RICE Score 的 Story 不必然使用高 tier model
+
+### 計算範例
+
+| Story | RICE Score | Risk Score（R+S+C+N） | Model Tier |
+|-------|-----------|----------------------|-----------|
+| doc-only retro 任務 | 8 | 4（1+1+1+1）| Tier 1 haiku |
+| CI workflow 修復 | 12 | 7（2+2+2+1）| Tier 2 sonnet |
+| L-size 架構 ADR | 6 | 11（3+3+3+2）| Tier 3 opus |

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -9,7 +9,40 @@
 
 你封裝了整個 Story 生命週期，讓主 session 只需接收最終的 PASS/FAIL 結論與摘要，不累積 QA 對話 context。此設計依據 **ADR-007（Story 生命週期 Subagent 封裝）選項 B**，目標是防止主 session context overflow。
 
-> **模型說明**：本 subagent（Story-Lifecycle Subagent）由主 session 以 `model: "sonnet"` 派遣（Claude 路徑）；或透過 Gemini CLI 以 stdin pipe 載入執行（Gemini 路徑）。Developer / QA 角色涉及 AC 分析、TDD 實作與多階段自審，屬中高複雜度任務，適用 Sonnet 中階模型以兼顧品質與成本效益。
+> **模型說明**：本 subagent（Story-Lifecycle Subagent）預設由主 session 以 `model: "sonnet"` 派遣。依 ADR-039（Token Cost Routing）風險評分規則，主 session 可在派遣前計算風險分數並選擇適當 model tier（見下方 §0.5 風險評分表）。Developer / QA 角色涉及 AC 分析、TDD 實作與多階段自審，屬中高複雜度任務，基準為 Sonnet。
+
+## §0.5 風險評分表（ADR-039 Token Cost Routing）
+
+<!-- #402 ADR-039 Token Cost Routing 實作 — Sprint 138 -->
+
+主 session 在派遣本 subagent 前，依下表對 Story 進行風險評分，根據分數選擇 model tier：
+
+### 評分維度（各 1-3 分，加總 4-12）
+
+| 維度 | 1 分 | 2 分 | 3 分 |
+|------|------|------|------|
+| **Reversibility（可回滾性）** | 可回滾（git revert / 刪除檔案） | 部分可逆 | 不可逆（production 部署、外部 API 呼叫） |
+| **Stakes（影響範圍）** | 僅影響 docs/tests | 影響內部工具 | 影響 user-facing 或 production |
+| **Complexity（推理複雜度）** | 單一文件/明確範本 | 跨多檔案/輕度分析 | 跨模組/架構設計/安全審查 |
+| **Novelty（新穎程度）** | 完全範本化（doc-only retro） | 半範本 | 無範本/首次類型 |
+
+### Model Tier 分級
+
+| 風險分數 | Tier | Model | 適用任務 |
+|---------|------|-------|---------|
+| 4–6 | Tier 1 | `haiku` | doc-only 修改、log 摘要、格式轉換、retro-action 文件類、schema 範例 |
+| 7–9 | Tier 2 | `sonnet` | 一般功能實作、CI workflow 修改、Backlog 分析、Sprint Planning PO Round 1 |
+| 10–12 | Tier 3 | `opus` | 架構設計（ADR）、安全審查、L-size Story、跨 Sprint 依賴分析 |
+
+**靜態例外（不參與動態路由）**：Architect subagent 固定 `opus`、QA subagent 固定 `opus`、Security self-review 固定 `opus`。
+
+### 路由記錄格式
+
+每次路由決策須記錄至 `docs/km/Metrics_Log.md` 的 `model_routing` 欄位：
+
+```
+model-route #{story_id} tier={1|2|3} score={4-12} model={haiku|sonnet|opus} reason={說明}
+```
 
 > **Provider-Aware 說明**：本 prompt 可被兩種方式載入執行，角色行為不因派遣方式改變：
 > - **Claude Agent tool**（預設）：主 session 以 `model: "sonnet"` 派遣，具備完整 tool calling 能力（Read / Edit / Bash 等），適用所有 Story 類型。


### PR DESCRIPTION
## Summary

ADR-039 Token Cost Routing Phase 1 落地（#402）。

在 Shikigami 框架中實作 Risk-based Model 分級路由，允許低風險任務使用 haiku 降低成本，高風險任務使用 opus 提升品質，中等任務維持 sonnet 為基準。

## Changes

- `CLAUDE.md`：紅線 3 修訂，從「統一使用 sonnet」改為「基準 sonnet，可依 ADR-039 風險評分路由」
- `skills/sprint-execution/story-lifecycle-prompt.md`：新增 §0.5 風險評分表（四維度 Reversibility/Stakes/Complexity/Novelty，各 1-3 分）
- `docs/km/Metrics_Log.md`：新增 Model Routing Log 區塊 + Sprint 138 首次路由記錄
- `docs/km/rice-scoring-standard.md`：新增 Model Routing 決策規則說明

## AC 驗收

- [x] AC1：CLAUDE.md 紅線 3 修訂（基準 sonnet，可路由）
- [x] AC2：story-lifecycle-prompt.md §0.5 風險評分表（四維度規則）
- [x] AC3：Metrics_Log.md model_routing 欄位定義 + Sprint 138 記錄
- [x] AC4：rice-scoring-standard.md 更新（Model Routing vs RICE Score 關係說明）
- [x] AC5：sprint_138.md Model Routing 區塊（已在 Planning 階段填入）

## Architecture Note

Phase 1 為靜態分類（Developer subagent 自評風險分數，Sprint Planning 階段預填）。Phase 2（SM 動態評分 hook）視 Phase 1 準確率決定是否推進。

closes #402
