### PR TITLE
fix: #646 watchdog-monitor.sh 閾值對齊 #408 NFR1 規格（30→10 min）

### DIFF
--- a/scripts/watchdog-monitor.sh
+++ b/scripts/watchdog-monitor.sh
@@ -2,6 +2,7 @@
 # scripts/watchdog-monitor.sh
 # Story #408 — Session Watchdog: Heartbeat Timeout Detection
 # ADR-042 決策 1 + 2：監控 heartbeat 文件更新時間，超過閾值觸發 hang 偵測
+# #646 — 閾值對齊 #408 NFR1：hang 偵測延遲 < timeout + 1 分鐘（timeout=10min）
 #
 # 使用方式：
 #   bash scripts/watchdog-monitor.sh [--check-only] [--session SESSION_ID]
@@ -9,12 +10,18 @@
 #
 # --check-only：單次檢查後退出（不持續監控）
 # 無 --check-only：持續監控循環（每 60 秒檢查一次）
+#
+# 環境變數覆蓋（SHIKIGAMI_WATCHDOG_TIMEOUT 為語意別名，等同 SHIKIGAMI_WD_HANG_MINS）：
+#   SHIKIGAMI_WATCHDOG_TIMEOUT=<分鐘>  — 覆蓋 hang 判定閾值（優先於 SHIKIGAMI_WD_HANG_MINS）
+#   SHIKIGAMI_WD_HANG_MINS=<分鐘>     — 覆蓋 hang 判定閾值
+#   SHIKIGAMI_WD_WARN_MINS=<分鐘>     — 覆蓋警告閾值
 
 set -uo pipefail
 
 # ── 配置 ──
-WD_WARN_MINS="${SHIKIGAMI_WD_WARN_MINS:-15}"   # 警告閾值（分鐘）
-WD_HANG_MINS="${SHIKIGAMI_WD_HANG_MINS:-30}"   # hang 判定閾值（分鐘）
+# SHIKIGAMI_WATCHDOG_TIMEOUT 為語意別名（AC4/#646），優先於 SHIKIGAMI_WD_HANG_MINS
+WD_WARN_MINS="${SHIKIGAMI_WD_WARN_MINS:-8}"    # 警告閾值（分鐘）— #646: 8m（< 10m hang 閾值）
+WD_HANG_MINS="${SHIKIGAMI_WATCHDOG_TIMEOUT:-${SHIKIGAMI_WD_HANG_MINS:-10}}"  # hang 判定閾值（分鐘）— #646: 10m（對齊 #408 NFR1）
 WD_POLL_SECS="${SHIKIGAMI_WD_POLL_SECS:-60}"   # 輪詢間隔（秒）
 
 # ── 引數解析 ──

--- a/tests/test-watchdog.sh
+++ b/tests/test-watchdog.sh
@@ -153,6 +153,35 @@ if [[ -f "scripts/watchdog-restart.sh" ]]; then
   fi
 fi
 
+# AC1（#646）: watchdog-monitor.sh 預設閾值驗證（10 分鐘）
+# NFR1：hang 偵測延遲 < timeout + 1 分鐘（#408 規格：timeout=10min → 偵測 < 11min）
+# 預設 WD_HANG_MINS 應為 10，WD_WARN_MINS 應為 8（或 ≤ 10）
+echo "[AC1/#646] watchdog-monitor.sh 預設閾值驗證"
+if [[ -f "scripts/watchdog-monitor.sh" ]]; then
+  DEFAULT_HANG=$(grep -E '^WD_HANG_MINS=.*:-[0-9]+' scripts/watchdog-monitor.sh | grep -oE ':-[0-9]+\}' | grep -oE '[0-9]+' | head -1)
+  DEFAULT_WARN=$(grep -E '^WD_WARN_MINS=.*:-[0-9]+' scripts/watchdog-monitor.sh | grep -oE ':-[0-9]+\}' | grep -oE '[0-9]+' | head -1)
+  if [[ "${DEFAULT_HANG}" == "10" ]]; then
+    check "WD_HANG_MINS 預設值 = 10 分鐘（#408 NFR1 規格）" "PASS"
+  else
+    check "WD_HANG_MINS 預設值 = 10 分鐘（實際: ${DEFAULT_HANG:-未設定}）" "FAIL"
+  fi
+  if [[ -n "${DEFAULT_WARN}" ]] && [[ "${DEFAULT_WARN}" -le 10 ]]; then
+    check "WD_WARN_MINS 預設值 ≤ 10 分鐘（實際: ${DEFAULT_WARN}）" "PASS"
+  else
+    check "WD_WARN_MINS 預設值 ≤ 10 分鐘（實際: ${DEFAULT_WARN:-未設定}）" "FAIL"
+  fi
+  # SHIKIGAMI_WATCHDOG_TIMEOUT 環境變數應可覆蓋 WD_HANG_MINS（AC4）
+  if grep -q "SHIKIGAMI_WATCHDOG_TIMEOUT\|SHIKIGAMI_WD_HANG_MINS" scripts/watchdog-monitor.sh 2>/dev/null; then
+    check "SHIKIGAMI_WATCHDOG_TIMEOUT / SHIKIGAMI_WD_HANG_MINS 環境變數覆蓋支援" "PASS"
+  else
+    check "SHIKIGAMI_WATCHDOG_TIMEOUT / SHIKIGAMI_WD_HANG_MINS 環境變數覆蓋支援" "FAIL"
+  fi
+else
+  check "WD_HANG_MINS 預設值 = 10 分鐘" "FAIL"
+  check "WD_WARN_MINS 預設值 ≤ 10 分鐘" "FAIL"
+  check "SHIKIGAMI_WATCHDOG_TIMEOUT / SHIKIGAMI_WD_HANG_MINS 環境變數覆蓋支援" "FAIL"
+fi
+
 echo ""
 echo "=== 結果：$PASS PASS, $FAIL FAIL ==="
 if [[ $FAIL -gt 0 ]]; then


### PR DESCRIPTION
## 摘要

- watchdog-monitor.sh hang 偵測閾值從 30 分鐘調整為 10 分鐘，對齊 #408 NFR1 規格
- warn 閾值從 15 分鐘調整為 8 分鐘（低於 hang 閾值）
- 新增 SHIKIGAMI_WATCHDOG_TIMEOUT 語意別名，AC4 環境變數覆蓋支援
- tests/test-watchdog.sh 新增 [AC1/#646] 閾值驗證段落，全程 15 PASS

## 驗收標準對照

- AC1: WD_HANG_MINS 預設 = 10 分鐘 — PASS
- AC2: WD_WARN_MINS 預設 <= 10 分鐘（實際 8）— PASS
- AC3: 過期 heartbeat 正確觸發告警 — PASS（既有 AC4 測試）
- AC4: SHIKIGAMI_WATCHDOG_TIMEOUT / SHIKIGAMI_WD_HANG_MINS 環境變數覆蓋支援 — PASS

## 測試計畫

- [x] bash tests/test-watchdog.sh — 15 PASS, 0 FAIL
- [x] 新增 [AC1/#646] 預設閾值驗證 3 個測試項目
- [x] 既有 AC1-AC5 測試全部通過，無回歸

Closes #646
