### PR TITLE
chore: GitHub Issue 模板補充 非功能性需求 欄位 (#683)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: 回報缺陷或非預期行為
+title: "fix: "
+labels: bug
+assignees: ''
+---
+
+## 問題描述
+
+<!-- 清楚描述 bug 的現象 -->
+
+## 重現步驟
+
+1.
+2.
+3.
+
+## 預期行為
+
+<!-- 預期應該發生什麼 -->
+
+## 實際行為
+
+<!-- 實際發生了什麼 -->
+
+## AC
+
+<!-- 修復驗收標準 -->
+- [ ] AC1: 問題現象不再出現
+- [ ] AC2:
+
+## 非功能性需求
+
+<!-- 品質屬性（freshness / completeness / performance / accessibility / reliability / security 或其他可量化屬性）
+     格式：NFR1: <屬性名稱> — <可量化描述>
+     範例：NFR1: reliability — 修復後既有測試全部通過，無回歸失敗
+     至少填寫一條 NFR，不可保留預設文字 -->
+- NFR1: <屬性名稱> — <可量化描述>
+
+## 環境資訊
+
+- 版本：
+- 平台：

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,40 @@
+---
+name: Feature Request / Story
+about: 新功能或使用者故事
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+## 問題 / 背景
+
+<!-- 描述目前的問題或需求背景 -->
+
+## 建議解法
+
+<!-- 描述希望實作的解法或功能 -->
+
+## AC
+
+<!-- 驗收標準：每條 AC 必須可被自動化測試驗證 -->
+- [ ] AC1:
+- [ ] AC2:
+
+## 非功能性需求
+
+<!-- 品質屬性（freshness / completeness / performance / accessibility / reliability / security 或其他可量化屬性）
+     格式：NFR1: <屬性名稱> — <可量化描述>
+     範例：NFR1: reliability — 外部來源不可用時有降級行為，回應時間 < 500ms
+     至少填寫一條 NFR，不可保留預設文字 -->
+- NFR1: <屬性名稱> — <可量化描述>
+
+## RICE Score
+
+**RICE Score** | **N/A**
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Reach     |       | 影響角色數（1-4） |
+| Impact    |       | 改善程度（1-5） |
+| Confidence|       | 信心度（0.5-1.0） |
+| Effort    |       | Story Points |

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,44 @@
+---
+name: Sprint Story
+about: Sprint 執行的工作項目（chore / refactor / docs / infra）
+title: "chore: "
+labels: enhancement
+assignees: ''
+---
+
+## 問題 / 背景
+
+<!-- 描述此工作項目的背景與動機 -->
+
+## 現況
+
+<!-- 描述目前的狀態 -->
+
+## 建議解法
+
+<!-- 描述計劃的實作方向 -->
+
+## AC
+
+<!-- 驗收標準：每條 AC 必須可被驗證 -->
+- [ ] AC1:
+- [ ] AC2:
+
+## 非功能性需求
+
+<!-- 品質屬性（freshness / completeness / performance / accessibility / reliability / security 或其他可量化屬性）
+     格式：NFR1: <屬性名稱> — <可量化描述>
+     範例：NFR1: maintainability — 修改後 validate-skills.sh PASS，無結構破壞
+     至少填寫一條 NFR，不可保留預設文字 -->
+- NFR1: <屬性名稱> — <可量化描述>
+
+## RICE Score
+
+**RICE Score** | **N/A**
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Reach     |       | 影響角色數（1-4） |
+| Impact    |       | 改善程度（1-5） |
+| Confidence|       | 信心度（0.5-1.0） |
+| Effort    |       | Story Points |


### PR DESCRIPTION
## 摘要

新建 `.github/ISSUE_TEMPLATE/` 目錄與 feature / bug / story 三個 Issue 模板，所有模板包含 `## 非功能性需求` 欄位，格式符合 po-prompt.md 規範（`NFR1: <屬性名稱> — <可量化描述>`）。

解決 Sprint Planning 時每個候選 Story 缺少 NFR section 的系統性問題（Sprint 147 案例）。

Closes #683
