### PR TITLE
feat: #404 TCB 斷點管理 — hooks/tcb-write.sh + §12 TCB 使用指引（ADR-040 落地）

### DIFF
--- a/hooks/tcb-write.sh
+++ b/hooks/tcb-write.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# tcb-write.sh — TCB（Thread Control Block）斷點管理（ADR-040）
+#
+# 用途：記錄 Agent Action 級 Checkpoint，支援細粒度 Sprint 斷點與恢復
+# 設計原則：best-effort（寫入失敗不阻塞主流程），純 shell + file-based
+#
+# 子命令：
+#   init {sprint} {session_id} {story_id}
+#       初始化 session TCB 目錄 + index.json
+#       建立 docs/sprints/tcb/sprint-{sprint}/session-{session_id}/
+#
+#   start {sprint} {session_id} {story_id} {action} [{depends_on}]
+#       記錄 action 開始（status=running）
+#       輸出：tcb_id（如 404-act-1），供 complete 子命令引用
+#
+#   complete {sprint} {session_id} {tcb_id} [{output_ref}]
+#       更新 TCB status=completed，填入 output_ref 與 completed_at
+#
+#   fail {sprint} {session_id} {tcb_id} [{error_msg}]
+#       更新 TCB status=failed，填入 error 與 completed_at
+#
+#   resume {sprint} {session_id}
+#       查詢恢復狀態：輸出 status=failed 或 status=running 的 tcb_id 清單
+#       SM 重啟時使用，判斷從哪個 action 繼續
+#
+# Story: #404 Sprint 139
+# ADR: docs/adr/ADR-040-tcb-checkpoint-design.md
+
+# best-effort：任何 trap/set -e 皆不阻塞主流程
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+AGENT="${SHIKIGAMI_AGENT:-scrum-master}"
+SESSION_ID="${SHIKIGAMI_SESSION_ID:-unknown}"
+
+# ── 工具函式 ──────────────────────────────────────────────
+
+_tcb_dir() {
+  local sprint="$1"
+  local session="$2"
+  echo "${REPO_ROOT}/docs/sprints/tcb/sprint-${sprint}/session-${session}"
+}
+
+_tcb_log() {
+  echo "[TCB] $*" >&2
+}
+
+_tcb_error() {
+  echo "[TCB-WARN] $*" >&2
+}
+
+_now_iso() {
+  date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date +%Y-%m-%dT%H:%M:%SZ
+}
+
+_sha256_digest() {
+  local input="$1"
+  # 取前 16 碼作為 digest
+  echo -n "$input" | sha256sum 2>/dev/null | cut -c1-16 || echo "xxxxxxxxxxxxxxxx"
+}
+
+# 自增序號：讀取 index.json 的 action_count，回傳下一個序號
+_next_seq() {
+  local tcb_dir="$1"
+  local story_id="$2"
+  local index_file="${tcb_dir}/index.json"
+
+  if [ -f "$index_file" ]; then
+    local count
+    count=$(python3 -c "import json; d=json.load(open('${index_file}')); print(d.get('action_count', 0))" 2>/dev/null || echo "0")
+    echo $((count + 1))
+  else
+    echo 1
+  fi
+}
+
+# 更新 index.json 的 action_count
+_update_index_count() {
+  local tcb_dir="$1"
+  local new_count="$2"
+  local index_file="${tcb_dir}/index.json"
+
+  if [ -f "$index_file" ]; then
+    python3 -c "
+import json
+f = '${index_file}'
+d = json.load(open(f))
+d['action_count'] = ${new_count}
+json.dump(d, open(f, 'w'), indent=2, ensure_ascii=False)
+" 2>/dev/null || _tcb_error "failed to update index action_count"
+  fi
+}
+
+# ── 子命令：init ──────────────────────────────────────────
+
+cmd_init() {
+  local sprint="${1:?sprint required}"
+  local session="${2:?session_id required}"
+  local story_id="${3:?story_id required}"
+
+  local tcb_dir
+  tcb_dir="$(_tcb_dir "$sprint" "$session")"
+
+  mkdir -p "$tcb_dir" 2>/dev/null || { _tcb_error "cannot create TCB dir: $tcb_dir"; return 0; }
+
+  local index_file="${tcb_dir}/index.json"
+  if [ ! -f "$index_file" ]; then
+    python3 -c "
+import json
+data = {
+    'sprint': ${sprint},
+    'session_id': '${session}',
+    'created_at': '$(_now_iso)',
+    'action_count': 0,
+    'stories': ['${story_id}'],
+    'tcb_entries': []
+}
+json.dump(data, open('${index_file}', 'w'), indent=2, ensure_ascii=False)
+" 2>/dev/null || _tcb_error "cannot write index.json"
+    _tcb_log "init sprint=${sprint} session=${session} story=${story_id}"
+  else
+    # Append story to existing index if not already present
+    python3 -c "
+import json
+f = '${index_file}'
+d = json.load(open(f))
+if '${story_id}' not in d.get('stories', []):
+    d.setdefault('stories', []).append('${story_id}')
+    json.dump(d, open(f, 'w'), indent=2, ensure_ascii=False)
+" 2>/dev/null || true
+    _tcb_log "init (session exists) sprint=${sprint} session=${session} story=${story_id}"
+  fi
+}
+
+# ── 子命令：start ─────────────────────────────────────────
+
+cmd_start() {
+  local sprint="${1:?sprint required}"
+  local session="${2:?session_id required}"
+  local story_id="${3:?story_id required}"
+  local action="${4:?action required}"
+  local depends_on="${5:-}"
+
+  local tcb_dir
+  tcb_dir="$(_tcb_dir "$sprint" "$session")"
+  mkdir -p "$tcb_dir" 2>/dev/null || { _tcb_error "cannot create TCB dir"; return 0; }
+
+  local seq
+  seq="$(_next_seq "$tcb_dir" "$story_id")"
+  local tcb_id="${story_id}-act-${seq}"
+  local tcb_file="${tcb_dir}/${tcb_id}.json"
+  local input_digest
+  input_digest="$(_sha256_digest "${story_id}:${action}:${seq}")"
+
+  python3 -c "
+import json
+data = {
+    'tcb_id': '${tcb_id}',
+    'story_id': '${story_id}',
+    'sprint': ${sprint},
+    'session_id': '${session}',
+    'agent': '${AGENT}',
+    'action': '${action}',
+    'status': 'running',
+    'depends_on': [x for x in '${depends_on}'.split(',') if x],
+    'input_digest': '${input_digest}',
+    'output_ref': '',
+    'started_at': '$(_now_iso)',
+    'completed_at': '',
+    'error': ''
+}
+json.dump(data, open('${tcb_file}', 'w'), indent=2, ensure_ascii=False)
+" 2>/dev/null || { _tcb_error "cannot write TCB start: $tcb_id"; echo "$tcb_id"; return 0; }
+
+  # Update index count
+  _update_index_count "$tcb_dir" "$seq"
+
+  # Append to index entries
+  python3 -c "
+import json
+f = '${tcb_dir}/index.json'
+if not __import__('os').path.exists(f):
+    d = {'sprint': ${sprint}, 'session_id': '${session}', 'action_count': ${seq}, 'stories': ['${story_id}'], 'tcb_entries': []}
+else:
+    d = json.load(open(f))
+d.setdefault('tcb_entries', []).append({'tcb_id': '${tcb_id}', 'story_id': '${story_id}', 'action': '${action}', 'status': 'running'})
+d['action_count'] = ${seq}
+json.dump(d, open(f, 'w'), indent=2, ensure_ascii=False)
+" 2>/dev/null || true
+
+  _tcb_log "start tcb_id=${tcb_id} action=${action}"
+  echo "$tcb_id"  # Output tcb_id for caller to reference
+}
+
+# ── 子命令：complete ──────────────────────────────────────
+
+cmd_complete() {
+  local sprint="${1:?sprint required}"
+  local session="${2:?session_id required}"
+  local tcb_id="${3:?tcb_id required}"
+  local output_ref="${4:-}"
+
+  local tcb_dir
+  tcb_dir="$(_tcb_dir "$sprint" "$session")"
+  local tcb_file="${tcb_dir}/${tcb_id}.json"
+
+  if [ ! -f "$tcb_file" ]; then
+    _tcb_error "TCB file not found: $tcb_id"
+    return 0  # best-effort
+  fi
+
+  python3 -c "
+import json
+f = '${tcb_file}'
+d = json.load(open(f))
+d['status'] = 'completed'
+d['output_ref'] = '${output_ref}'
+d['completed_at'] = '$(_now_iso)'
+json.dump(d, open(f, 'w'), indent=2, ensure_ascii=False)
+" 2>/dev/null || { _tcb_error "cannot update TCB complete: $tcb_id"; return 0; }
+
+  # Update index entry status
+  python3 -c "
+import json
+f = '${tcb_dir}/index.json'
+if __import__('os').path.exists(f):
+    d = json.load(open(f))
+    for e in d.get('tcb_entries', []):
+        if e.get('tcb_id') == '${tcb_id}':
+            e['status'] = 'completed'
+    json.dump(d, open(f, 'w'), indent=2, ensure_ascii=False)
+" 2>/dev/null || true
+
+  _tcb_log "complete tcb_id=${tcb_id} output_ref=${output_ref}"
+}
+
+# ── 子命令：fail ──────────────────────────────────────────
+
+cmd_fail() {
+  local sprint="${1:?sprint required}"
+  local session="${2:?session_id required}"
+  local tcb_id="${3:?tcb_id required}"
+  local error_msg="${4:-unknown error}"
+
+  local tcb_dir
+  tcb_dir="$(_tcb_dir "$sprint" "$session")"
+  local tcb_file="${tcb_dir}/${tcb_id}.json"
+
+  if [ ! -f "$tcb_file" ]; then
+    _tcb_error "TCB file not found: $tcb_id"
+    return 0
+  fi
+
+  python3 -c "
+import json
+f = '${tcb_file}'
+d = json.load(open(f))
+d['status'] = 'failed'
+d['error'] = '${error_msg}'
+d['completed_at'] = '$(_now_iso)'
+json.dump(d, open(f, 'w'), indent=2, ensure_ascii=False)
+" 2>/dev/null || { _tcb_error "cannot update TCB fail: $tcb_id"; return 0; }
+
+  # Update index
+  python3 -c "
+import json
+f = '${tcb_dir}/index.json'
+if __import__('os').path.exists(f):
+    d = json.load(open(f))
+    for e in d.get('tcb_entries', []):
+        if e.get('tcb_id') == '${tcb_id}':
+            e['status'] = 'failed'
+    json.dump(d, open(f, 'w'), indent=2, ensure_ascii=False)
+" 2>/dev/null || true
+
+  _tcb_log "fail tcb_id=${tcb_id} error=${error_msg}"
+}
+
+# ── 子命令：resume ────────────────────────────────────────
+
+cmd_resume() {
+  local sprint="${1:?sprint required}"
+  local session="${2:?session_id required}"
+
+  local tcb_dir
+  tcb_dir="$(_tcb_dir "$sprint" "$session")"
+
+  if [ ! -d "$tcb_dir" ]; then
+    _tcb_log "resume: no TCB session found for sprint=${sprint} session=${session}"
+    echo "[]"
+    return 0
+  fi
+
+  # Find all TCB files with status=running or status=failed
+  python3 -c "
+import json, os, glob
+tcb_dir = '${tcb_dir}'
+incomplete = []
+for f in sorted(glob.glob(os.path.join(tcb_dir, '*-act-*.json'))):
+    try:
+        d = json.load(open(f))
+        if d.get('status') in ('running', 'failed', 'pending'):
+            incomplete.append({
+                'tcb_id': d.get('tcb_id'),
+                'story_id': d.get('story_id'),
+                'action': d.get('action'),
+                'status': d.get('status')
+            })
+    except Exception:
+        pass
+print(json.dumps(incomplete, indent=2, ensure_ascii=False))
+" 2>/dev/null || echo "[]"
+}
+
+# ── 主入口 ────────────────────────────────────────────────
+
+SUBCMD="${1:-}"
+
+# best-effort wrapper：任何錯誤只輸出警告，不退出
+{
+  case "$SUBCMD" in
+    init)
+      shift
+      cmd_init "$@"
+      ;;
+    start)
+      shift
+      cmd_start "$@"
+      ;;
+    complete)
+      shift
+      cmd_complete "$@"
+      ;;
+    fail)
+      shift
+      cmd_fail "$@"
+      ;;
+    resume)
+      shift
+      cmd_resume "$@"
+      ;;
+    ""|--help|-h)
+      echo "Usage: tcb-write.sh <init|start|complete|fail|resume> [args...]"
+      echo "  init     {sprint} {session_id} {story_id}"
+      echo "  start    {sprint} {session_id} {story_id} {action} [{depends_on}]"
+      echo "  complete {sprint} {session_id} {tcb_id} [{output_ref}]"
+      echo "  fail     {sprint} {session_id} {tcb_id} [{error_msg}]"
+      echo "  resume   {sprint} {session_id}"
+      ;;
+    *)
+      _tcb_error "unknown subcommand: $SUBCMD"
+      exit 0  # best-effort: unknown command exits 0
+      ;;
+  esac
+} || true  # best-effort: catch all errors (stderr stays on stderr, not merged)
+
+exit 0  # Always exit 0 (best-effort, AC5)

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -745,3 +745,55 @@ commit 失敗 → 輸出 `[COMMIT-FAIL] 原因: {msg}，影響: {files}` → `ES
 | `references/output-schema.md` | §9 輸出格式（YAML 契約、PASS/ESCALATE 模板、升級決策） |
 
 > **Trace Log 隱私保護**（#392 ADR-033）：trace log 不記錄使用者輸入內容，僅記錄 action metadata（agentRole、action 名稱、timestamp、duration、storyId）。禁止將 `$CLAUDE_TOOL_INPUT`、使用者提供的文字或任何 PII 寫入 trace log。
+
+---
+
+## §12 TCB（Thread Control Block）斷點管理（ADR-040）
+
+<!-- #404 Sprint 139 — TCB Checkpoint 整合 -->
+
+Story-Lifecycle Subagent 在執行**關鍵路徑 action**（高成本或有副作用的操作）時，應使用 `hooks/tcb-write.sh` 記錄 action 狀態，支援 Sprint 中斷後的細粒度恢復。
+
+**觸發條件**：session 中有 `SHIKIGAMI_SESSION_ID` 環境變數（自動觸發），或 SM 明確傳入 `tcb_enabled: true`。
+
+### 12.1 關鍵路徑 Action 分類（ADR-040 決策 1）
+
+| Action 類型 | 記錄 | 說明 |
+|------------|------|------|
+| `git commit` / `git push` | **必記錄** | 有副作用，不可重複 |
+| `gh pr create` / `gh pr merge` | **必記錄** | 外部 API，不可重複 |
+| 文件生成（ADR / Sprint doc / Meeting notes）| **必記錄** | 高成本輸出 |
+| LLM 分析輸出（>500 token）| **必記錄** | 高成本，可快取 |
+| 驗證腳本（validate-*.sh）| 可選 | 低成本，可重跑 |
+| git checkout / worktree 操作 | 不記錄 | 低成本，冪等 |
+
+### 12.2 使用範式
+
+```bash
+# Story 開始時初始化 TCB session
+bash hooks/tcb-write.sh init "${SPRINT_NUM}" "${SHIKIGAMI_SESSION_ID:-unknown}" "${STORY_ID}" 2>/dev/null || true
+
+# 關鍵 action 開始前記錄（保存 tcb_id 供後續 complete/fail 使用）
+TCB_ID=$(bash hooks/tcb-write.sh start "${SPRINT_NUM}" "${SHIKIGAMI_SESSION_ID:-unknown}" "${STORY_ID}" "git-commit" 2>/dev/null)
+
+# ... 執行 action ...
+
+# Action 成功後記錄完成
+bash hooks/tcb-write.sh complete "${SPRINT_NUM}" "${SHIKIGAMI_SESSION_ID:-unknown}" "${TCB_ID}" "${OUTPUT_REF}" 2>/dev/null || true
+
+# Action 失敗時記錄失敗
+bash hooks/tcb-write.sh fail "${SPRINT_NUM}" "${SHIKIGAMI_SESSION_ID:-unknown}" "${TCB_ID}" "${ERROR_MSG}" 2>/dev/null || true
+```
+
+**best-effort 原則（ADR-040 決策 1）**：TCB 寫入失敗（`|| true`）不阻塞主流程。失敗訊息輸出至 stderr，不影響 Story 執行結果。
+
+### 12.3 Sprint 重啟恢復（SM 職責）
+
+SM 在 session 啟動時執行恢復檢測：
+```bash
+# 查詢未完成的 TCB actions
+INCOMPLETE=$(bash hooks/tcb-write.sh resume "${SPRINT_NUM}" "${SHIKIGAMI_SESSION_ID}" 2>/dev/null)
+# 若有 status=running|failed 的 action → [RECOVERY-TRIGGER]，參照 ADR-041 恢復流程
+```
+
+詳見 `docs/adr/ADR-040-tcb-checkpoint-design.md` 與 `docs/adr/ADR-041-crash-recovery-design.md`。


### PR DESCRIPTION
feat: TCB 斷點管理 — Agent Action 級 Checkpoint（ADR-040 落地）

## Summary

- 新建 `hooks/tcb-write.sh`：支援 `init | start | complete | fail | resume` 四個子命令
- TCB JSON schema 符合 ADR-040 決策 1（關鍵路徑 action 分類：git-commit/push, gh-pr-create/merge, 文件生成, LLM 分析輸出）
- 儲存路徑：`docs/sprints/tcb/sprint-N/session-{id}/`（per-session 隔離，ADR-040 決策 2）
- `best-effort` 語義：寫入失敗 `|| true`，`exit 0`，不阻塞主流程（AC5）
- `skills/sprint-execution/story-lifecycle-prompt.md` §12 新增 TCB 使用指引（AC4）

## Test Plan

- [x] `hooks/tcb-write.sh init|start|complete|fail|resume` 所有子命令手動測試通過
- [x] `bash scripts/validate-json.sh` PASS
- [x] `bash tests/test-*.sh` PASS（12/16，4 個 pre-existing failures 無變化）
- [x] Spec Compliance: AC1-AC7 全部通過
- [x] Team Debate PASS（設計完全遵循 ADR-040 規格）

## Closes

Closes #404
