### PR TITLE
fix: cruise 啟動時自動清理 stale worktree（prunable）(#697)

### DIFF
--- a/skills/cruise/SKILL.md
+++ b/skills/cruise/SKILL.md
@@ -74,6 +74,7 @@ Cruise Mode 支援兩種執行模式：
 2. 偵測 Repo 列表（單一 repo 或多 repo 模式）
 2.5. 驗證 Repo Remote（排除 local:* 或無效 GitHub remote）
 3. 列出偵測結果
+3.5. 自動清理 Stale Worktree（git worktree prune + orphan 目錄清除，#697）
 4. 建立 Flag File（SESSION_ID 命名，互不干擾）
 4.2. 建立 Sprint Stories Task List（{repo}/cruise-cycle-{N}）
 4.5. 讀取 project_level（.claude/shikigami.local.md）

--- a/skills/cruise/references/startup-flow.md
+++ b/skills/cruise/references/startup-flow.md
@@ -68,6 +68,33 @@ for REPO_PATH in "${REPOS[@]}"; do
 done
 ```
 
+## §3.5 自動清理 Stale Worktree（#697）
+
+在建立 Flag File 之前，對所有偵測到的 repo 執行 worktree 清理，釋放被 prunable worktree 佔用的 `SHIKIGAMI_MAX_PARALLEL` 額度，防止 auto-shoot 永遠被 OOM 擋住的死循環（#697 歷史案例）。
+
+```bash
+# §3.5 Stale Worktree 自動清理（#697）
+for REPO_PATH in "${REPOS[@]}"; do
+  # AC2: 對所有 REPOS 執行 git worktree prune
+  git -C "$REPO_PATH" worktree prune 2>/dev/null || true  # AC4: 失敗不阻塞 cruise
+
+  # AC3: 移除超過 1 小時的 orphan worktree 目錄
+  WORKTREE_DIR="${REPO_PATH}/.claude/worktrees"
+  if [[ -d "$WORKTREE_DIR" ]]; then
+    find "$WORKTREE_DIR" -maxdepth 1 -mindepth 1 -type d -mmin +60 | while read -r orphan_dir; do
+      git -C "$REPO_PATH" worktree remove --force "$orphan_dir" 2>/dev/null || true  # AC4: 失敗不阻塞
+    done
+  fi
+done
+echo "[CRUISE] §3.5 worktree prune 完成"
+```
+
+**適用範圍**：每次 cruise 啟動時（Loop Mode 與 Once Mode 均執行）。
+**AC1**：本步驟位於 §4 之前，確保建立 Flag File 前額度已釋放。
+**AC5**：驗證方式 — 執行後 `git worktree list` 不應出現 prunable 條目。
+
+---
+
 ## §4 建立 Flag File（SSOT — #449 AC4）
 
 ```bash


### PR DESCRIPTION
fix: cruise 啟動時自動清理 stale worktree（prunable）(#697)

新增 startup-flow.md §3.5 — 在 §4 建立 Flag File 之前，對所有 REPOS 執行 git worktree prune 並強制移除超過 1 小時的 orphan worktree 目錄。失敗不阻塞（|| true）。修復 prunable worktree 佔住 SHIKIGAMI_MAX_PARALLEL 額度導致 auto-shoot 死循環問題。

## AC 確認
- AC1: cruise SKILL.md §3.5 已新增，位於 §4 之前 ✅
- AC2: git worktree prune 對所有 REPOS 執行 ✅
- AC3: find -mmin +60 強制移除 orphan 目錄 ✅
- AC4: || true 確保失敗不阻塞 ✅
- AC5: 文件說明驗證方式 ✅

Closes #697