### PR TITLE
feat: validate-orphans.sh 豁免清單機制 — .orphan-allowlist (#658)

### DIFF
--- a/.orphan-allowlist
+++ b/.orphan-allowlist
@@ -1,0 +1,22 @@
+# .orphan-allowlist — validate-orphans.sh 永久性孤兒豁免清單
+# 每行為一個豁免路徑前綴（支援前綴匹配）
+# 匹配的孤兒文件改為 [INFO] 輸出，不計入 WARNING 數
+# 空行與 # 開頭行視為註解忽略
+#
+# 建立日期：2026-03-25（Sprint 144，#658）
+# 更新方式：直接新增一行路徑前綴，commit 至 repo（專案設定，需可重現）
+
+# Sprint subagent 執行結果（設計上不需要被引用）
+docs/sprints/subagent-results/
+
+# Sprint TCB 斷點文件
+docs/sprints/tcb/
+
+# Sprint Watchdog 監控文件
+docs/sprints/watchdog/
+
+# 決策文件（非 ADR 格式的決策紀錄）
+docs/decisions/
+
+# 文件模板（設計上為範本，不需被引用）
+docs/templates/

--- a/scripts/validate-orphans.sh
+++ b/scripts/validate-orphans.sh
@@ -11,6 +11,12 @@
 #       exit code 均為 0（warning 不影響 CI pass/fail）
 # AC3：處置說明 — 見 skills/health-check/SKILL.md 第 6 節
 #
+# .orphan-allowlist 豁免清單機制（#658）：
+#   專案根目錄下的 .orphan-allowlist 文件，每行為一個豁免路徑前綴。
+#   匹配豁免前綴的孤兒文件改為 [INFO] 級別輸出，不計入 WARNING 數。
+#   建立方式：在專案根目錄建立 .orphan-allowlist，每行填入豁免路徑前綴
+#   （如 docs/sprints/subagent-results/），空行與 # 開頭行視為註解忽略。
+#
 # 使用方式：
 #   bash scripts/validate-orphans.sh
 #   （在專案根目錄下執行；docs/ 目錄相對於 cwd）
@@ -28,13 +34,42 @@ source "$(dirname "$0")/lib/validate-helpers.sh"
 # 常數
 # ---------------------------------------------------------------------------
 readonly DOCS_DIR="docs"
+readonly ALLOWLIST_FILE=".orphan-allowlist"
 
 # 豁免清單規則（4 類）：
 #   CLASS_1：sprints/sprint_N.md — Sprint 週期文件，不需要被引用
 #   CLASS_2：km/Metrics_Log.md — 度量紀錄，自動累積不需引用
 #   CLASS_3：頂層文件（docs/ 直屬，非子目錄）— PROJECT_BOARD.md 等
 #   CLASS_4：adr/ADR-*.md — ADR 文件，由 Backlog 管理而非相互引用
+#   CLASS_5：.orphan-allowlist 路徑前綴豁免（#658）— 永久性孤兒靜默為 [INFO]
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# 載入 .orphan-allowlist 豁免前綴清單（#658）
+# ---------------------------------------------------------------------------
+ALLOWLIST_PREFIXES=()
+if [[ -f "$ALLOWLIST_FILE" ]]; then
+  while IFS= read -r line; do
+    # 跳過空行與 # 開頭的註解行
+    [[ -z "$line" || "$line" =~ ^# ]] && continue
+    ALLOWLIST_PREFIXES+=("$line")
+  done < "$ALLOWLIST_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# is_allowlisted：判斷文件是否匹配 .orphan-allowlist 中的路徑前綴
+# 參數：$1 = 相對於專案根目錄的文件路徑
+# 回傳：0 = 匹配豁免（輸出 INFO），1 = 不匹配
+# ---------------------------------------------------------------------------
+is_allowlisted() {
+  local filepath="$1"
+  for prefix in "${ALLOWLIST_PREFIXES[@]+"${ALLOWLIST_PREFIXES[@]}"}"; do
+    if [[ "$filepath" == ${prefix}* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 # ---------------------------------------------------------------------------
 # 狀態追蹤（EXIT_CODE 固定為 0，但仍追蹤 WARNING_COUNT）
@@ -42,6 +77,7 @@ readonly DOCS_DIR="docs"
 EXIT_CODE=0
 ERROR_COUNT=0
 WARNING_COUNT=0
+INFO_ALLOWLISTED_COUNT=0
 SCANNED_COUNT=0
 ORPHAN_COUNT=0
 
@@ -121,24 +157,36 @@ is_referenced() {
 # ---------------------------------------------------------------------------
 scan_and_detect_orphans() {
   local orphan_list=()
+  local allowlisted_list=()
 
   while IFS= read -r md_file; do
     # 去掉開頭的 "./" 讓路徑更乾淨
     local clean_path="${md_file#./}"
     SCANNED_COUNT=$((SCANNED_COUNT + 1))
 
-    # 檢查是否豁免
+    # 檢查是否豁免（CLASS_1~4 硬編碼規則）
     if is_exempt "$clean_path"; then
       continue
     fi
 
     # 檢查是否被引用
     if ! is_referenced "$clean_path"; then
-      orphan_list+=("$clean_path")
-      ORPHAN_COUNT=$((ORPHAN_COUNT + 1))
+      # 檢查是否在 .orphan-allowlist 豁免清單中（CLASS_5，#658）
+      if is_allowlisted "$clean_path"; then
+        allowlisted_list+=("$clean_path")
+        INFO_ALLOWLISTED_COUNT=$((INFO_ALLOWLISTED_COUNT + 1))
+      else
+        orphan_list+=("$clean_path")
+        ORPHAN_COUNT=$((ORPHAN_COUNT + 1))
+      fi
     fi
 
   done < <(find "./${DOCS_DIR}" -name "*.md" -not -path "./.git/*" | sort)
+
+  # 輸出 .orphan-allowlist 豁免的文件（INFO 級別，不計入 WARNING）
+  for allowlisted in "${allowlisted_list[@]+"${allowlisted_list[@]}"}"; do
+    echo "[INFO] ${allowlisted}: 永久性孤兒（已加入 .orphan-allowlist 豁免，不計 WARNING）"
+  done
 
   # 輸出孤兒警告
   for orphan in "${orphan_list[@]+"${orphan_list[@]}"}"; do
@@ -163,9 +211,13 @@ main() {
   print_section "摘要"
   print_info "掃描 ${SCANNED_COUNT} 個 .md 文件（含豁免項目）"
 
+  if [[ $INFO_ALLOWLISTED_COUNT -gt 0 ]]; then
+    print_info "${INFO_ALLOWLISTED_COUNT} 個永久性孤兒已由 .orphan-allowlist 豁免（[INFO]，不計 WARNING）"
+  fi
+
   if [[ $ORPHAN_COUNT -gt 0 ]]; then
     print_info "偵測到 ${ORPHAN_COUNT} 個孤兒文件（WARNING，不阻塞 CI）"
-    print_info "處置方式：在 Retro 列為 Problem，由 PO 裁定刪除 / 補充引用 / 加入豁免清單"
+    print_info "處置方式：在 Retro 列為 Problem，由 PO 裁定刪除 / 補充引用 / 加入 .orphan-allowlist"
   else
     print_pass "未偵測到孤兒文件，docs/ 文件結構健康"
   fi

--- a/tests/test-orphan-allowlist.sh
+++ b/tests/test-orphan-allowlist.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# tests/test-orphan-allowlist.sh
+# Test: validate-orphans.sh 豁免清單機制 (#658)
+#
+# AC1: validate-orphans.sh 支援 .orphan-allowlist 設定檔
+# AC2: 豁免路徑改為 [INFO] 級別輸出（不影響 WARNING 計數）
+# AC3: 初始化 .orphan-allowlist 含指定路徑
+# AC4: test-infra-regression.sh PASS（或等效 validate 測試）
+# AC5: README 或 validate-orphans.sh 頂部說明豁免清單
+
+set -uo pipefail
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "[PASS] $1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { echo "[FAIL] $1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+SCRIPT="scripts/validate-orphans.sh"
+ALLOWLIST=".orphan-allowlist"
+
+echo "=== Test: #658 validate-orphans.sh 豁免清單機制 ==="
+echo ""
+
+# AC1: validate-orphans.sh 支援 .orphan-allowlist
+echo "--- AC1: validate-orphans.sh 讀取 .orphan-allowlist ---"
+if grep -q "orphan-allowlist\|ORPHAN_ALLOWLIST" "$SCRIPT" 2>/dev/null; then
+  pass "AC1: validate-orphans.sh 含豁免清單讀取邏輯"
+else
+  fail "AC1: validate-orphans.sh 未含豁免清單讀取邏輯"
+fi
+
+# AC2: 豁免路徑輸出 [INFO] 而非 WARNING
+echo "--- AC2: 豁免路徑輸出 INFO 級別 ---"
+if grep -q "\[INFO\].*allowlist\|INFO.*豁免\|allowlist.*INFO" "$SCRIPT" 2>/dev/null; then
+  pass "AC2: validate-orphans.sh 豁免路徑輸出 INFO"
+else
+  fail "AC2: validate-orphans.sh 未實作 INFO 輸出邏輯"
+fi
+
+# AC3: .orphan-allowlist 存在且含指定路徑
+echo "--- AC3: .orphan-allowlist 存在且含必要路徑 ---"
+if [ -f "$ALLOWLIST" ]; then
+  pass "AC3a: .orphan-allowlist 文件存在"
+  if grep -q "docs/sprints/subagent-results" "$ALLOWLIST" 2>/dev/null; then
+    pass "AC3b: 含 docs/sprints/subagent-results/ 豁免"
+  else
+    fail "AC3b: 缺少 docs/sprints/subagent-results/ 豁免"
+  fi
+  if grep -q "docs/sprints/tcb" "$ALLOWLIST" 2>/dev/null; then
+    pass "AC3c: 含 docs/sprints/tcb/ 豁免"
+  else
+    fail "AC3c: 缺少 docs/sprints/tcb/ 豁免"
+  fi
+  if grep -q "docs/sprints/watchdog" "$ALLOWLIST" 2>/dev/null; then
+    pass "AC3d: 含 docs/sprints/watchdog/ 豁免"
+  else
+    fail "AC3d: 缺少 docs/sprints/watchdog/ 豁免"
+  fi
+else
+  fail "AC3a: .orphan-allowlist 文件不存在"
+  fail "AC3b: 無法驗證路徑（文件不存在）"
+  fail "AC3c: 無法驗證路徑（文件不存在）"
+  fail "AC3d: 無法驗證路徑（文件不存在）"
+fi
+
+# AC5: validate-orphans.sh 頂部說明豁免清單使用方式
+echo "--- AC5: validate-orphans.sh 說明豁免清單使用方式 ---"
+if grep -q "orphan-allowlist\|allowlist" "$SCRIPT" | head -20 &>/dev/null || \
+   head -30 "$SCRIPT" | grep -q "allowlist\|orphan-allowlist"; then
+  pass "AC5: validate-orphans.sh 含豁免清單說明"
+else
+  fail "AC5: validate-orphans.sh 缺少豁免清單說明"
+fi
+
+echo ""
+echo "=============================="
+echo " 測試結果：PASS=$PASS_COUNT, FAIL=$FAIL_COUNT"
+echo "=============================="
+
+[ $FAIL_COUNT -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
feat: validate-orphans.sh 豁免清單機制 — .orphan-allowlist (#658)

## 問題

validate-orphans.sh 報告大量永久性孤兒 WARNING（設計上不需要被引用的文件），降低 WARNING 信噪比。

## 解決方案

新增 .orphan-allowlist 豁免清單機制：
- validate-orphans.sh 讀取 .orphan-allowlist（每行一個路徑前綴）
- 匹配豁免前綴的孤兒文件改為 [INFO] 輸出，不計入 WARNING 數
- 豁免清單空缺時靜默忽略（backward compatible）

## 結果

- WARNING: 253 → 216（41 個永久性孤兒轉為 INFO）
- 測試：7/7 PASS

## 豁免路徑

- docs/sprints/subagent-results/
- docs/sprints/tcb/
- docs/sprints/watchdog/
- docs/decisions/
- docs/templates/

Closes #658
