### PR TITLE
feat: TDAD 依賴分析可透過設定關閉 (#653)

### DIFF
--- a/skills/sprint-execution/developer-prompt.md
+++ b/skills/sprint-execution/developer-prompt.md
@@ -20,13 +20,34 @@
 ## Pre-TDD Dependency Analysis（TDAD，ADR-035，#394）
 
 <!-- feat: TDAD Dependency Map — Sprint 132，ADR-035 Accepted -->
+<!-- feat: TDAD 可透過設定關閉 — Sprint 144，#653 -->
 
 在進入 TDD 循環之前，若 Story 涉及修改已有測試覆蓋的程式碼模組，**必須**先執行依賴分析，識別受影響的測試集合。
+
+### TDAD 啟用設定（#653）
+
+TDAD 可透過 `.claude/shikigami.local.md` 設定關閉：
+
+```yaml
+shikigami:
+  tdad: true   # true（預設，向後相容）| false（跳過 TDAD，適合小型專案）
+```
+
+**讀取方式**：
+
+```bash
+TDAD_ENABLED=$(grep -A10 'shikigami:' .claude/shikigami.local.md 2>/dev/null \
+  | grep 'tdad:' | awk '{print $2}' | head -1)
+TDAD_ENABLED="${TDAD_ENABLED:-true}"  # 預設 true（向後相容）
+```
+
+若 `tdad=false`，跳過整個 Pre-TDD Dependency Analysis 步驟，直接進入 TDD Red phase。輸出 `[TDAD-SKIP] tdad=false，跳過依賴分析`。
 
 ### 觸發條件
 
 | 情況 | 處置 |
 |------|------|
+| `tdad=false`（設定關閉） | 跳過 TDAD，直接進入 TDD Red |
 | Story 修改已有測試覆蓋的程式碼模組 | 執行 Pre-TDD Dependency Analysis（強制） |
 | Story 為新增功能（無既有測試） | 跳過，直接進入 TDD Red |
 | Story 為 doc-only / RESEARCH | 跳過，TDD 豁免 |

--- a/tests/test-tdad-config.sh
+++ b/tests/test-tdad-config.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# tests/test-tdad-config.sh
+# Test: TDAD 依賴分析可透過設定關閉 (#653)
+#
+# AC1: developer-prompt.md TDAD 觸發條件加入 tdad=false 時跳過
+# AC2: 預設 true（向後相容）
+# AC3: 測試驗證
+
+set -uo pipefail
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "[PASS] $1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { echo "[FAIL] $1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+DEVELOPER_PROMPT="skills/sprint-execution/developer-prompt.md"
+
+echo "=== Test: #653 TDAD 依賴分析可透過設定關閉 ==="
+echo ""
+
+# AC1: developer-prompt.md 應包含 tdad=false 跳過條件
+echo "--- AC1: developer-prompt.md 含 tdad=false 跳過條件 ---"
+if grep -q "tdad.*false\|tdad=false\|tdad: false" "$DEVELOPER_PROMPT" 2>/dev/null; then
+  pass "AC1: developer-prompt.md 含 tdad=false 跳過條件"
+else
+  fail "AC1: developer-prompt.md 未含 tdad=false 跳過條件"
+fi
+
+# AC2: 預設為 true（backward compatible）- developer-prompt.md 應說明預設行為
+echo "--- AC2: developer-prompt.md 說明預設行為（tdad 預設啟用）---"
+if grep -q "tdad.*true\|預設.*啟用\|預設.*true\|backward\|向後相容" "$DEVELOPER_PROMPT" 2>/dev/null; then
+  pass "AC2: developer-prompt.md 說明 tdad 預設啟用（向後相容）"
+else
+  fail "AC2: developer-prompt.md 未說明 tdad 預設行為"
+fi
+
+# AC1 detail: grep 確認 .claude/shikigami.local.md 讀取方式有描述
+echo "--- AC1 detail: 讀取設定方式描述 ---"
+if grep -q "shikigami.local.md\|local.md\|tdad" "$DEVELOPER_PROMPT" 2>/dev/null; then
+  pass "AC1 detail: developer-prompt.md 描述設定讀取方式"
+else
+  fail "AC1 detail: developer-prompt.md 未描述設定讀取方式"
+fi
+
+echo ""
+echo "=============================="
+echo " 測試結果：PASS=$PASS_COUNT, FAIL=$FAIL_COUNT"
+echo "=============================="
+
+[ $FAIL_COUNT -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
feat: TDAD 依賴分析可透過設定關閉 (#653)

## 變更說明

developer-prompt.md 新增 tdad 設定讀取邏輯，允許透過 .claude/shikigami.local.md 關閉 TDAD 分析。

## 變更內容

- skills/sprint-execution/developer-prompt.md: 新增 TDAD 啟用設定區塊
  - 說明 shikigami.tdad: true/false 設定
  - 讀取方式（bash grep）
  - tdad=false 時跳過並輸出 [TDAD-SKIP]
  - 預設 true（向後相容）
- tests/test-tdad-config.sh: 新增測試（3/3 PASS）

## 測試

bash tests/test-tdad-config.sh → PASS (3/3)

Closes #653
