### PR TITLE
fix: onboarding 流程新增 claim/release hooks 安裝步驟 (#692)

### DIFF
--- a/skills/cruise/references/sre-inspection.md
+++ b/skills/cruise/references/sre-inspection.md
@@ -438,3 +438,126 @@ done
 | `"spot-preemption-or-failure"` | SPOT 回收或 VM 故障（異常），`recommendedSize = 之前 VM 數` 但 VM 減少 |
 | `"no-change"` | VM 數量無變化，跳過查證 |
 | `"skipped"` | gcloud 不可用，跳過 MIG 查證（`[SRE] gcloud 不可用，跳過 MIG 查證`） |
+
+## Claim Hooks 健康檢查（CLAIM-WARN）
+
+> **背景**：claim-issue.sh 與 release-issue.sh 是 Shikigami 跨機器協調機制的核心 hooks。若消費端 repo 缺少這兩個 hooks，Sprint Execution 和 Cruise 的互斥鎖功能將無法運作，導致多機器並行時發生競態條件。
+
+### 偵測邏輯
+
+```bash
+# 檢查 claim hooks 是否存在且可執行
+CLAIM_HOOK="${REPO_PATH}/hooks/claim-issue.sh"
+RELEASE_HOOK="${REPO_PATH}/hooks/release-issue.sh"
+
+CLAIM_WARN=false
+CLAIM_WARN_REASON=""
+
+if [[ ! -f "$CLAIM_HOOK" ]]; then
+  CLAIM_WARN=true
+  CLAIM_WARN_REASON="${CLAIM_WARN_REASON} claim-issue.sh 缺失"
+  echo "[CLAIM-WARN] ${REPO_PATH}/hooks/claim-issue.sh 不存在"
+elif [[ ! -x "$CLAIM_HOOK" ]]; then
+  CLAIM_WARN=true
+  CLAIM_WARN_REASON="${CLAIM_WARN_REASON} claim-issue.sh 不可執行"
+  echo "[CLAIM-WARN] ${REPO_PATH}/hooks/claim-issue.sh 缺少 +x 權限"
+fi
+
+if [[ ! -f "$RELEASE_HOOK" ]]; then
+  CLAIM_WARN=true
+  CLAIM_WARN_REASON="${CLAIM_WARN_REASON} release-issue.sh 缺失"
+  echo "[CLAIM-WARN] ${REPO_PATH}/hooks/release-issue.sh 不存在"
+elif [[ ! -x "$RELEASE_HOOK" ]]; then
+  CLAIM_WARN=true
+  CLAIM_WARN_REASON="${CLAIM_WARN_REASON} release-issue.sh 不可執行"
+  echo "[CLAIM-WARN] ${REPO_PATH}/hooks/release-issue.sh 缺少 +x 權限"
+fi
+```
+
+### Self-Heal：自動從 Plugin Cache 補裝
+
+若偵測到 `CLAIM_WARN=true`，嘗試自動從 plugin cache 複製：
+
+```bash
+if [[ "$CLAIM_WARN" == "true" ]]; then
+  echo "[SRE] CLAIM-WARN 偵測到，嘗試 self-heal..."
+
+  # Plugin cache 路徑（與 onboarding §2.3.1 一致）
+  PLUGIN_CACHE="${SHIKIGAMI_PLUGIN_PATH:-${HOME}/.claude/plugins/shikigami/hooks}"
+
+  SELF_HEAL_OK=true
+  mkdir -p "${REPO_PATH}/hooks"
+
+  for HOOK in claim-issue.sh release-issue.sh; do
+    DEST="${REPO_PATH}/hooks/${HOOK}"
+    SRC="${PLUGIN_CACHE}/${HOOK}"
+    if [[ -f "$DEST" ]] && [[ -x "$DEST" ]]; then
+      echo "[SRE] ${HOOK} 已就緒，跳過"
+      continue
+    fi
+    if [[ -f "$SRC" ]]; then
+      cp "$SRC" "$DEST"
+      chmod +x "$DEST"
+      echo "[SRE] self-heal 成功：${HOOK} 已安裝至 ${REPO_PATH}/hooks/"
+      log action: "claim-hooks-self-heal ${HOOK}"
+    else
+      echo "[SRE] self-heal 失敗：找不到 plugin cache ${SRC}"
+      SELF_HEAL_OK=false
+    fi
+  done
+
+  if [[ "$SELF_HEAL_OK" == "true" ]]; then
+    echo "[SRE] claim hooks self-heal 完成"
+    CLAIM_WARN=false
+  else
+    # AC3: 自動安裝失敗 → 建 Issue 提醒
+    ISSUE_TITLE="[SRE] claim hooks 缺失，需手動安裝"
+    EXISTING=$(gh issue list -R ${OWNER_REPO} \
+      --search "\"${ISSUE_TITLE}\"" \
+      --state open \
+      --json number,title \
+      2>/dev/null || echo "[]")
+
+    if echo "$EXISTING" | jq -e '. | length > 0' &>/dev/null; then
+      echo "[SRE] 跳過重複 Issue：$ISSUE_TITLE"
+      log action: "跳過重複 Issue: ${ISSUE_TITLE}"
+    else
+      printf '%s\n' \
+        "## SRE 巡檢發現 claim hooks 缺失" \
+        "" \
+        "**發現時間**：$(date '+%Y-%m-%dT%H:%M:%S')" \
+        "**Session**：${SESSION_ID}" \
+        "**Repo**：${OWNER_REPO}" \
+        "**問題**：${CLAIM_WARN_REASON}" \
+        "" \
+        "### 影響" \
+        "缺少 claim hooks 時，多機器同時執行 Sprint Execution 或 Cruise 可能發生競態條件，導致重複派工或狀態不一致。" \
+        "" \
+        "### 手動安裝步驟" \
+        "1. 確認 Shikigami plugin 已安裝" \
+        "2. 執行：\`bash hooks/lib/install-claim-hooks.sh\`（若存在）" \
+        "3. 或手動複製：\`cp ~/.claude/plugins/shikigami/hooks/claim-issue.sh hooks/\`" \
+        "4. 設定可執行：\`chmod +x hooks/claim-issue.sh hooks/release-issue.sh\`" \
+        "" \
+        "### 參考" \
+        "- Onboarding §2.3.1 安裝 Claim/Release Hooks" \
+        "- ADR-024 attendance-hook" \
+        "" \
+        "> 此 Issue 由 SRE Cruise Agent 自動建立（CLAIM-WARN self-heal 失敗）。請勿重複建立。" \
+        > /tmp/claim-hooks-issue-body.txt
+
+      gh issue create -R ${OWNER_REPO} \
+        --title "$ISSUE_TITLE" \
+        --body-file /tmp/claim-hooks-issue-body.txt \
+        --label "sre,needs-triage"
+      log action: "create-issue-claim-hooks-missing"
+    fi
+  fi
+fi
+```
+
+### 自動行動決策表（補充）
+
+| 情境 | 判斷條件 | 自動行動 | label | log action 類型 |
+|------|----------|----------|-------|-----------------|
+| **Claim hooks 缺失** | `hooks/claim-issue.sh` 或 `hooks/release-issue.sh` 不存在或無 +x 權限 | 嘗試 self-heal（從 plugin cache 複製）；失敗時建 Issue | `sre,needs-triage` | `"claim-hooks-self-heal"` / `"create-issue-claim-hooks-missing"` |

--- a/skills/onboarding/references/execution-steps.md
+++ b/skills/onboarding/references/execution-steps.md
@@ -170,6 +170,63 @@ gh label list --json name --limit 100
           如需重置，請手動刪除後重新執行。
   ```
 
+#### 2.3.1 安裝 Claim/Release Hooks（必要）
+
+**目的**：claim-issue.sh 與 release-issue.sh 是 Shikigami 跨機器協調機制的核心 hooks（見 ADR-024）。消費端專案必須有這兩個 hooks 才能使用 Sprint Execution 和 Cruise 的互斥鎖功能。
+
+**Plugin cache 路徑偵測**（依序嘗試）：
+
+```bash
+# 方法 1：從 plugin 安裝路徑推算（預設路徑）
+PLUGIN_CACHE="${HOME}/.claude/plugins/shikigami/hooks"
+# 方法 2：環境變數覆蓋（CI 或特殊安裝路徑）
+PLUGIN_CACHE="${SHIKIGAMI_PLUGIN_PATH:-${PLUGIN_CACHE}}"
+```
+
+**執行步驟**：
+
+```bash
+# 確保消費端 hooks/ 目錄存在
+mkdir -p hooks/
+
+# 複製兩個 claim hooks（冪等：已存在則跳過）
+for HOOK in claim-issue.sh release-issue.sh; do
+  DEST="hooks/${HOOK}"
+  SRC="${PLUGIN_CACHE}/${HOOK}"
+  if [[ -f "$DEST" ]]; then
+    echo "[略過] ${DEST} 已存在，跳過複製"
+  elif [[ -f "$SRC" ]]; then
+    cp "$SRC" "$DEST"
+    chmod +x "$DEST"
+    echo "[複製] ${SRC} → ${DEST}"
+  else
+    echo "[警告] 找不到 ${SRC}，跳過（Cruise self-heal 將在下次巡邏補裝）"
+  fi
+done
+```
+
+**判定規則**：
+
+| 情況 | 行動 |
+|------|------|
+| 兩個 hooks 均已安裝 | 輸出 `[略過]` 訊息，繼續 |
+| Plugin cache 存在，複製成功 | 輸出 `[複製]` 訊息，繼續 |
+| Plugin cache 不存在或 hooks 缺失 | 輸出 `[警告]`，在 §2.5 完成清單標記「claim hooks 待補裝」，繼續（不阻塞） |
+| hooks/ 已存在但無 +x 權限 | 執行 `chmod +x hooks/claim-issue.sh hooks/release-issue.sh`，繼續 |
+
+**驗證**：
+
+```bash
+# 確認 hooks 存在且可執行
+for HOOK in hooks/claim-issue.sh hooks/release-issue.sh; do
+  if [[ -f "$HOOK" ]] && [[ -x "$HOOK" ]]; then
+    echo "[Pass] ${HOOK} 已安裝且可執行"
+  else
+    echo "[警告] ${HOOK} 安裝不完整（Cruise self-heal 將在下次巡邏補裝）"
+  fi
+done
+```
+
 ### 2.4 生成專案配置文件（CLAUDE.md / GEMINI.md）
 
 **目的**：建立框架啟動設定文件，定義專案資訊與自治等級。

--- a/tests/test-onboarding-hooks.sh
+++ b/tests/test-onboarding-hooks.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# test-onboarding-hooks.sh
+# Story #692 — 驗證 onboarding 流程說明包含 claim/release hooks 安裝步驟
+# AC4: 測試驗證 onboarding 後 hooks 存在且可執行
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0; FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== test-onboarding-hooks.sh ==="
+
+# ── AC1: execution-steps.md §2.3 包含 claim-issue.sh 複製步驟 ────────────
+EXEC_STEPS="${REPO_ROOT}/skills/onboarding/references/execution-steps.md"
+
+if [[ -f "$EXEC_STEPS" ]]; then
+  pass "execution-steps.md 存在"
+else
+  fail "execution-steps.md 不存在"
+fi
+
+if grep -q "claim-issue.sh" "$EXEC_STEPS" 2>/dev/null; then
+  pass "execution-steps.md 包含 claim-issue.sh 安裝步驟"
+else
+  fail "execution-steps.md 缺少 claim-issue.sh 安裝步驟（AC1 未滿足）"
+fi
+
+if grep -q "release-issue.sh" "$EXEC_STEPS" 2>/dev/null; then
+  pass "execution-steps.md 包含 release-issue.sh 安裝步驟"
+else
+  fail "execution-steps.md 缺少 release-issue.sh 安裝步驟（AC1 未滿足）"
+fi
+
+if grep -q "hooks/" "$EXEC_STEPS" 2>/dev/null; then
+  pass "execution-steps.md 包含 hooks/ 目錄安裝指引"
+else
+  fail "execution-steps.md 缺少 hooks/ 目錄指引（AC1 未滿足）"
+fi
+
+# ── AC2: sre-inspection.md 包含 CLAIM-WARN 偵測與 self-heal 步驟 ─────────
+SRE_INSP="${REPO_ROOT}/skills/cruise/references/sre-inspection.md"
+
+if [[ -f "$SRE_INSP" ]]; then
+  pass "sre-inspection.md 存在"
+else
+  fail "sre-inspection.md 不存在"
+fi
+
+if grep -q "CLAIM-WARN\|claim-warn" "$SRE_INSP" 2>/dev/null; then
+  pass "sre-inspection.md 包含 CLAIM-WARN 偵測邏輯（AC2 滿足）"
+else
+  fail "sre-inspection.md 缺少 CLAIM-WARN 偵測邏輯（AC2 未滿足）"
+fi
+
+if grep -q "self-heal\|自動安裝\|claim-issue.sh" "$SRE_INSP" 2>/dev/null; then
+  pass "sre-inspection.md 包含 self-heal 安裝邏輯（AC2 滿足）"
+else
+  fail "sre-inspection.md 缺少 self-heal 邏輯（AC2 未滿足）"
+fi
+
+# ── AC3: sre-inspection.md 包含失敗時建 Issue 的邏輯 ────────────────────
+if grep -q "SRE.*claim hooks\|claim hooks.*缺失\|\[SRE\] claim" "$SRE_INSP" 2>/dev/null; then
+  pass "sre-inspection.md 包含 claim hooks 缺失 Issue 建立（AC3 滿足）"
+else
+  fail "sre-inspection.md 缺少 claim hooks 缺失 Issue 邏輯（AC3 未滿足）"
+fi
+
+# ── AC4: 框架本身 hooks 存在且可執行 ─────────────────────────────────────
+CLAIM_HOOK="${REPO_ROOT}/hooks/claim-issue.sh"
+RELEASE_HOOK="${REPO_ROOT}/hooks/release-issue.sh"
+
+if [[ -f "$CLAIM_HOOK" ]]; then
+  pass "hooks/claim-issue.sh 存在"
+else
+  fail "hooks/claim-issue.sh 不存在"
+fi
+
+if [[ -x "$CLAIM_HOOK" ]]; then
+  pass "hooks/claim-issue.sh 可執行"
+else
+  fail "hooks/claim-issue.sh 不可執行（缺少 +x 權限）"
+fi
+
+if [[ -f "$RELEASE_HOOK" ]]; then
+  pass "hooks/release-issue.sh 存在"
+else
+  fail "hooks/release-issue.sh 不存在"
+fi
+
+if [[ -x "$RELEASE_HOOK" ]]; then
+  pass "hooks/release-issue.sh 可執行"
+else
+  fail "hooks/release-issue.sh 不可執行（缺少 +x 權限）"
+fi
+
+# ── AC4: 模擬 onboarding 後 hooks 複製並驗證可執行性 ─────────────────────
+# 建立臨時目錄模擬消費端 repo
+TMP_CONSUMER=$(mktemp -d)
+trap "rm -rf $TMP_CONSUMER" EXIT
+
+mkdir -p "${TMP_CONSUMER}/hooks"
+
+# 模擬 onboarding 複製動作
+cp "${CLAIM_HOOK}" "${TMP_CONSUMER}/hooks/claim-issue.sh"
+cp "${RELEASE_HOOK}" "${TMP_CONSUMER}/hooks/release-issue.sh"
+chmod +x "${TMP_CONSUMER}/hooks/claim-issue.sh"
+chmod +x "${TMP_CONSUMER}/hooks/release-issue.sh"
+
+if [[ -f "${TMP_CONSUMER}/hooks/claim-issue.sh" ]] && \
+   [[ -x "${TMP_CONSUMER}/hooks/claim-issue.sh" ]]; then
+  pass "onboarding 後消費端 claim-issue.sh 存在且可執行（AC4 滿足）"
+else
+  fail "onboarding 後消費端 claim-issue.sh 不存在或不可執行（AC4 未滿足）"
+fi
+
+if [[ -f "${TMP_CONSUMER}/hooks/release-issue.sh" ]] && \
+   [[ -x "${TMP_CONSUMER}/hooks/release-issue.sh" ]]; then
+  pass "onboarding 後消費端 release-issue.sh 存在且可執行（AC4 滿足）"
+else
+  fail "onboarding 後消費端 release-issue.sh 不存在或不可執行（AC4 未滿足）"
+fi
+
+# ── 結果 ──────────────────────────────────────────────────────────────────
+echo ""
+echo "=== 結果：PASS=${PASS} FAIL=${FAIL} ==="
+if [[ $FAIL -eq 0 ]]; then
+  echo "[OK] 全部通過"
+  exit 0
+else
+  echo "[NG] ${FAIL} 個測試失敗"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **AC1**: `skills/onboarding/references/execution-steps.md` §2.3.1 新增「安裝 Claim/Release Hooks」步驟，包含冪等保護、plugin cache 路徑偵測（`SHIKIGAMI_PLUGIN_PATH` 環境變數覆蓋）、+x 權限設定
- **AC2**: `skills/cruise/references/sre-inspection.md` 新增 CLAIM-WARN 偵測邏輯，偵測到 hooks 缺失時自動從 plugin cache 補裝（self-heal）
- **AC3**: self-heal 失敗時建立 `[SRE] claim hooks 缺失，需手動安裝` Issue（--body-file 模式、重複防護、含手動安裝步驟）
- **AC4**: `tests/test-onboarding-hooks.sh` 驗證 14 個測試點全部 PASS（hooks 存在、可執行、onboarding 後消費端驗證）

## Test plan

- [x] `bash tests/test-onboarding-hooks.sh` → 14/14 PASS
- [x] `bash scripts/validate-skills.sh` → 全部通過
- [x] `bash scripts/validate-xrefs.sh` → 全部通過
- [x] `bash scripts/validate-orphans.sh` → 全部通過

## Closes

#692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
