### PR TITLE
feat: Backlog Bridge 流程引用 ISSUE_TEMPLATE 模板，確保 NFR 欄位完整性 (#691)

### DIFF
--- a/skills/backlog-management/SKILL.md
+++ b/skills/backlog-management/SKILL.md
@@ -59,7 +59,7 @@ Backlog Management 負責 **Backlog Grooming** 流程，由 **Product Owner (PO)
     --json number,title,body,labels --limit 200
   ```
 - [ ] 關閉過時或已不再適用的 Story Issue（`gh issue close <number>`）
-- [ ] 根據最新需求與回饋，新開 Issue 或套用 `status: backlog` label 並編寫 Story template
+- [ ] 根據最新需求與回饋，新開 Issue 或套用 `status: backlog` label 並依 `.github/ISSUE_TEMPLATE/` 對應模板編寫 Story body（feature → feature.md、bug → bug.md、chore/refactor/docs/infra → story.md），確保 `## 非功能性需求` 欄位已填寫
 - [ ] 以 `gh issue edit <number>` 調整優先級 label（`priority: must` / `priority: should` / `priority: could`）並更新 RICE 分數
 - [ ] 確保每個 Backlog Issue body 有清楚的 Acceptance Criteria
 

--- a/skills/issue-management/SKILL.md
+++ b/skills/issue-management/SKILL.md
@@ -195,7 +195,7 @@ gh issue comment <number> --body "<comment>"
 
 **摘要**：
 - ADR-010 單層 Issue 架構，直接改寫 Issue body
-- Step 1 Injection 防護 → Step 2 前端識別 + AI 填補 Story template → Step 3 RICE 驗證 → Step 4 改寫 body → Step 5-6 套用 labels + 冪等標記 → Step 7 PO Review Gate
+- Step 1 Injection 防護 → Step 2 前端識別 + AI 填補 Story template（以 `.github/ISSUE_TEMPLATE/` 對應模板為基礎，必含 `## 非功能性需求` 欄位）→ Step 3 RICE 驗證 → Step 4 改寫 body → Step 5-6 套用 labels + 冪等標記 → Step 7 PO Review Gate
 
 ---
 

--- a/skills/issue-management/references/backlog-bridge.md
+++ b/skills/issue-management/references/backlog-bridge.md
@@ -46,7 +46,17 @@ PO subagent 角色宣告：
 
 **Step 2.1：AI 填補 Story template**
 
-PO subagent 根據 Issue 內容產生新 Issue body，格式：
+PO subagent 根據 Issue 內容與類型，**以 `.github/ISSUE_TEMPLATE/` 對應模板為基礎**產生新 Issue body。
+
+**模板選擇規則**：
+
+| Issue 類型 | 對應模板 |
+|-----------|---------|
+| Bug / 缺陷 | `.github/ISSUE_TEMPLATE/bug.md` |
+| Feature / 功能需求 | `.github/ISSUE_TEMPLATE/feature.md` |
+| Chore / Refactor / Docs / Infra | `.github/ISSUE_TEMPLATE/story.md` |
+
+PO subagent 根據選定模板結構填補欄位，並在最前方加上 Backlog Bridge 專屬欄位，最後附加入庫資訊。完整格式如下：
 
 ```markdown
 ## 原始需求
@@ -56,6 +66,8 @@ PO subagent 根據 Issue 內容產生新 Issue body，格式：
 ## User Story
 
 身為 <角色>，我希望 <功能描述>，以便 <業務價值>。
+
+{以下欄位依選定 ISSUE_TEMPLATE 模板結構填補，保持與模板一致的欄位名稱與格式}
 
 ## Acceptance Criteria
 
@@ -97,6 +109,13 @@ PO subagent 根據 Issue 內容產生新 Issue body，格式：
 **入庫時間**：<YYYY-MM-DD>
 **入庫狀態**：待 PO 精化
 ```
+
+**欄位完整性規則**：
+
+- `## 非功能性需求` 欄位為必填，不得省略，至少填寫一條 NFR（AC2 需求）
+- `## 原始需求` blockquote 必須完整保留原始 Issue body（Backlog Bridge 專屬，不在 ISSUE_TEMPLATE 中）
+- `## 入庫資訊` 區塊必須附加於 body 末尾（Backlog Bridge 專屬，不在 ISSUE_TEMPLATE 中）
+- 所有 ISSUE_TEMPLATE 模板欄位均須保留，不得刪減
 
 **Step 3：RICE Score 正則驗證**
 


### PR DESCRIPTION
## Summary

- `backlog-bridge.md` Step 2.1 改為以 `.github/ISSUE_TEMPLATE/` 為 canonical source，依 Issue 類型（Bug/Feature/Story）選擇對應模板，消除硬編碼模板定義（方案 b）
- 保留 Backlog Bridge 專屬欄位：`## 原始需求` blockquote 與 `## 入庫資訊`（不在 ISSUE_TEMPLATE 中）
- 新增欄位完整性規則：`## 非功能性需求` 為必填，確保所有入庫 Issue 包含 NFR 欄位（AC2）
- `issue-management/SKILL.md` §11 摘要同步更新
- `backlog-management/SKILL.md` §3 Grooming 流程同步更新

## AC Compliance

- AC1: Backlog Bridge Step 2.1 引用 `.github/ISSUE_TEMPLATE/` 對應模板 ✓
- AC2: 欄位完整性規則明確要求 `## 非功能性需求` 必填 ✓
- NFR completeness: 所有透過 Backlog Bridge 建立的 Issue 均使用模板（模板選擇規則覆蓋所有 Issue 類型）✓

## Team Debate 豁免

`doc_only=true`，純流程定義文件修改，依規豁免。

## Test plan

- [ ] 執行 `bash scripts/validate-skills.sh` — 通過（30 個 Skill 全部 PASS）
- [ ] 執行 `bash scripts/validate-xrefs.sh` — 通過（297 個引用全部有效）
- [ ] 確認 `backlog-bridge.md` Step 2.1 模板選擇規則涵蓋 Bug/Feature/Story 三種類型
- [ ] 確認 `## 原始需求` blockquote 與 `## 入庫資訊` 保留為 Backlog Bridge 專屬欄位

🤖 Generated with [Claude Code](https://claude.com/claude-code)
