### PR TITLE
feat: SRE 巡檢讀取 runner_min_count 設定，避免 MIG 正常縮減誤報

### DIFF
--- a/skills/cruise/references/sre-inspection.md
+++ b/skills/cruise/references/sre-inspection.md
@@ -61,6 +61,13 @@ fi
 > **前置條件**：查詢 org-level runner 需要 `admin:org` scope（`gh auth refresh -s admin:org`）。若缺少此 scope 將自動 fallback 至 repo-level。
 
 ```bash
+# Step 0：讀取 runner_min_count 設定（預設 1）
+# 設定來源：.claude/shikigami.local.md（由主 loop 傳入 CONFIG_FILE 或使用預設路徑）
+CONFIG_FILE="${CONFIG_FILE:-${REPO_PATH}/.claude/shikigami.local.md}"
+RUNNER_MIN_COUNT=$(grep 'runner_min_count:' "${CONFIG_FILE}" 2>/dev/null \
+  | awk '{print $2}' | head -1)
+RUNNER_MIN_COUNT="${RUNNER_MIN_COUNT:-1}"
+
 # Step 1：偵測 owner 類型（org vs user）
 # OWNER_REPO 由主 loop 帶入（如 "KCTW/shikigami"）
 OWNER=$(echo "${OWNER_REPO}" | cut -d'/' -f1)
@@ -70,19 +77,34 @@ OWNER_TYPE=$(gh api /orgs/${OWNER} --jq '.type' 2>/dev/null || echo "User")
 if [[ "$OWNER_TYPE" == "User" ]]; then
   # 個人帳號 repo — 直接走 repo-level，不嘗試 org API
   echo "[SRE] owner 為 User，使用 repo-level runner API"
-  gh api /repos/${OWNER}/${REPO}/actions/runners --jq '.runners[] | {name, status, busy}' 2>/dev/null || true
+  RUNNERS_RAW=$(gh api /repos/${OWNER}/${REPO}/actions/runners 2>/dev/null || echo '{"runners":[]}')
 else
   # Step 2：org-level API 優先（需 admin:org scope）
-  RUNNERS=$(gh api /orgs/${OWNER}/actions/runners --jq '.runners[] | {name, status, busy}' 2>/dev/null)
+  RUNNERS_RAW=$(gh api /orgs/${OWNER}/actions/runners 2>/dev/null)
   ORG_EXIT=$?
 
   if [[ $ORG_EXIT -ne 0 ]]; then
     # Step 3：fallback 至 repo-level（403 或 404）
     echo "[SRE] org-level API 不可用，fallback 至 repo-level（可能缺少 admin:org scope）"
-    gh api /repos/${OWNER}/${REPO}/actions/runners --jq '.runners[] | {name, status, busy}' 2>/dev/null || true
-  else
-    echo "$RUNNERS"
+    RUNNERS_RAW=$(gh api /repos/${OWNER}/${REPO}/actions/runners 2>/dev/null || echo '{"runners":[]}')
   fi
+fi
+
+# Step 4：判斷 online runner 數量（對照 runner_min_count）
+ONLINE_COUNT=$(echo "${RUNNERS_RAW}" \
+  | jq '[.runners[] | select(.status == "online")] | length' 2>/dev/null || echo "0")
+
+if [[ "${ONLINE_COUNT}" -ge "${RUNNER_MIN_COUNT}" ]]; then
+  # online 數量符合最低要求 — 正常
+  echo "[SRE] runner-count-normal: online=${ONLINE_COUNT} >= min=${RUNNER_MIN_COUNT}"
+  log action: "runner-count-normal online=${ONLINE_COUNT} min=${RUNNER_MIN_COUNT}"
+  # 不建 Issue，不報警
+else
+  # online 數量低於最低要求 — 觸發 Runner offline Issue 流程
+  echo "[SRE] runner-count-low: online=${ONLINE_COUNT} < min=${RUNNER_MIN_COUNT}，觸發 offline 處理"
+  # OFFLINE_RUNNERS 仍依原邏輯處理（見下方 Runner offline → Issue 段落）
+  OFFLINE_RUNNERS=$(echo "${RUNNERS_RAW}" \
+    | jq '[.runners[] | select(.status == "offline")] // []' 2>/dev/null || echo "[]")
 fi
 ```
 
@@ -322,8 +344,11 @@ done
 ## Runner offline → Issue
 
 ```bash
-# runner offline：偵測 runner status=offline
-OFFLINE_RUNNERS=$(echo "$RUNNERS" | jq '[.[] | select(.status == "offline")] // []')
+# runner offline：OFFLINE_RUNNERS 由 Runner 健康檢查段落的 Step 4 設定
+# （runner-count-low 分支已設定 OFFLINE_RUNNERS；runner-count-normal 分支不進入此段落）
+# 若直接執行此段落（不經由健康檢查），使用 RUNNERS_RAW fallback
+OFFLINE_RUNNERS="${OFFLINE_RUNNERS:-$(echo "${RUNNERS_RAW:-{\\"runners\\":[]}}" \
+  | jq '[.runners[] | select(.status == "offline")] // []' 2>/dev/null || echo "[]")}"
 
 for runner_name in $(echo "$OFFLINE_RUNNERS" | jq -r '.[].name'); do
   ISSUE_TITLE="[SRE] Runner offline: ${runner_name}"

--- a/tests/test-sre-runner-min-count.sh
+++ b/tests/test-sre-runner-min-count.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Test: SRE runner_min_count logic
+# AC1: sre-inspection.md reads sre.runner_min_count (default 1)
+# AC2: online count >= runner_min_count -> not report
+# AC3: online count < runner_min_count -> report
+
+PASS=0
+FAIL=0
+
+# Test helper
+assert_contains() {
+  local desc="$1" expected="$2" actual="$3"
+  if echo "$actual" | grep -q "$expected"; then
+    echo "PASS: $desc"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $desc"
+    echo "  Expected: '$expected' in output"
+    echo "  Got: '$actual'"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" expected="$2" actual="$3"
+  if ! echo "$actual" | grep -q "$expected"; then
+    echo "PASS: $desc"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $desc (should NOT contain '$expected')"
+    echo "  Got: '$actual'"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# ---- Test AC1: runner_min_count can be read from config ----
+# Simulate config reading
+MOCK_CONFIG=$(cat << 'EOF'
+---
+shikigami:
+  sre:
+    runner_min_count: 2
+EOF
+)
+
+RUNNER_MIN_COUNT=$(echo "$MOCK_CONFIG" | grep 'runner_min_count:' | awk '{print $2}' | head -1)
+RUNNER_MIN_COUNT="${RUNNER_MIN_COUNT:-1}"
+
+assert_contains "AC1: runner_min_count read from config = 2" "2" "$RUNNER_MIN_COUNT"
+
+# ---- Test AC1 default: when not set, default = 1 ----
+EMPTY_CONFIG="shikigami:\n  project_level: low"
+RUNNER_MIN_COUNT_DEFAULT=$(echo -e "$EMPTY_CONFIG" | grep 'runner_min_count:' | awk '{print $2}' | head -1)
+RUNNER_MIN_COUNT_DEFAULT="${RUNNER_MIN_COUNT_DEFAULT:-1}"
+
+assert_contains "AC1: default runner_min_count = 1 when not configured" "1" "$RUNNER_MIN_COUNT_DEFAULT"
+
+# ---- Test AC2: online >= runner_min_count -> no alert ----
+ONLINE_COUNT=2
+RUNNER_MIN=1
+
+if [[ "$ONLINE_COUNT" -ge "$RUNNER_MIN" ]]; then
+  ALERT="runner-count-normal"
+else
+  ALERT="runner-count-low"
+fi
+
+assert_contains "AC2: online=2 >= min=1 -> runner-count-normal" "runner-count-normal" "$ALERT"
+
+# ---- Test AC2b: online == runner_min_count -> no alert ----
+ONLINE_COUNT=1
+RUNNER_MIN=1
+
+if [[ "$ONLINE_COUNT" -ge "$RUNNER_MIN" ]]; then
+  ALERT="runner-count-normal"
+else
+  ALERT="runner-count-low"
+fi
+
+assert_contains "AC2b: online=1 >= min=1 -> runner-count-normal" "runner-count-normal" "$ALERT"
+assert_not_contains "AC2b: no create-issue when online=min" "runner-count-low" "$ALERT"
+
+# ---- Test AC3: online < runner_min_count -> create issue ----
+ONLINE_COUNT=0
+RUNNER_MIN=1
+
+if [[ "$ONLINE_COUNT" -ge "$RUNNER_MIN" ]]; then
+  ALERT="runner-count-normal"
+else
+  ALERT="runner-count-low"
+fi
+
+assert_contains "AC3: online=0 < min=1 -> runner-count-low" "runner-count-low" "$ALERT"
+assert_not_contains "AC3: no normal when online < min" "runner-count-normal" "$ALERT"
+
+# ---- Summary ----
+echo ""
+echo "=== Test Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- `sre-inspection.md` Runner 健康檢查新增 Step 0：讀取 `sre.runner_min_count`（預設 1）
- online runner 數量 >= `runner_min_count` 時記錄 `runner-count-normal`，不建 Issue 不報警
- online runner 數量 < `runner_min_count` 時才進入 offline Issue 流程
- 修正 `OFFLINE_RUNNERS` 變數來源，與新的 Step 4 健康判斷整合

## Test

`tests/test-sre-runner-min-count.sh` — 7 個測試全 PASS：
- AC1: 讀取 config runner_min_count = 2
- AC1: 預設值 = 1（未設定時）
- AC2: online=2 >= min=1 → runner-count-normal
- AC2b: online=1 >= min=1 → runner-count-normal（邊界）
- AC2b: online=min 時不建 Issue
- AC3: online=0 < min=1 → runner-count-low
- AC3: online < min 時不輸出 normal

Closes #681
