### PR TITLE
retro: bug 類 Issue Template 補充 NFR 欄位 — 與 enhancement 模板對齊 (#699)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -34,8 +34,12 @@ assignees: ''
 
 <!-- 品質屬性（freshness / completeness / performance / accessibility / reliability / security 或其他可量化屬性）
      格式：NFR1: <屬性名稱> — <可量化描述>
-     範例：NFR1: reliability — 修復後既有測試全部通過，無回歸失敗
-     至少填寫一條 NFR，不可保留預設文字 -->
+     Bug 類常見 NFR 建議（至少填寫一條，不可保留預設文字）：
+     - reliability（可靠性）：NFR1: reliability — 修復後既有測試全部通過，無回歸失敗
+     - performance（效能）：NFR1: performance — 修復後操作回應時間 < Xms，與修復前持平或更優
+     - stability（穩定性）：NFR1: stability — 修復後相同條件下不再出現此問題，連續 N 次驗證無復現
+     - security（安全性）：NFR1: security — 修復不引入新的輸入驗證漏洞或權限控制問題
+     - compatibility（相容性）：NFR1: compatibility — 修復在所有支援平台（列舉）均驗證通過 -->
 - NFR1: <屬性名稱> — <可量化描述>
 
 ## 環境資訊

--- a/skills/issue-management/references/backlog-bridge.md
+++ b/skills/issue-management/references/backlog-bridge.md
@@ -117,6 +117,20 @@ PO subagent 根據選定模板結構填補欄位，並在最前方加上 Backlog
 - `## 入庫資訊` 區塊必須附加於 body 末尾（Backlog Bridge 專屬，不在 ISSUE_TEMPLATE 中）
 - 所有 ISSUE_TEMPLATE 模板欄位均須保留，不得刪減
 
+**Bug 類 Issue NFR 填寫指引**（#699）：
+
+Bug 類 Issue 與 enhancement 類 Issue 一樣需要填寫 NFR 欄位，且格式一致。Bug 修復的 NFR 聚焦於修復後的品質保證，常見建議如下：
+
+| NFR 屬性 | 適用情境 | 填寫範例 |
+|---------|---------|---------|
+| reliability（可靠性） | 所有 bug 修復 | `NFR1: reliability — 修復後既有測試全部通過，無回歸失敗` |
+| performance（效能） | 效能退化類 bug | `NFR1: performance — 修復後回應時間不超過修復前基線的 110%` |
+| stability（穩定性） | 偶發性 bug | `NFR1: stability — 修復後相同條件下連續 5 次驗證無復現` |
+| security（安全性） | 安全漏洞修復 | `NFR1: security — 修復不引入新的輸入驗證漏洞` |
+| compatibility（相容性） | 跨平台問題 | `NFR1: compatibility — 修復在 macOS / Linux / WSL 均驗證通過` |
+
+PO 在 Backlog Bridge 填補 Bug 類 Issue 時，若原始 Issue body 未填寫 NFR，**應自動補充最少一條 NFR**（優先選擇 reliability），不可留下 `NFR1: <屬性名稱> — <可量化描述>` 預設文字。
+
 **Step 3：RICE Score 正則驗證**
 
 ```bash


### PR DESCRIPTION
retro: bug 類 Issue Template 補充 NFR 欄位 — 與 enhancement 模板對齊 (#699)

強化 bug.md NFR 區塊說明文字，加入 reliability/performance/stability/security/compatibility 五類 bug 修復常見 NFR 建議。新增 backlog-bridge.md「Bug 類 Issue NFR 填寫指引」段落，說明 bug 類 Issue NFR 填寫要求與範例表格（AC4）。

## AC 確認
- AC1: bug.md 包含 NFR 區塊，有預填範例 ✅
- AC2: 明確說明文字含五類 NFR 建議 ✅
- AC3: bug/enhancement 模板 NFR 格式一致 ✅
- AC4: backlog-bridge.md 新增 bug 類 NFR 填寫指引 ✅

Closes #699