### PR TITLE
retro: #667 validate-skills.sh 覆蓋完整性驗證 PASS

### DIFF
--- a/docs/km/shoot-log/2026-03-25-story-667-verification.md
+++ b/docs/km/shoot-log/2026-03-25-story-667-verification.md
@@ -1,0 +1,61 @@
+# Story #667 — validate-skills.sh 覆蓋完整性驗證報告
+
+**日期**: 2026-03-25
+**Sprint**: 144
+**Issue**: #667
+
+## 驗證目標
+
+Sprint 143 完成 #654（sprint-execution/SKILL.md 拆分至 references/ 子目錄），驗證 validate-skills.sh 在新結構下仍能正確偵測 SKILL 完整性。
+
+## 驗證結果
+
+### AC1: validate-skills.sh 執行 PASS
+
+```
+bash scripts/validate-skills.sh
+# 輸出：總結：Skill 完整性驗證全部通過（共 30 個 Skill）
+# exit code: 0
+```
+
+### NFR 驗收 — Skill 數量一致性
+
+| 檢查項目 | 結果 |
+|---------|------|
+| validate-skills.sh 回報 Skill 數量 | 30 |
+| `ls skills/ \| wc -l` 實際目錄數 | 30 |
+| 數量一致 | YES |
+
+### sprint-execution 覆蓋分析
+
+- `skills/sprint-execution/SKILL.md` 存在 → validate-skills.sh 正確偵測 ✓
+- `skills/sprint-execution/references/` 下有 26 個 .md 文件（content files）
+- references/*.md **不是獨立 Skill**，是 sprint-execution Skill 的內容文件
+- validate-skills.sh 設計為掃描頂層 Skill 目錄（`find -maxdepth 1 -mindepth 1`），此設計正確
+- references/ 子目錄內容由 SKILL.md 引用，不需要獨立驗證
+
+### AC2: 路徑更新後全 validate-*.sh PASS
+
+無需路徑更新（腳本邏輯正確）。執行完整 validate suite：
+
+```
+bash scripts/validate-skills.sh   → PASS (0 errors)
+bash scripts/validate-version.sh  → PASS
+bash scripts/validate-agents.sh   → PASS  
+bash scripts/validate-json.sh     → PASS
+```
+
+### 結論
+
+validate-skills.sh 在 sprint-execution/references/ 新結構下覆蓋完整，無盲區。**不需要修改腳本**。
+
+## Spec Compliance Review
+
+- [x] AC1: validate-skills.sh PASS ✓
+- [x] AC2: 無路徑更新需求，全 validate-*.sh PASS ✓
+- [x] AC3: 驗證結果已記錄於本文件 ✓
+- [x] NFR: reliability — 數量一致性確認 (30=30) ✓
+
+## 附記：發現的既有問題
+
+`bash scripts/validate-version.sh` 顯示 `gemini-extension.json` 版號為 0.95.0，與 plugin.json 0.95.1 不一致。此為 Sprint 144 #667 Story 範疇外的既有問題，記錄於此供後續 Sprint 排程修復。


### PR DESCRIPTION
retro: #667 validate-skills.sh 覆蓋完整性驗證 PASS

## 驗證結論

Sprint 143 #654（sprint-execution/SKILL.md 拆分）後，validate-skills.sh 仍能正確覆蓋所有 Skill。

- validate-skills.sh PASS（共 30 個 Skill，數量一致）
- references/*.md 為 sprint-execution Skill 的內容文件，非獨立 Skill，掃描邏輯正確
- 無盲區，無需修改腳本
- 附記：發現 gemini-extension.json 版號不一致（0.95.0 vs 0.95.1），超出本 Story 範疇

Closes #667
