### PR TITLE
shoot: #644 sprint_N.md TODO→DONE Issue ID 精確匹配修正

### DIFF
--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -347,7 +347,10 @@ Claim Story（§2.11，多 Session 並行協調）
   │  Story Completion Checklist（#368 方向3，每個 Story 完成後） │
   │  1. [ ] git checkout main && git pull                       │
   │  2. [ ] 更新 PROJECT_BOARD.md + sprint_N.md 狀態           │
-  │         sprint_N.md：每個完成 Story 行尾加 DONE(#PR) 標記  │
+  │         sprint_N.md：找到含 Issue ID 的 Story 資料列，     │
+  │         將該列最後一欄（狀態欄）的值替換為 DONE(#PR)。     │
+  │         匹配方式：以 Issue ID 定位列，取代最後一欄值，     │
+  │         不依賴完整行格式（避免欄位變動致 replace 未命中）  │
   │         git commit + push（豁免直推 main，ADR-023 決策 3）  │
   │  3. [ ] 寫入 sprint-checkpoint.json（§2.12，豁免直推 main）  │
   │  4. [ ] release claim：bash hooks/release-issue.sh <id>    │

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -638,7 +638,18 @@ commit 失敗 → 輸出 `[COMMIT-FAIL] 原因: {msg}，影響: {files}` → `ES
 
 ## §8.2 共用文件更新（循序執行路徑）
 
-**循序模式**：直接讀取並更新 `PROJECT_BOARD.md` 與 `sprint_N.md` 狀態欄（依 `SKILL.md` §3 步驟 7，含 read-then-compare 衝突偵測），完成後 git commit + git push。**sprint_N.md 每個完成 Story 行尾必須加 `DONE(#PR)` 標記**（`#PR` 為合併的 PR 編號）。
+**循序模式**：直接讀取並更新 `PROJECT_BOARD.md` 與 `sprint_N.md` 狀態欄（依 `SKILL.md` §3 步驟 7，含 read-then-compare 衝突偵測），完成後 git commit + git push。
+
+**sprint_N.md 狀態欄更新步驟**（`#PR` 為合併的 PR 編號）：
+1. 讀取 sprint_N.md 全文（Read 工具）
+2. 找到含當前 Story Issue ID 精確欄位（如 `| #637 |`）的資料列
+3. 將該列**最後一欄**的值替換為 `DONE(#PR)`
+   - 匹配方式：以 `| #NNN |`（pipe-delimited）精確定位資料列，再取代最後一欄值
+   - 不使用 substring 匹配（避免 #63 誤命中 #637）
+   - 不依賴完整行格式（避免 ADR 欄等欄位變動導致 replace 未命中）
+   - 替換後格式：`... | DONE(#640) |`
+4. 以 Edit 工具寫回（old_string = 原始資料列全文，new_string = 替換後全文）
+   - 使用完整資料列作為 old_string 確保精確定位
 
 ## §8.3 共用文件更新（平行執行路徑）
 

--- a/tests/test-sprint-status-update.sh
+++ b/tests/test-sprint-status-update.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# tests/test-sprint-status-update.sh
+# Issue #644 — retro: sprint_N.md TODO→DONE 狀態更新邏輯驗證
+# 驗證以 Issue ID 定位資料列、取代最後一欄（狀態欄）的替換邏輯
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# 測試框架
+# ---------------------------------------------------------------------------
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  echo "PASS: $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# ---------------------------------------------------------------------------
+# 替換函式：以 Issue ID 定位列，取代最後一欄值
+# 用法：update_sprint_status <file> <issue_id> <new_status>
+# ---------------------------------------------------------------------------
+update_sprint_status() {
+  local file="$1"
+  local issue_id="$2"
+  local new_status="$3"
+
+  # 找到含 Issue ID 的精確欄位（| #NNN |），將最後一欄值替換
+  # 使用 pipe-delimited 匹配避免 substring 誤命中（如 #63 不會匹配 #637）
+  sed -i -E "/\\| ${issue_id} \\|/s/\\| [^|]+ \\|$/| ${new_status} |/" "$file"
+}
+
+# ---------------------------------------------------------------------------
+# Setup: 建立暫存測試目錄
+# ---------------------------------------------------------------------------
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "=== test-sprint-status-update.sh ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# TC-1: 正常情境 — 8 欄表格（含 ADR 欄），TODO → DONE(#640)
+# ---------------------------------------------------------------------------
+cat > "$TMPDIR/sprint_140.md" << 'EOF'
+## Sprint Backlog
+
+| Story | Issue | Type | Size | Points | ADR | 負責人 | 狀態 |
+|-------|-------|------|------|--------|-----|--------|------|
+| retro: CI Token 輪換 | #637 | INFRA | S | 1 | 無需 | Developer | TODO |
+| feat: Crash Recovery | #405 | FEATURE | M | 2 | ADR-041 ✓ | Developer | TODO |
+| feat: Session Watchdog | #408 | FEATURE | M | 2 | ADR-042 ✓ | Developer | TODO |
+EOF
+
+update_sprint_status "$TMPDIR/sprint_140.md" "#637" "DONE(#640)"
+
+if grep -q '| #637 |.*| DONE(#640) |' "$TMPDIR/sprint_140.md"; then
+  pass "TC-1: 8 欄表格 #637 TODO → DONE(#640) 替換成功"
+else
+  fail "TC-1: 8 欄表格 #637 TODO → DONE(#640) 替換失敗"
+fi
+
+# 確認其他列未被修改
+if grep -q '| #405 |.*| TODO |' "$TMPDIR/sprint_140.md"; then
+  pass "TC-1b: #405 列未受影響"
+else
+  fail "TC-1b: #405 列被意外修改"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-2: 邊界情境 — ADR 欄含特殊字元（ADR-041 ✓）
+# ---------------------------------------------------------------------------
+update_sprint_status "$TMPDIR/sprint_140.md" "#405" "DONE(#641)"
+
+if grep -q '| #405 |.*| ADR-041 ✓ |.*| DONE(#641) |' "$TMPDIR/sprint_140.md"; then
+  pass "TC-2: ADR 含特殊字元時替換正確"
+else
+  fail "TC-2: ADR 含特殊字元時替換失敗"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-3: 負向情境 — Issue ID 不存在時不修改
+# ---------------------------------------------------------------------------
+BEFORE=$(cat "$TMPDIR/sprint_140.md")
+update_sprint_status "$TMPDIR/sprint_140.md" "#999" "DONE(#999)"
+AFTER=$(cat "$TMPDIR/sprint_140.md")
+
+if [[ "$BEFORE" == "$AFTER" ]]; then
+  pass "TC-3: 不存在的 Issue ID #999 未修改任何列"
+else
+  fail "TC-3: 不存在的 Issue ID #999 意外修改了內容"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-4: 7 欄舊格式表格（無 ADR 欄）也能正確替換
+# ---------------------------------------------------------------------------
+cat > "$TMPDIR/sprint_old.md" << 'EOF'
+| Story | Issue | Type | Size | Points | 負責人 | 狀態 |
+|-------|-------|------|------|--------|--------|------|
+| fix: Bug | #100 | BUG | S | 1 | Developer | TODO |
+EOF
+
+update_sprint_status "$TMPDIR/sprint_old.md" "#100" "DONE(#200)"
+
+if grep -q '| #100 |.*| DONE(#200) |' "$TMPDIR/sprint_old.md"; then
+  pass "TC-4: 7 欄舊格式替換成功（向後相容）"
+else
+  fail "TC-4: 7 欄舊格式替換失敗"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-5: 多個 Story 連續替換
+# ---------------------------------------------------------------------------
+update_sprint_status "$TMPDIR/sprint_140.md" "#408" "DONE(#642)"
+
+DONE_COUNT=$(grep -c 'DONE(#' "$TMPDIR/sprint_140.md")
+if [[ "$DONE_COUNT" -eq 3 ]]; then
+  pass "TC-5: 3 個 Story 全部替換為 DONE"
+else
+  fail "TC-5: 預期 3 個 DONE，實際 ${DONE_COUNT} 個"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-6: 表頭行（| 狀態 |）不被替換
+# ---------------------------------------------------------------------------
+if grep -q '| 狀態 |' "$TMPDIR/sprint_140.md"; then
+  pass "TC-6: 表頭行未被替換"
+else
+  fail "TC-6: 表頭行被意外修改"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-7: Substring 防護 — #63 不會誤命中 #637
+# ---------------------------------------------------------------------------
+cat > "$TMPDIR/sprint_substring.md" << 'EOF'
+| Story | Issue | Type | Size | Points | ADR | 負責人 | 狀態 |
+|-------|-------|------|------|--------|-----|--------|------|
+| feat: Short ID | #63 | FEATURE | S | 1 | 無需 | Developer | TODO |
+| feat: Long ID | #637 | FEATURE | S | 1 | 無需 | Developer | TODO |
+EOF
+
+update_sprint_status "$TMPDIR/sprint_substring.md" "#63" "DONE(#700)"
+
+if grep -q '| #63 |.*| DONE(#700) |' "$TMPDIR/sprint_substring.md"; then
+  pass "TC-7a: #63 正確替換為 DONE(#700)"
+else
+  fail "TC-7a: #63 替換失敗"
+fi
+
+if grep -q '| #637 |.*| TODO |' "$TMPDIR/sprint_substring.md"; then
+  pass "TC-7b: #637 未被 #63 的 substring 誤命中"
+else
+  fail "TC-7b: #637 被 #63 的 substring 誤命中"
+fi
+
+# ---------------------------------------------------------------------------
+# 結果摘要
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== 結果：${PASS_COUNT} PASS / ${FAIL_COUNT} FAIL ==="
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **Root cause**: Story Completion Checklist §3 步驟 2 使用完整行匹配，當表格新增 ADR 欄時 pattern 未命中
- **Fix**: 改為 Issue ID pipe-delimited 精確匹配（`| #NNN |`），取代最後一欄值
- **Docs**: SKILL.md §3 + story-lifecycle-prompt.md §8.2 新增明確操作指引
- **Tests**: 9 個測試案例（正向/邊界/負向/substring 防護）

## Test plan
- [x] bash tests/test-sprint-status-update.sh — 9 PASS / 0 FAIL
- [x] QA Pre-flight PASS
- [x] Architect 審查 PASS (DM-1~DM-4)
- [x] QA Post-check PASS (Spec Compliance + Code Quality)
- [x] External independent review: CONFIRM
- [x] pr-review-toolkit code-reviewer: substring bug found and fixed

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
