### PR TITLE
chore: validate-orphans.sh 226 WARNING 系統性分類與批次豁免 (#674)

### DIFF
--- a/.orphan-allowlist
+++ b/.orphan-allowlist
@@ -20,3 +20,36 @@ docs/decisions/
 
 # 文件模板（設計上為範本，不需被引用）
 docs/templates/
+
+# Sprint 會議紀錄（設計上為記錄產物，不需被其他文件引用）
+docs/meetings/
+
+# 知識管理記錄（retro-log, metrics-log, shoot-log, runbook — 時序記錄，不需被引用）
+docs/km/
+
+# Discovery session 記錄（探索階段產物，不需被引用）
+docs/discovery/
+
+# 研究報告（research reports — 點性分析，不需被引用）
+docs/research/
+
+# 評估報告（assessment reports — 點性評估，不需被引用）
+docs/reports/
+
+# 規劃文件（planning docs — Sprint 外規劃記錄，不需被引用）
+docs/plans/
+
+# Solo mode 實驗文件（非正式框架功能，不需被引用）
+docs/solo-mode/
+
+# Kotodama 記錄（不需被引用）
+docs/kotodama/
+
+# Cruise log .md 文件（session 記錄，不需被引用）
+docs/cruise-logs/
+
+# SBE 範例文件（定義在 SKILL.md 中以路徑引用，非 markdown link 格式）
+docs/definition/sbe-examples/
+
+# Infrastructure 文件（infra 設定記錄，不需被引用）
+docs/infra/


### PR DESCRIPTION
validate-orphans.sh 剩餘 226 WARNING 系統性分類與批次豁免 (#674)

## 變更摘要

### WARNING 分析（AC1）
Sprint 144 後剩餘 226 個 WARNING，目錄分佈：
| 目錄 | 數量 | 處置 |
|------|------|------|
| docs/km/ | 83 | allowlisted（時序知識管理記錄） |
| docs/meetings/ | 81 | allowlisted（Sprint 會議紀錄） |
| docs/discovery/ | 30 | allowlisted（Discovery session 記錄） |
| docs/research/ | 5 | allowlisted（研究報告） |
| docs/definition/sbe-examples/ | 4 | allowlisted（SBE 範例） |
| docs/plans/ | 4 | allowlisted（規劃文件） |
| docs/reports/ | 3 | allowlisted（評估報告） |
| docs/sdd/ | 3 | 保留（有引用但格式非 markdown link） |
| 其餘 | 13 | 部分 allowlisted，部分保留 |

### 結果（AC2）
226 WARNING → 9 WARNINGs（降幅 95.6%，< 50 閾值）

## AC 驗收結果
- [x] AC1: WARNING 分析報告（目錄分佈統計）完成
- [x] AC2: bash scripts/validate-orphans.sh WARNING 數量 = 9（< 50）
- [x] AC3: .orphan-allowlist 已更新，每條目含說明

Closes #674
