### PR TITLE
chore: 為剩餘 9 個孤兒文件補充引用或 allowlist 豁免 (#677)

### DIFF
--- a/.orphan-allowlist
+++ b/.orphan-allowlist
@@ -53,3 +53,15 @@ docs/definition/sbe-examples/
 
 # Infrastructure 文件（infra 設定記錄，不需被引用）
 docs/infra/
+
+# Sprint 146 (#677) — 逐一評估剩餘 9 個孤兒文件後的 B 類豁免
+# Skill 寫作規範（自成體系的風格指南，不需被其他文件引用）
+docs/definition/skill-description-guide.md
+# 設計師協作指南（外部受眾文件，不在框架 .md 引用鏈內）
+docs/design/DESIGNER_GUIDE.md
+# M5 完成度評估報告（PRD 評估產物，自成一體）
+docs/prd/M5_COMPLETION_ASSESSMENT.md
+# SDD-001 前端範本（框架範本文件，自成一體供複製使用，不需被引用）
+docs/sdd/SDD-001-frontend-template.md
+# Sprint 122 Retrospective Analytics（analytics 輸出，與 subagent-results 同性質）
+docs/sprints/sprint_122_retrospective_analytics.md

--- a/docs/meetings/2026-03-24-sprint-planning.md
+++ b/docs/meetings/2026-03-24-sprint-planning.md
@@ -25,7 +25,7 @@ Sprint 138 全部完成（4/4 DONE，6 pts），連續第 12 Sprint 100%。#622 
 
 ### 巡邏處置結果
 - **#622**（SRE 調查）：Sprint 138 DONE，結案關閉
-- **#404**（TCB Checkpoint）：ADR-040 Accepted，SM 狀態圖（docs/sdd/scrum-master-state-graph.md）已完成 → Hard Gate PASS，選入 Sprint 139
+- **#404**（TCB Checkpoint）：ADR-040 Accepted，SM 狀態圖（[docs/sdd/scrum-master-state-graph.md](../sdd/scrum-master-state-graph.md)）已完成 → Hard Gate PASS，選入 Sprint 139
 - **#405**（Crash Recovery）：需 ADR，ADR-041 尚未存在 → Hard Gate FAIL，退回 Backlog。新建 #631 ADR RESEARCH Story 先行
 - **#408**（Session Watchdog）：需 ADR，ADR-042 尚未存在 → Hard Gate FAIL，退回 Backlog。新建 #632 ADR RESEARCH Story 先行
 - **#399**（A2A Research）：RESEARCH 類型，無需 ADR → PASS，選入 Sprint 139

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -315,7 +315,7 @@ Architect 在 Refinement 中擔任 **Refinement Chair**，負責主持每個 M/L
 
 DM-1/DM-2/DM-3 FAIL 判定：Router 含業務判斷 > 5 行、相同規則在 2+ 處各自實作、狀態轉換散落各 handler。DM-4 FAIL：2+ 模組直接寫入同一 DB collection 無 Gateway。
 
-觸發 DM-1/2/3/4 時，SDD 需補「模組設計」章節（責任劃分、業務邏輯 SSOT、狀態轉換對照）。各 SDD 只放循序圖/流程圖，領域模型與類別圖統一引用 `docs/sdd/SDD-000-architecture.md`。
+觸發 DM-1/2/3/4 時，SDD 需補「模組設計」章節（責任劃分、業務邏輯 SSOT、狀態轉換對照）。各 SDD 只放循序圖/流程圖，領域模型與類別圖統一引用 [`docs/sdd/SDD-000-architecture.md`](../../docs/sdd/SDD-000-architecture.md)。
 
 審查輸出格式：架構符合性、ADR 觸發、Layer Compliance（共用常數/import 方向/SSOT）、DM-1/2/3/4、全局架構文件一致性 各項 `[PASS/FAIL]`。
 

--- a/skills/deployment-readiness/references/security-prompt.md
+++ b/skills/deployment-readiness/references/security-prompt.md
@@ -64,7 +64,7 @@ L2 驗證結果必須記錄於部署就緒檢查的 Checklist 備注欄。
 
 > **注意**：L3 E2E 驗證為 **Soft Gate**。失敗時輸出 `[E2E-SOFT-GATE]`，需 PO 確認後方可繼續。
 
-> **模板參照**：Playwright workflow 模板 `docs/guides/E2E-TEST-MANAGEMENT.md`（`.github/workflows/e2e.yml` 已於 Sprint 142 移除，請依文件中的 workflow 範例自行建立）、Firebase 登入腳本 `docs/templates/ci-firebase-login.js`。依模板內佔位符說明設定即可。
+> **模板參照**：Playwright workflow 模板 [`docs/guides/E2E-TEST-MANAGEMENT.md`](../../../docs/guides/E2E-TEST-MANAGEMENT.md)（`.github/workflows/e2e.yml` 已於 Sprint 142 移除，請依文件中的 workflow 範例自行建立）、Firebase 登入腳本 `docs/templates/ci-firebase-login.js`。依模板內佔位符說明設定即可。
 
 ### 驗證結果判斷
 

--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -172,7 +172,7 @@ Issue 快掃（gh issue list --state open --limit 10）
   |-- gh 失敗 --> 靜默略過，繼續下一步（不阻塞）
   +-- 成功 --> 篩出需回覆的 issue
               → **Security Gate 掃描（#393，ADR-006 Security Gate 擴充）**
-                規則檔：`docs/definition/SECURITY_RULES.md`
+                規則檔：[`docs/definition/SECURITY_RULES.md`](../../docs/definition/SECURITY_RULES.md)
                 |-- HIGH_RISK  → [SECURITY-GATE-HIGH] 暫停，通知 Stakeholder，ESCALATE: SECURITY_CRITICAL
                 |-- MEDIUM_RISK → [SECURITY-GATE-MEDIUM] 附 warning 繼續，寫入 trace log
                 +-- PASS → 繼續


### PR DESCRIPTION
## 摘要

Sprint 146 #677: 為剩餘 9 個孤兒文件補充引用或 allowlist 豁免

### A 類（補充 markdown link 引用）— 4 個文件

| 文件 | 補充引用至 |
|------|----------|
| `docs/definition/SECURITY_RULES.md` | `skills/sprint-execution/SKILL.md` |
| `docs/guides/E2E-TEST-MANAGEMENT.md` | `skills/deployment-readiness/references/security-prompt.md` |
| `docs/sdd/SDD-000-architecture.md` | `skills/architect/SKILL.md` |
| `docs/sdd/scrum-master-state-graph.md` | `docs/meetings/2026-03-24-sprint-planning.md` |

### B 類（加入 .orphan-allowlist 豁免）— 5 個文件

| 文件 | 理由 |
|------|------|
| `docs/definition/skill-description-guide.md` | 風格指南，自成體系 |
| `docs/design/DESIGNER_GUIDE.md` | 外部受眾文件，不在框架引用鏈內 |
| `docs/prd/M5_COMPLETION_ASSESSMENT.md` | PRD 評估產物，自成一體 |
| `docs/sdd/SDD-001-frontend-template.md` | 框架範本文件，供複製使用 |
| `docs/sprints/sprint_122_retrospective_analytics.md` | Analytics 輸出，與 subagent-results 同性質 |

### 驗證結果

`validate-orphans.sh`: [PASS] 未偵測到孤兒文件，WARNING = 0

Closes #677
