### PR TITLE
feat: memory-aware parallel-safety dynamic adjustment (#712)

### DIFF
--- a/scripts/memory-aware-dispatch.sh
+++ b/scripts/memory-aware-dispatch.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+
+# Memory-aware parallel dispatch safety mechanism (#712)
+# Dynamically adjusts SHIKIGAMI_MAX_PARALLEL based on available system memory
+# Supports: Linux (/proc/meminfo), macOS (sysctl), WSL2 (fallback)
+
+set -u
+
+# ────────────────────────────────────────────────────────────────────────────
+# Configuration
+# ────────────────────────────────────────────────────────────────────────────
+
+# Baseline memory per worktree subagent (MB)
+MEMORY_PER_AGENT_MB=${MEMORY_PER_AGENT_MB:-512}
+
+# Default static max parallel limit (fallback)
+DEFAULT_MAX_PARALLEL=${SHIKIGAMI_MAX_PARALLEL:-2}
+
+# Timeout for memory detection (milliseconds)
+MEMORY_DETECTION_TIMEOUT_MS=100
+
+# ────────────────────────────────────────────────────────────────────────────
+# Function: get_memory_detection_method
+# Returns: Detection method name (proc, sysctl, wsl2-proc, unknown)
+# ────────────────────────────────────────────────────────────────────────────
+
+get_memory_detection_method() {
+    if [ -r /proc/meminfo ]; then
+        echo "proc"
+    elif command -v sysctl &>/dev/null; then
+        echo "sysctl"
+    elif [ -r /proc/meminfo ] && grep -q "^MemAvailable" /proc/meminfo 2>/dev/null; then
+        echo "wsl2-proc"
+    else
+        echo "unknown"
+    fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Function: get_available_memory_mb
+# Returns: Available system memory in MB
+# Fallback: Returns DEFAULT_MAX_PARALLEL * MEMORY_PER_AGENT_MB if detection fails
+# ────────────────────────────────────────────────────────────────────────────
+
+get_available_memory_mb() {
+    local method
+    local available_kb=0
+    local available_mb=0
+
+    method=$(get_memory_detection_method)
+
+    case "$method" in
+        proc)
+            # Linux: Read from /proc/meminfo
+            # Try MemAvailable (preferred, newer kernels), fallback to MemFree
+            if available_kb=$(awk '/^MemAvailable:/{print $2; exit}' /proc/meminfo 2>/dev/null); then
+                [ -z "$available_kb" ] && available_kb=$(awk '/^MemFree:/{print $2; exit}' /proc/meminfo 2>/dev/null)
+            fi
+            available_mb=$((available_kb / 1024))
+            ;;
+
+        sysctl)
+            # macOS: Use sysctl to get total physical memory, then estimate available
+            # Note: macOS sysctl doesn't provide direct "available" - use total and estimate
+            local total_bytes
+            if total_bytes=$(sysctl -n hw.memsize 2>/dev/null); then
+                local total_mb=$((total_bytes / 1048576))
+                # Conservative estimate: assume 60% of total is available
+                available_mb=$((total_mb * 60 / 100))
+            fi
+            ;;
+
+        wsl2-proc)
+            # WSL2: Fallback to MemFree from /proc/meminfo
+            available_kb=$(awk '/^MemFree:/{print $2; exit}' /proc/meminfo 2>/dev/null || echo "0")
+            available_mb=$((available_kb / 1024))
+            ;;
+
+        *)
+            # Unknown system: Return fallback value
+            available_mb=$((DEFAULT_MAX_PARALLEL * MEMORY_PER_AGENT_MB))
+            ;;
+    esac
+
+    # Sanity check: minimum 512MB, maximum 256GB
+    if [ "$available_mb" -lt 512 ]; then
+        available_mb=512
+    elif [ "$available_mb" -gt 262144 ]; then
+        available_mb=262144
+    fi
+
+    echo "$available_mb"
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Function: calculate_dynamic_max_parallel
+# Args:
+#   $1: Available memory in MB (optional, will detect if not provided)
+#   $2: Static max parallel limit (optional, defaults to SHIKIGAMI_MAX_PARALLEL or 2)
+# Returns: Safe maximum parallel count
+# ────────────────────────────────────────────────────────────────────────────
+
+calculate_dynamic_max_parallel() {
+    local available_mb="${1:-$(get_available_memory_mb)}"
+    local static_max="${2:-${SHIKIGAMI_MAX_PARALLEL:-2}}"
+
+    # Calculate dynamic max: floor(available_mb / per_agent_mb)
+    local dynamic_max=$((available_mb / MEMORY_PER_AGENT_MB))
+
+    # Ensure at least 1 agent can run
+    if [ "$dynamic_max" -lt 1 ]; then
+        dynamic_max=1
+    fi
+
+    # Return minimum of dynamic and static max
+    if [ "$dynamic_max" -lt "$static_max" ]; then
+        echo "$dynamic_max"
+    else
+        echo "$static_max"
+    fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Function: log_memory_dispatch_decision
+# Logs memory-aware dispatch decision to cruise log in JSONL format
+# Args:
+#   $1: Available memory (MB)
+#   $2: Dynamic max calculated
+#   $3: Static max limit
+#   $4: Detection method used
+#   $5: Log file path (optional)
+# ────────────────────────────────────────────────────────────────────────────
+
+log_memory_dispatch_decision() {
+    local available_mb="$1"
+    local dynamic_max="$2"
+    local static_max="$3"
+    local detection_method="$4"
+    local log_file="${5:-}"
+
+    # Determine cruise log file if not provided
+    if [ -z "$log_file" ]; then
+        local session_id="${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
+        log_file="docs/cruise-logs/$(date +%Y-%m-%d)-session-${session_id}.jsonl"
+    fi
+
+    # Create parent directory if needed
+    mkdir -p "$(dirname "$log_file")"
+
+    # Build JSONL entry
+    local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    local warning_triggered="false"
+    if [ "$dynamic_max" -lt "$static_max" ]; then
+        warning_triggered="true"
+    fi
+
+    local json_entry="{\"timestamp\":\"$timestamp\",\"type\":\"memory-aware-dispatch\",\"available_mb\":$available_mb,\"dynamic_max\":$dynamic_max,\"static_max\":$static_max,\"detection_method\":\"$detection_method\",\"warning_triggered\":$warning_triggered,\"memory_per_agent_mb\":$MEMORY_PER_AGENT_MB}"
+
+    # Append to log file
+    echo "$json_entry" >> "$log_file" 2>/dev/null || true
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Function: get_dispatch_decision
+# Main function that performs all memory-aware dispatch checks
+# Returns: Space-separated values: dynamic_max, detection_method, warning_triggered
+# ────────────────────────────────────────────────────────────────────────────
+
+get_dispatch_decision() {
+    local method
+    local available_mb
+    local dynamic_max
+    local static_max
+    local warning_triggered="false"
+
+    # Get detection method
+    method=$(get_memory_detection_method)
+
+    # Get available memory
+    available_mb=$(get_available_memory_mb)
+
+    # Get static max from environment
+    static_max="${SHIKIGAMI_MAX_PARALLEL:-2}"
+
+    # Calculate dynamic max
+    dynamic_max=$(calculate_dynamic_max_parallel "$available_mb" "$static_max")
+
+    # Check if warning should be triggered
+    if [ "$dynamic_max" -lt "$static_max" ]; then
+        warning_triggered="true"
+    fi
+
+    # Log the decision
+    log_memory_dispatch_decision "$available_mb" "$dynamic_max" "$static_max" "$method"
+
+    # Output decision info
+    echo "$dynamic_max $method $warning_triggered"
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Function: format_oom_warning
+# Formats OOM warning message for output
+# Args:
+#   $1: Dynamic max calculated
+#   $2: Static max limit
+#   $3: Available memory (MB)
+#   $4: Detection method
+# ────────────────────────────────────────────────────────────────────────────
+
+format_oom_warning() {
+    local dynamic_max="$1"
+    local static_max="$2"
+    local available_mb="$3"
+    local method="$4"
+
+    printf "[OOM-WARN] Dynamic memory adjustment: available=%dMB, safe_parallel=%d (limit=%d, method=%s)\n" \
+        "$available_mb" "$dynamic_max" "$static_max" "$method"
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Main execution: Export functions when sourced
+# ────────────────────────────────────────────────────────────────────────────
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    # Script is being executed directly (for testing)
+    get_dispatch_decision
+    exit 0
+fi

--- a/skills/sprint-execution/references/parallel-safety.md
+++ b/skills/sprint-execution/references/parallel-safety.md
@@ -18,6 +18,7 @@
 
 <!-- US-255 低記憶體環境平行 Subagent 數量上限控制 — Sprint 93 -->
 <!-- #536 平行 subagent OOM 防護 — Sprint 129 -->
+<!-- #712 動態記憶體感知調整機制 — Sprint 153 -->
 
 環境變數 `SHIKIGAMI_MAX_PARALLEL` 控制 Sprint Execution 平行派遣 subagent 的最大數量，用於防止記憶體不足（OOM）。
 
@@ -30,6 +31,97 @@
 | 未設定 | **預設 2**：最多同時 2 個 subagent（OOM 防護預設值） |
 | `1` | 強制循序執行：所有 Story 一個接一個執行，不出現平行派遣 |
 | `N`（N ≥ 2） | 最多同時 N 個 subagent；超出部分排入下一批次依序執行 |
+
+### 動態記憶體感知調整（#712）
+
+<!-- #712 Sprint Execution parallel-safety 動態記憶體感知調整機制 — Sprint 153 -->
+
+除了靜態上限外，Sprint Execution 派遣 subagent 前自動執行**動態記憶體偵測**，根據實時可用系統記憶體動態調整並行上限，防止在低記憶體環境中仍超配並行數量。
+
+#### 設計原理
+
+靜態上限 `SHIKIGAMI_MAX_PARALLEL = N` 為保守值，適用於「平均情況」。但實際可承受的並行數量取決於：
+- **可用系統記憶體** — 實時檢測 `/proc/meminfo`（Linux）、`sysctl hw.memsize`（macOS）或 WSL2 fallback
+- **估計每個 worktree subagent 的記憶體佔用** — baseline 512MB（包含 Claude model context、git worktree、node 進程）
+- **動態計算安全並行上限** — `DYNAMIC_MAX = min(N, floor(available_mb / 512))`
+
+#### 偵測流程
+
+派遣 subagent 前：
+
+```
+1. 取得環境變數 SHIKIGAMI_MAX_PARALLEL（靜態上限，無則預設 2）
+2. 偵測系統可用記憶體
+   |-- Linux: 讀取 /proc/meminfo
+   |           優先使用 MemAvailable（kernel 3.14+），fallback 至 MemFree
+   |-- macOS: 透過 sysctl hw.memsize 取得總記憶體，保守估計 60% 可用
+   |-- WSL2:  /proc/meminfo MemFree（同 Linux）
+   |-- 偵測失敗: 靜默降級至靜態值 2
+3. 計算動態上限
+   DYNAMIC_MAX = floor(available_mb / 512)
+   FINAL_MAX = min(DYNAMIC_MAX, SHIKIGAMI_MAX_PARALLEL)
+4. 決策
+   |-- FINAL_MAX == SHIKIGAMI_MAX_PARALLEL → 不觸發警告，正常派遣
+   |-- FINAL_MAX < SHIKIGAMI_MAX_PARALLEL  → 記憶體受限，輸出 [OOM-WARN]，採用 FINAL_MAX
+5. 記錄決策
+   →  cruise log（type: memory-aware-dispatch）
+      含：detected_method, available_mb, dynamic_max, static_max, warning_triggered
+```
+
+#### 範例
+
+| 環境 | 可用記憶體 | 靜態上限 N | 動態上限 | 結果 | 輸出 |
+|------|----------|----------|--------|------|------|
+| 低記憶體 Linux（1GB） | 1024 MB | 2 | floor(1024/512)=2 | 採用 2 | 無警告 |
+| 低記憶體 Linux（512MB） | 512 MB | 2 | floor(512/512)=1 | 採用 1 | `[OOM-WARN]` |
+| 高記憶體 Linux（8GB） | 8192 MB | 2 | floor(8192/512)=16 | 採用 2 | 無警告 |
+| 高記憶體 Linux（8GB） | 8192 MB | 4 | floor(8192/512)=16 | 採用 4 | 無警告 |
+| macOS（16GB） | ~9600 MB | 2 | floor(9600/512)=18 | 採用 2 | 無警告 |
+
+#### 實作細節
+
+**偵測腳本**：`scripts/memory-aware-dispatch.sh`
+
+主要函式：
+- `get_available_memory_mb()` — 傳回系統可用記憶體（MB）
+- `get_memory_detection_method()` — 傳回偵測方法名稱（proc / sysctl / wsl2-proc / unknown）
+- `calculate_dynamic_max_parallel(available_mb, static_max)` — 計算動態上限
+- `log_memory_dispatch_decision(...)` — 記錄決策至 cruise log（JSONL type: "memory-aware-dispatch"）
+- `get_dispatch_decision()` — 主函式，執行完整偵測流程並傳回決策資訊
+
+**環境變數**（可選調整）：
+- `MEMORY_PER_AGENT_MB=512` — 每個 worktree subagent 的估計記憶體佔用（default: 512MB）
+- `SHIKIGAMI_MAX_PARALLEL=N` — 靜態上限（default: 2，若未設定視為 2）
+
+**效能承諾**：偵測操作 < 100ms（記憶體讀取不阻塞派遣流程）
+
+#### 降級與容錯
+
+| 情況 | 處理 |
+|------|------|
+| 記憶體偵測失敗 | 靜默降級至靜態值 2，無警告，繼續派遣 |
+| `/proc/meminfo` 不可讀（permission） | 自動 fallback 至偵測方法 unknown，採用靜態值 |
+| macOS sysctl 失敗 | 自動 fallback，採用靜態值 |
+| WSL2 混合環境異常 | WSL2-proc fallback，採用 MemFree，採用靜態值 |
+
+#### 可觀察性
+
+每次派遣決策均記錄至 cruise log（`docs/cruise-logs/`），JSONL 格式：
+
+```json
+{
+  "timestamp": "2026-03-25T13:45:23Z",
+  "type": "memory-aware-dispatch",
+  "available_mb": 1024,
+  "dynamic_max": 2,
+  "static_max": 2,
+  "detection_method": "proc",
+  "warning_triggered": false,
+  "memory_per_agent_mb": 512
+}
+```
+
+事後可查詢 cruise log 追蹤動態調整決策歷史。
 
 ### 上限檢查規則（含現存 Worktree 計數）
 

--- a/tests/test-memory-aware-parallel.sh
+++ b/tests/test-memory-aware-parallel.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+# Test suite for memory-aware parallel dispatch safety mechanism (#712)
+# Tests memory detection logic across Linux, macOS, and WSL2 environments
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Source the memory detection function
+source "${PROJECT_ROOT}/scripts/memory-aware-dispatch.sh"
+
+# Color output for test results
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+test_count=0
+pass_count=0
+fail_count=0
+
+# Helper function to run tests
+run_test() {
+    local test_name="$1"
+    local test_func="$2"
+
+    test_count=$((test_count + 1))
+    echo -e "\n${YELLOW}[TEST $test_count]${NC} $test_name"
+
+    if $test_func; then
+        pass_count=$((pass_count + 1))
+        echo -e "${GREEN}✓ PASS${NC}"
+    else
+        fail_count=$((fail_count + 1))
+        echo -e "${RED}✗ FAIL${NC}"
+    fi
+}
+
+# Test 1: Function exists and is callable
+test_get_available_memory_exists() {
+    declare -F get_available_memory_mb &>/dev/null
+}
+
+# Test 2: Memory value is a positive integer
+test_get_available_memory_returns_positive_integer() {
+    local mem=$(get_available_memory_mb)
+    [[ "$mem" =~ ^[0-9]+$ ]] && [ "$mem" -gt 0 ]
+}
+
+# Test 3: Memory value is reasonable (between 512MB and 256GB)
+test_get_available_memory_reasonable_range() {
+    local mem=$(get_available_memory_mb)
+    [ "$mem" -ge 512 ] && [ "$mem" -le 262144 ]
+}
+
+# Test 4: Calculate dynamic max function exists
+test_calculate_dynamic_max_exists() {
+    declare -F calculate_dynamic_max_parallel &>/dev/null
+}
+
+# Test 5: Dynamic max calculation is correct
+test_calculate_dynamic_max_formula() {
+    local result=$(calculate_dynamic_max_parallel 2048 10)  # 2GB available, high static max
+    # Should be floor(2048 / 512) = 4, min(4, 10) = 4
+    [ "$result" -eq 4 ]
+}
+
+# Test 6: Dynamic max respects static max
+test_calculate_dynamic_max_respects_static_max() {
+    # With 1024MB available and static max 2
+    # Should return min(2, floor(1024/512)) = min(2, 2) = 2
+    local result=$(calculate_dynamic_max_parallel 1024 2)
+    [ "$result" -eq 2 ]
+}
+
+# Test 7: Dynamic max uses fallback when static max not provided
+test_calculate_dynamic_max_default_fallback() {
+    # With 3GB available and default static max 2
+    # Should return min(2, floor(3072/512)) = min(2, 6) = 2
+    local result=$(calculate_dynamic_max_parallel 3072)
+    [ "$result" -eq 2 ]
+}
+
+# Test 8: Get memory detection method
+test_get_memory_detection_method() {
+    local method=$(get_memory_detection_method)
+    [[ "$method" =~ ^(proc|sysctl|wsl2-proc|unknown)$ ]]
+}
+
+# Test 9: Dispatch decision logging exists
+test_log_dispatch_decision_exists() {
+    declare -F log_memory_dispatch_decision &>/dev/null
+}
+
+# Test 10: Memory too low warning calculation
+test_memory_warning_threshold() {
+    # With 768MB available and static max 2
+    # Should calculate: available=768, baseline_per_agent=512
+    # safe_count = floor(768/512) = 1, which is < 2 (static max)
+    # This should trigger warning
+    local mem=768
+    local static_max=2
+    local dynamic=$(calculate_dynamic_max_parallel "$mem" "$static_max")
+    [ "$dynamic" -lt "$static_max" ]
+}
+
+# Test 11: Memory sufficient case
+test_memory_sufficient_case() {
+    # With 2GB available and static max 2
+    # Should calculate: available=2048, baseline=512
+    # safe_count = floor(2048/512) = 4, which is >= 2
+    # No warning needed
+    local mem=2048
+    local static_max=2
+    local dynamic=$(calculate_dynamic_max_parallel "$mem" "$static_max")
+    [ "$dynamic" -eq "$static_max" ]
+}
+
+# Test 12: Edge case: very low memory
+test_edge_case_very_low_memory() {
+    # With 256MB available (below one agent baseline)
+    # Should return 0 or fallback to 1
+    local result=$(calculate_dynamic_max_parallel 256)
+    # Must not be negative and must be >= 1 (at least one agent must run)
+    [ "$result" -ge 1 ]
+}
+
+# Test 13: Edge case: very high memory
+test_edge_case_very_high_memory() {
+    # With 128GB available
+    # Should calculate: floor(131072/512) = 256, but capped by static max
+    local result=$(calculate_dynamic_max_parallel 131072 4)
+    [ "$result" -le 4 ]
+}
+
+# Test 14: Environment variable reading
+test_environment_variable_reading() {
+    # Test that static max can be read from environment
+    local original_max="${SHIKIGAMI_MAX_PARALLEL:-2}"
+    export SHIKIGAMI_MAX_PARALLEL=3
+    local result=$(calculate_dynamic_max_parallel 2048)
+    SHIKIGAMI_MAX_PARALLEL="$original_max"
+    # With 2GB and max 3: floor(2048/512)=4, min(4,3)=3
+    [ "$result" -eq 3 ]
+}
+
+# Test 15: Fallback to default when env not set
+test_fallback_to_default_when_env_unset() {
+    local original_max="${SHIKIGAMI_MAX_PARALLEL:-}"
+    unset SHIKIGAMI_MAX_PARALLEL || true
+    local result=$(calculate_dynamic_max_parallel 2048)
+    if [ -n "$original_max" ]; then
+        export SHIKIGAMI_MAX_PARALLEL="$original_max"
+    fi
+    # Should use default 2: min(floor(2048/512), 2) = min(4, 2) = 2
+    [ "$result" -eq 2 ]
+}
+
+# Run all tests
+run_test "Memory detection function exists" test_get_available_memory_exists
+run_test "Memory returns positive integer" test_get_available_memory_returns_positive_integer
+run_test "Memory value in reasonable range" test_get_available_memory_reasonable_range
+run_test "Dynamic max calculation function exists" test_calculate_dynamic_max_exists
+run_test "Dynamic max calculation formula correct" test_calculate_dynamic_max_formula
+run_test "Dynamic max respects static max" test_calculate_dynamic_max_respects_static_max
+run_test "Dynamic max uses default fallback" test_calculate_dynamic_max_default_fallback
+run_test "Memory detection method identification" test_get_memory_detection_method
+run_test "Dispatch decision logging function exists" test_log_dispatch_decision_exists
+run_test "Memory warning threshold triggers" test_memory_warning_threshold
+run_test "Sufficient memory case" test_memory_sufficient_case
+run_test "Edge case: very low memory" test_edge_case_very_low_memory
+run_test "Edge case: very high memory" test_edge_case_very_high_memory
+run_test "Environment variable reading" test_environment_variable_reading
+run_test "Fallback to default when env unset" test_fallback_to_default_when_env_unset
+
+# Summary
+echo -e "\n${YELLOW}═════════════════════════════════════════${NC}"
+echo -e "Test Results: ${GREEN}$pass_count PASS${NC} / ${RED}$fail_count FAIL${NC} (Total: $test_count)"
+echo -e "${YELLOW}═════════════════════════════════════════${NC}\n"
+
+if [ "$fail_count" -eq 0 ]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Implements dynamic memory-aware adjustment for the Sprint Execution parallel-safety mechanism. Automatically detects available system memory and dynamically adjusts `SHIKIGAMI_MAX_PARALLEL` to prevent OOM crashes while optimizing for available resources.

- Memory detection via `/proc/meminfo` (Linux), `sysctl` (macOS), WSL2 fallback
- Dynamic calculation: `DYNAMIC_MAX = min(N, floor(available_mb / 512))`
- Graceful degradation to static value 2 on detection failure
- Full observability via cruise log (JSONL format)

## Test Plan

- [x] 15 comprehensive tests in `tests/test-memory-aware-parallel.sh` (all passing)
  - Memory detection function accuracy
  - Dynamic/static max calculation correctness
  - Environment variable handling
  - Edge cases (very low/high memory)
  - Fallback behavior
- [x] Manual testing on WSL2 Linux environment confirms:
  - Detection method: proc (Linux)
  - Available memory: 5992 MB
  - Dynamic max: 2 (respects default static limit)
  - No false warnings
- [x] Documentation validation:
  - parallel-safety.md updated with design principles
  - Examples for different memory scenarios provided
  - Degradation/fallback paths documented

🤖 Generated with Claude Code
