### PR TITLE
refactor: cruise/SKILL.md 行數超限重構 — 段落移至 references/ 控制在 250 行以內 (#684)

### DIFF
--- a/skills/cruise/SKILL.md
+++ b/skills/cruise/SKILL.md
@@ -19,6 +19,7 @@ requiredTools:
 | Auto-shoot 派遣 | [references/auto-shoot.md](./references/auto-shoot.md) | 連續 shoot 派遣邏輯、失敗升級、log 類型 |
 | Stop 機制 | [references/stop-mechanism.md](./references/stop-mechanism.md) | /cruise stop 指令、SessionEnd cleanup |
 | Log 格式範例 | [references/log-format.md](./references/log-format.md) | JSONL 完整範例（單一 repo / 多 repo） |
+| 啟動流程細節 | [references/startup-flow.md](./references/startup-flow.md) | §1–§6b 完整啟動與執行步驟（參數解析、Repo 偵測、Flag、Task List、Loop） |
 
 ## 觸發語法
 
@@ -62,172 +63,27 @@ Cruise Mode 支援兩種執行模式：
 
 ---
 
-## 啟動流程
+## 啟動流程（摘要）
 
-### 1. 解析參數
+> 完整步驟詳見 [references/startup-flow.md](./references/startup-flow.md)
 
-```bash
-STRICT_MODE=false; ONCE_MODE=false; INTERVAL="30m"
-for ARG in "$@"; do
-  [[ "$ARG" == "--once" ]] && ONCE_MODE=true
-  [[ "$ARG" == "strict" ]] && STRICT_MODE=true
-  [[ "$ARG" =~ ^[0-9]+m$ ]] && INTERVAL="$ARG"
-done
-THRESHOLD_DAYS=$([[ "$STRICT_MODE" == "true" ]] && echo 0 || echo 3)
-INTERVAL_SECONDS=$(echo "$INTERVAL" | sed 's/m$//' | awk '{print $1 * 60}')
-```
-
-### 2. 偵測 Repo 列表（AC-1 / AC-2）
-
-```bash
-REPOS=(); MULTI_REPO=false
-if [[ -d ".git" ]]; then
-  REPOS+=("$(pwd)")
-else
-  for dir in */; do
-    [[ -d "${dir}.git" ]] && REPOS+=("$(realpath "$dir")")
-  done
-  [[ ${#REPOS[@]} -gt 0 ]] && MULTI_REPO=true
-fi
-[[ ${#REPOS[@]} -eq 0 ]] && { echo "[CRUISE] 錯誤：無可巡 repo"; exit 1; }
-
-declare -A REPO_REMOTES
-for REPO_PATH in "${REPOS[@]}"; do
-  REMOTE_URL=$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null || echo "")
-  if [[ -n "$REMOTE_URL" ]]; then
-    OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##; s#\.git$##')
-    REPO_REMOTES["$REPO_PATH"]="$OWNER_REPO"
-  else
-    REPO_REMOTES["$REPO_PATH"]="local:$(basename "$REPO_PATH")"
-  fi
-done
-```
-
-### 2.5 驗證 Repo Remote（排除無效 repo）
-
-```bash
-VALID_REPOS=()
-for REPO_PATH in "${REPOS[@]}"; do
-  OWNER_REPO="${REPO_REMOTES[$REPO_PATH]}"
-  if [[ "$OWNER_REPO" == local:* ]] || [[ ! "$OWNER_REPO" =~ ^[^/]+/[^/]+$ ]]; then
-    echo "[CRUISE] WARNING: ${REPO_PATH} 無有效 GitHub remote，跳過"
-  else
-    VALID_REPOS+=("$REPO_PATH")
-  fi
-done
-REPOS=("${VALID_REPOS[@]}")
-[[ ${#REPOS[@]} -eq 0 ]] && { echo "[CRUISE] 錯誤：所有 repo 均無有效 GitHub remote"; exit 1; }
-```
-
-### 3. 列出偵測結果（AC-7）
-
-```bash
-echo "[CRUISE] 偵測到 ${#REPOS[@]} 個有效 repo："
-for REPO_PATH in "${REPOS[@]}"; do
-  echo "  - ${REPO_REMOTES[$REPO_PATH]} (${REPO_PATH})"
-done
-```
-
-### 4. 建立 Flag File（SSOT — #449 AC4）
-
-```bash
-# 解析 Session ID（#572 fallback chain）
-source hooks/lib/resolve-session-id.sh
-SESSION_ID="${SHIKIGAMI_SESSION_ID}"
-CRUISE_FLAG="/tmp/shikigami-cruise-${SESSION_ID}.active"
-SHOOT_FLAG="/tmp/shikigami-cruise-shoot-${SESSION_ID}.active"
-touch "$CRUISE_FLAG"
-echo "[CRUISE] Loop Mode 啟動（Session: ${SESSION_ID}，間隔: ${INTERVAL}）"
-echo "[CRUISE] 停止指令：/cruise stop"
-```
-
-### 4.2 建立 Sprint Stories Task List（#513 / #538）
-
-為當前 Cruise Cycle 建立一個 Task，追蹤進度並支援 compact 後恢復。同時為每個 in-sprint Story 建立追蹤 Task。
-
-**Task 命名格式（#538 AC1）**：`{repo}/cruise-cycle-{N}`
-
-其中 `{repo}` = `OWNER_REPO`（如 `kctw-dev/shikigami`），`{N}` = `CYCLE` 編號（從 1 開始）。
+### 執行路徑摘要
 
 ```
-# 清理上一 cycle 的殘留 Task（#538 AC5）
-# 查詢並刪除前一個 cycle 的 Task（若存在）
-PREV_CYCLE=$((CYCLE - 1))
-if [[ $PREV_CYCLE -gt 0 ]]; then
-  OLD_TASKS=$(TaskList | filter subject matches "${OWNER_REPO}/cruise-cycle-${PREV_CYCLE}")
-  for OLD_TASK in OLD_TASKS:
-    TaskUpdate id=OLD_TASK.id status="completed"
-    # 標記完成以保留記錄（不刪除，避免 TaskList API 無 delete 方法時出錯）
-fi
-
-# 建立本 cycle 的 Cruise Task
-TaskCreate subject="${OWNER_REPO}/cruise-cycle-${CYCLE}" status="in-progress"
-
-# 查詢當前 Sprint 的 Stories
-SPRINT_STORIES=$(gh issue list -R ${OWNER_REPO} --label "status: in-sprint" --json number,title)
-
-# 每個 Story 建立一個 Task（task 數量上限：取決於 Claude Task 工具上限，通常 50 個）
-for STORY in SPRINT_STORIES:
-  TaskCreate subject="${OWNER_REPO}/cruise-cycle-${CYCLE}/#${STORY.number}" status="pending"
-
-# 若無 Story，Cruise Task 本身即為 placeholder
+1. 解析參數（STRICT_MODE / ONCE_MODE / INTERVAL）
+2. 偵測 Repo 列表（單一 repo 或多 repo 模式）
+2.5. 驗證 Repo Remote（排除 local:* 或無效 GitHub remote）
+3. 列出偵測結果
+4. 建立 Flag File（SESSION_ID 命名，互不干擾）
+4.2. 建立 Sprint Stories Task List（{repo}/cruise-cycle-{N}）
+4.5. 讀取 project_level（.claude/shikigami.local.md）
+4.55. 讀取 cruise.patrol（po / sre / both）
+4.6. 讀取 close_policy 與 delivery_chain
+5. 準備 Log 目錄（docs/cruise-logs/）
+6. 選擇執行模式 → Once Mode（§6a）或 Loop Mode（§6b）
 ```
 
-**Task 命名範例**：
-- `kctw-dev/shikigami/cruise-cycle-3`（本次 cycle 主 Task）
-- `kctw-dev/shikigami/cruise-cycle-3/#538`（Story 追蹤 Task）
-
-**Task 狀態對應**：
-
-| Story 狀態 | Task status |
-|-----------|-------------|
-| 等待派工 | `pending` |
-| auto-shoot 進行中 | `in-progress` |
-| shoot 成功完成 | `completed` |
-| shoot 失敗升級 | `failed` |
-
-**compact 後恢復（#538 AC4）**：查詢 TaskList，以 `{repo}/cruise-cycle-` 為前綴找出 `in-progress` 的 Cycle Task，從中萃取 `CYCLE` 編號並繼續執行。
-
-```
-# compact 恢復邏輯
-ACTIVE_CYCLE_TASK=$(TaskList | filter subject starts_with "${OWNER_REPO}/cruise-cycle-" AND status="in-progress" | first)
-CYCLE=$(extract N from ACTIVE_CYCLE_TASK.subject)  # 從 "repo/cruise-cycle-N" 取出 N
-PENDING_STORIES=$(TaskList | filter subject starts_with "${OWNER_REPO}/cruise-cycle-${CYCLE}/#" AND status in ["pending", "in-progress"])
-ACTIONABLE_ISSUES = PENDING_STORIES.map(task => extract story_number from task.subject)
-```
-
-**Cruise phase 追蹤改用 JSONL log entries**（不佔用 TaskCreate）：
-
-| 事件 | JSONL log entry type |
-|------|----------------------|
-| cruise 初始化 | `"cruise-init"` |
-| PO 巡邏開始 | `"po-patrol-start"` |
-| PO 巡邏完成 | `"po-patrol-complete"` |
-| SRE 巡檢開始 | `"sre-inspection-start"` |
-| SRE 巡檢完成 | `"sre-inspection-complete"` |
-| auto-shoot 開始 | `"auto-shoot-start"` |
-| cruise 清理完成 | `"cruise-cleanup"` |
-
-### 4.5 讀取 project_level（#348）
-
-```bash
-CONFIG_FILE=".claude/shikigami.local.md"
-PROJECT_LEVEL=$(grep -A5 'shikigami:' "$CONFIG_FILE" 2>/dev/null | grep 'project_level:' | awk '{print $2}' | head -1)
-PROJECT_LEVEL="${PROJECT_LEVEL:-medium}"
-```
-
-### 4.55 讀取 cruise.patrol（#590）
-
-```bash
-PATROL_MODE=$(grep -A10 'cruise:' "$CONFIG_FILE" 2>/dev/null | grep 'patrol:' | awk '{print $2}' | head -1)
-PATROL_MODE="${PATROL_MODE:-both}"
-```
-
-| 值 | 行為 |
-|----|------|
-| `po` | 只派 PO-patrol subagent，跳過 SRE-inspection |
-| `sre` | 只派 SRE-inspection subagent，跳過 PO-patrol |
-| `both`（預設） | 同時派 PO + SRE（向後相容，未設定時 fallback） |
+## project_level 行為矩陣
 
 <HARD-GATE>
 project_level=low 的所有自動行為（auto-shoot、auto-close、auto-sprint-planning、auto-sprint-execution）為強制執行，Agent 禁止加入額外確認步驟。
@@ -239,91 +95,31 @@ project_level=low 的所有自動行為（auto-shoot、auto-close、auto-sprint-
 | Sprint Planning | 自動 invoke shikigami:sprint-planning | 留言通知等確認 | 只標記 sprint-candidate |
 | Issue close | 自動 close | 自動 close | 留言建議，等人確認 |
 
-### 4.6 讀取 close_policy 與 delivery_chain（#338）
-
-```bash
-CONFIG_FILE=".claude/shikigami.local.md"
-REQUIRE_CREATOR_APPROVAL="false"; CLOSE_DEFAULT_TIMEOUT="2h"
-DELIVERY_CHAIN_DEFAULT="production"
-# 若 CONFIG_FILE 存在，從中讀取 require_creator_approval / default_timeout / delivery_chain.default
-# get_delivery_chain() / get_close_timeout() 函式：讀 per-repo 覆蓋值，fallback 至 DEFAULT
-```
-
-### 5. 準備 Log 目錄
-
-```bash
-LOG_BASE=$([[ "$MULTI_REPO" == "true" ]] && echo "$(pwd)" || echo "${REPOS[0]}")
-LOG_DIR="${LOG_BASE}/cruise-logs"
-mkdir -p "$LOG_DIR"
-CRUISE_LOG="${LOG_DIR}/$(date '+%Y-%m-%d')-session-${SESSION_ID}.jsonl"
-CYCLE=0
-```
-
-### 6. 選擇執行模式
-
-- **Once Mode**（`--once`）：呼叫 `_cruise_run_once`，完成後清除 flag 並 `exit 0`
-- **Loop Mode**（預設）：進入 while loop（見 6b）
-
-### 6a. Once Mode 執行流程（`/cruise --once`）
+## Once Mode 執行摘要（`/cruise --once`）
 
 ```
-CYCLE=1
-寫入 {"type":"cruise-init",...} log entry
-for REPO_PATH in REPOS:
-  # 依 PATROL_MODE 決定派遣
-  if PATROL_MODE == "po" or PATROL_MODE == "both":
-    派遣 PO-patrol subagent（帶入 REPO_PATH, OWNER_REPO）
-  if PATROL_MODE == "sre" or PATROL_MODE == "both":
-    派遣 SRE-inspection subagent（帶入 REPO_PATH, OWNER_REPO）
-等待完成，寫入 JSONL log（格式見 references/log-format.md）
-寫入 {"type":"po-patrol-complete",...} / {"type":"sre-inspection-complete",...} log entry（依實際派遣的 agent）
-
-# [AUTO-CONTINUE] project_level=low → 自動派 auto-shoot，不停
-if PROJECT_LEVEL != "high": auto-shoot ACTIONABLE_ISSUES（見 references/auto-shoot.md）
-寫入 {"type":"once-mode-complete",...} log entry
-寫入 {"type":"cruise-cleanup",...} log entry
-rm -f "$CRUISE_FLAG" "$SHOOT_FLAG"; exit 0
+CYCLE=1 → 寫入 cruise-init log
+→ 依 PATROL_MODE 派遣 PO-patrol / SRE-inspection subagent
+→ 等待完成，寫入 patrol-complete log
+→ [AUTO-CONTINUE] project_level=low：auto-shoot ACTIONABLE_ISSUES
+→ 寫入 once-mode-complete + cruise-cleanup log
+→ 清除 flag file，exit 0
 ```
 
-**`[AUTO-CONTINUE]` Phase 轉換點**（AC5）：
-
-| Phase 轉換點 | 說明 |
-|------------|------|
-| 啟動 → 執行巡邏 | `project_level=low` 時自動執行，不詢問 |
-| 巡邏完成 → auto-shoot | `project_level=low` 時自動派工，不停 |
-| auto-shoot → 退出 | 所有 actionable 處理完後自動退出 |
-
-### 6b. Loop Mode
+## Loop Mode 執行摘要
 
 ```
-寫入 {"type":"cruise-init",...} log entry
-while 檢查 flag file 存在:
-  CYCLE += 1; touch "$CRUISE_FLAG"
-  寫入 {"type":"po-patrol-start",...} / {"type":"sre-inspection-start",...} log entry
-  for REPO_PATH in REPOS:
-    # 依 PATROL_MODE 決定派遣
-    if PATROL_MODE == "po" or PATROL_MODE == "both":
-      派遣 PO-patrol subagent（詳見 references/po-patrol.md）
-    if PATROL_MODE == "sre" or PATROL_MODE == "both":
-      派遣 SRE-inspection subagent（詳見 references/sre-inspection.md）
-  等待完成，寫入 log
-  寫入 {"type":"po-patrol-complete",...} / {"type":"sre-inspection-complete",...} log entry
-
-  # SHOOT_FLAG 殘留防護：>30 分鐘強制清除，寫 auto-shoot-stale-cleared log
-  # Auto-shoot（依 project_level）— 詳見 references/auto-shoot.md
-  # Sprint Planning 觸發已移至 PO 巡邏直接執行（#352）
-  # Step 5（Sprint Planning 觸發）必須由 PO subagent 自行 Read `references/po-patrol.md` Step 5 執行，
-  # 主 session prompt 中禁止包含觸發條件描述（HARD-GATE，見 po-patrol.md Step 5）
-
-  sleep ${INTERVAL_SECONDS}
-  if flag file 不存在: break
+寫入 cruise-init log
+while flag file 存在:
+  CYCLE += 1 → 依 PATROL_MODE 派遣 subagent
+  → 等待完成，寫入 patrol-complete log
+  → SHOOT_FLAG 殘留防護（>30分鐘強制清除）
+  → Auto-shoot（詳見 references/auto-shoot.md）
+  sleep INTERVAL_SECONDS
 echo "[CRUISE] 巡航模式已停止"
 ```
 
-**subagent 派遣約定**：
-- 每個 subagent 帶入 `REPO_PATH`（絕對路徑）與 `OWNER_REPO`（`owner/repo`）
-- 所有 `gh` 指令加 `-R ${OWNER_REPO}`
-- subagent **不自行寫入 log**（DM-4：log 由主 loop 統一寫入）
+> Sprint Planning 觸發由 PO subagent 自行執行（HARD-GATE，見 po-patrol.md Step 5）。
 
 ---
 

--- a/skills/cruise/references/startup-flow.md
+++ b/skills/cruise/references/startup-flow.md
@@ -1,0 +1,236 @@
+# Cruise Mode — 啟動流程與執行細節
+
+本文件包含 Cruise Mode 啟動流程的詳細實作步驟，由 `SKILL.md` 引用。
+
+---
+
+## §1 解析參數
+
+```bash
+STRICT_MODE=false; ONCE_MODE=false; INTERVAL="30m"
+for ARG in "$@"; do
+  [[ "$ARG" == "--once" ]] && ONCE_MODE=true
+  [[ "$ARG" == "strict" ]] && STRICT_MODE=true
+  [[ "$ARG" =~ ^[0-9]+m$ ]] && INTERVAL="$ARG"
+done
+THRESHOLD_DAYS=$([[ "$STRICT_MODE" == "true" ]] && echo 0 || echo 3)
+INTERVAL_SECONDS=$(echo "$INTERVAL" | sed 's/m$//' | awk '{print $1 * 60}')
+```
+
+## §2 偵測 Repo 列表（AC-1 / AC-2）
+
+```bash
+REPOS=(); MULTI_REPO=false
+if [[ -d ".git" ]]; then
+  REPOS+=("$(pwd)")
+else
+  for dir in */; do
+    [[ -d "${dir}.git" ]] && REPOS+=("$(realpath "$dir")")
+  done
+  [[ ${#REPOS[@]} -gt 0 ]] && MULTI_REPO=true
+fi
+[[ ${#REPOS[@]} -eq 0 ]] && { echo "[CRUISE] 錯誤：無可巡 repo"; exit 1; }
+
+declare -A REPO_REMOTES
+for REPO_PATH in "${REPOS[@]}"; do
+  REMOTE_URL=$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null || echo "")
+  if [[ -n "$REMOTE_URL" ]]; then
+    OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##; s#\.git$##')
+    REPO_REMOTES["$REPO_PATH"]="$OWNER_REPO"
+  else
+    REPO_REMOTES["$REPO_PATH"]="local:$(basename "$REPO_PATH")"
+  fi
+done
+```
+
+## §2.5 驗證 Repo Remote（排除無效 repo）
+
+```bash
+VALID_REPOS=()
+for REPO_PATH in "${REPOS[@]}"; do
+  OWNER_REPO="${REPO_REMOTES[$REPO_PATH]}"
+  if [[ "$OWNER_REPO" == local:* ]] || [[ ! "$OWNER_REPO" =~ ^[^/]+/[^/]+$ ]]; then
+    echo "[CRUISE] WARNING: ${REPO_PATH} 無有效 GitHub remote，跳過"
+  else
+    VALID_REPOS+=("$REPO_PATH")
+  fi
+done
+REPOS=("${VALID_REPOS[@]}")
+[[ ${#REPOS[@]} -eq 0 ]] && { echo "[CRUISE] 錯誤：所有 repo 均無有效 GitHub remote"; exit 1; }
+```
+
+## §3 列出偵測結果（AC-7）
+
+```bash
+echo "[CRUISE] 偵測到 ${#REPOS[@]} 個有效 repo："
+for REPO_PATH in "${REPOS[@]}"; do
+  echo "  - ${REPO_REMOTES[$REPO_PATH]} (${REPO_PATH})"
+done
+```
+
+## §4 建立 Flag File（SSOT — #449 AC4）
+
+```bash
+# 解析 Session ID（#572 fallback chain）
+source hooks/lib/resolve-session-id.sh
+SESSION_ID="${SHIKIGAMI_SESSION_ID}"
+CRUISE_FLAG="/tmp/shikigami-cruise-${SESSION_ID}.active"
+SHOOT_FLAG="/tmp/shikigami-cruise-shoot-${SESSION_ID}.active"
+touch "$CRUISE_FLAG"
+echo "[CRUISE] Loop Mode 啟動（Session: ${SESSION_ID}，間隔: ${INTERVAL}）"
+echo "[CRUISE] 停止指令：/cruise stop"
+```
+
+## §4.2 建立 Sprint Stories Task List（#513 / #538）
+
+為當前 Cruise Cycle 建立 Task，追蹤進度並支援 compact 後恢復。
+
+**Task 命名格式（#538 AC1）**：`{repo}/cruise-cycle-{N}`
+
+```
+# 清理上一 cycle 的殘留 Task（#538 AC5）
+PREV_CYCLE=$((CYCLE - 1))
+if [[ $PREV_CYCLE -gt 0 ]]; then
+  OLD_TASKS=$(TaskList | filter subject matches "${OWNER_REPO}/cruise-cycle-${PREV_CYCLE}")
+  for OLD_TASK in OLD_TASKS:
+    TaskUpdate id=OLD_TASK.id status="completed"
+fi
+
+# 建立本 cycle 的 Cruise Task
+TaskCreate subject="${OWNER_REPO}/cruise-cycle-${CYCLE}" status="in-progress"
+
+# 查詢當前 Sprint 的 Stories
+SPRINT_STORIES=$(gh issue list -R ${OWNER_REPO} --label "status: in-sprint" --json number,title)
+for STORY in SPRINT_STORIES:
+  TaskCreate subject="${OWNER_REPO}/cruise-cycle-${CYCLE}/#${STORY.number}" status="pending"
+```
+
+**Task 狀態對應**：
+
+| Story 狀態 | Task status |
+|-----------|-------------|
+| 等待派工 | `pending` |
+| auto-shoot 進行中 | `in-progress` |
+| shoot 成功完成 | `completed` |
+| shoot 失敗升級 | `failed` |
+
+**compact 後恢復（#538 AC4）**：
+
+```
+ACTIVE_CYCLE_TASK=$(TaskList | filter subject starts_with "${OWNER_REPO}/cruise-cycle-" AND status="in-progress" | first)
+CYCLE=$(extract N from ACTIVE_CYCLE_TASK.subject)
+PENDING_STORIES=$(TaskList | filter subject starts_with "${OWNER_REPO}/cruise-cycle-${CYCLE}/#" AND status in ["pending", "in-progress"])
+ACTIONABLE_ISSUES = PENDING_STORIES.map(task => extract story_number from task.subject)
+```
+
+**Cruise phase 追蹤改用 JSONL log entries**：
+
+| 事件 | JSONL log entry type |
+|------|----------------------|
+| cruise 初始化 | `"cruise-init"` |
+| PO 巡邏開始 | `"po-patrol-start"` |
+| PO 巡邏完成 | `"po-patrol-complete"` |
+| SRE 巡檢開始 | `"sre-inspection-start"` |
+| SRE 巡檢完成 | `"sre-inspection-complete"` |
+| auto-shoot 開始 | `"auto-shoot-start"` |
+| cruise 清理完成 | `"cruise-cleanup"` |
+
+## §4.5 讀取 project_level（#348）
+
+```bash
+CONFIG_FILE=".claude/shikigami.local.md"
+PROJECT_LEVEL=$(grep -A5 'shikigami:' "$CONFIG_FILE" 2>/dev/null | grep 'project_level:' | awk '{print $2}' | head -1)
+PROJECT_LEVEL="${PROJECT_LEVEL:-medium}"
+```
+
+## §4.55 讀取 cruise.patrol（#590）
+
+```bash
+PATROL_MODE=$(grep -A10 'cruise:' "$CONFIG_FILE" 2>/dev/null | grep 'patrol:' | awk '{print $2}' | head -1)
+PATROL_MODE="${PATROL_MODE:-both}"
+```
+
+| 值 | 行為 |
+|----|------|
+| `po` | 只派 PO-patrol subagent，跳過 SRE-inspection |
+| `sre` | 只派 SRE-inspection subagent，跳過 PO-patrol |
+| `both`（預設） | 同時派 PO + SRE（向後相容，未設定時 fallback） |
+
+## §4.6 讀取 close_policy 與 delivery_chain（#338）
+
+```bash
+CONFIG_FILE=".claude/shikigami.local.md"
+REQUIRE_CREATOR_APPROVAL="false"; CLOSE_DEFAULT_TIMEOUT="2h"
+DELIVERY_CHAIN_DEFAULT="production"
+# 若 CONFIG_FILE 存在，從中讀取 require_creator_approval / default_timeout / delivery_chain.default
+# get_delivery_chain() / get_close_timeout() 函式：讀 per-repo 覆蓋值，fallback 至 DEFAULT
+```
+
+## §5 準備 Log 目錄
+
+```bash
+LOG_BASE=$([[ "$MULTI_REPO" == "true" ]] && echo "$(pwd)" || echo "${REPOS[0]}")
+LOG_DIR="${LOG_BASE}/cruise-logs"
+mkdir -p "$LOG_DIR"
+CRUISE_LOG="${LOG_DIR}/$(date '+%Y-%m-%d')-session-${SESSION_ID}.jsonl"
+CYCLE=0
+```
+
+## §6a Once Mode 執行流程（`/cruise --once`）
+
+```
+CYCLE=1
+寫入 {"type":"cruise-init",...} log entry
+for REPO_PATH in REPOS:
+  if PATROL_MODE == "po" or PATROL_MODE == "both":
+    派遣 PO-patrol subagent（帶入 REPO_PATH, OWNER_REPO）
+  if PATROL_MODE == "sre" or PATROL_MODE == "both":
+    派遣 SRE-inspection subagent（帶入 REPO_PATH, OWNER_REPO）
+等待完成，寫入 JSONL log（格式見 references/log-format.md）
+寫入 {"type":"po-patrol-complete",...} / {"type":"sre-inspection-complete",...} log entry
+
+# [AUTO-CONTINUE] project_level=low → 自動派 auto-shoot，不停
+if PROJECT_LEVEL != "high": auto-shoot ACTIONABLE_ISSUES（見 references/auto-shoot.md）
+寫入 {"type":"once-mode-complete",...} log entry
+寫入 {"type":"cruise-cleanup",...} log entry
+rm -f "$CRUISE_FLAG" "$SHOOT_FLAG"; exit 0
+```
+
+**`[AUTO-CONTINUE]` Phase 轉換點**（AC5）：
+
+| Phase 轉換點 | 說明 |
+|------------|------|
+| 啟動 → 執行巡邏 | `project_level=low` 時自動執行，不詢問 |
+| 巡邏完成 → auto-shoot | `project_level=low` 時自動派工，不停 |
+| auto-shoot → 退出 | 所有 actionable 處理完後自動退出 |
+
+## §6b Loop Mode
+
+```
+寫入 {"type":"cruise-init",...} log entry
+while 檢查 flag file 存在:
+  CYCLE += 1; touch "$CRUISE_FLAG"
+  寫入 {"type":"po-patrol-start",...} / {"type":"sre-inspection-start",...} log entry
+  for REPO_PATH in REPOS:
+    if PATROL_MODE == "po" or PATROL_MODE == "both":
+      派遣 PO-patrol subagent（詳見 references/po-patrol.md）
+    if PATROL_MODE == "sre" or PATROL_MODE == "both":
+      派遣 SRE-inspection subagent（詳見 references/sre-inspection.md）
+  等待完成，寫入 log
+  寫入 {"type":"po-patrol-complete",...} / {"type":"sre-inspection-complete",...} log entry
+
+  # SHOOT_FLAG 殘留防護：>30 分鐘強制清除，寫 auto-shoot-stale-cleared log
+  # Auto-shoot（依 project_level）— 詳見 references/auto-shoot.md
+  # Sprint Planning 觸發已移至 PO 巡邏直接執行（#352）
+  # Step 5（Sprint Planning 觸發）必須由 PO subagent 自行 Read `references/po-patrol.md` Step 5 執行，
+  # 主 session prompt 中禁止包含觸發條件描述（HARD-GATE，見 po-patrol.md Step 5）
+
+  sleep ${INTERVAL_SECONDS}
+  if flag file 不存在: break
+echo "[CRUISE] 巡航模式已停止"
+```
+
+**subagent 派遣約定**：
+- 每個 subagent 帶入 `REPO_PATH`（絕對路徑）與 `OWNER_REPO`（`owner/repo`）
+- 所有 `gh` 指令加 `-R ${OWNER_REPO}`
+- subagent **不自行寫入 log**（DM-4：log 由主 loop 統一寫入）


### PR DESCRIPTION
## 摘要

重構 `skills/cruise/SKILL.md`（353→148行），將 §1-§6b 完整啟動流程細節抽離至新建的 `references/startup-flow.md`，主文件控制在 250 行以內。

- SKILL.md: 353 行 → 148 行（-58%）
- 主文件保留摘要版執行路徑 + 所有 references 導覽指引
- 行為定義完整保留，無任何語義變更
- validate-skills.sh / validate-xrefs.sh / validate-orphans.sh 全部 PASS

Closes #684
