### PR TITLE
chore: 修復 gemini-extension.json 版號不一致（0.95.0 → 0.95.1）(#673)

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "shikigami",
-  "version": "0.95.0",
+  "version": "0.95.1",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
   "author": "KCTW",
   "homepage": "https://github.com/KCTW/shikigami",


### PR DESCRIPTION
修復 gemini-extension.json 版號不一致（0.95.0 → 0.95.1）

## 變更摘要
- gemini-extension.json version: 0.95.0 → 0.95.1（與 plugin.json、README.md、CLAUDE.md 對齊）

## AC 驗收結果
- [x] AC1: gemini-extension.json version = 0.95.1
- [x] AC2: bash scripts/validate-version.sh 全部 PASS
- [x] AC3: git tag v0.95.1 對應 plugin.json 版號（tag 已存在）

Closes #673
