### PR TITLE
feat: cruise logs 壓縮歸檔機制（長期可觀測性）(#708)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ logs/
 
 # Kill Switch runtime files（ADR-038）— flag と report は runtime のみ、git 対象外
 .kill-switch/
+
+# cruise logs 歸檔機制（#708 §4.4）
+# 歸檔後的原始 JSONL 不入版控，壓縮後的 .gz 保留於 archive 目錄
+docs/cruise-logs/archive/**/*.jsonl
+# .gz 檔案允許入版控（! 規則豁免）
+!docs/cruise-logs/archive/**/*.gz

--- a/skills/cruise/references/startup-flow.md
+++ b/skills/cruise/references/startup-flow.md
@@ -196,6 +196,85 @@ fi
 
 ---
 
+## §4.4 Log 歸檔機制（#708）
+
+每次 cruise 啟動時，自動掃描 `docs/cruise-logs/` 目錄，將超過 7 天的 JSONL 壓縮歸檔，維持 repo 輕量化。
+
+```bash
+# §4.4 Log 歸檔機制（#708）
+# AC2: 超過 7 天的 JSONL 自動壓縮至 docs/cruise-logs/archive/YYYY-MM/
+ARCHIVE_DAYS="${CRUISE_ARCHIVE_DAYS:-7}"
+CRUISE_LOG_DIR="${REPO_PATH}/docs/cruise-logs"
+ARCHIVE_BASE_DIR="${CRUISE_LOG_DIR}/archive"
+
+if [[ -d "${CRUISE_LOG_DIR}" ]]; then
+  # 取得 7 天前時間戳（跨平台：Linux + macOS + WSL2）
+  if date --version &>/dev/null 2>&1; then
+    # GNU date（Linux / WSL2）
+    CUTOFF_DATE=$(date -d "${ARCHIVE_DAYS} days ago" '+%Y-%m-%d')
+  else
+    # BSD date（macOS）
+    CUTOFF_DATE=$(date -v "-${ARCHIVE_DAYS}d" '+%Y-%m-%d')
+  fi
+
+  ARCHIVE_COUNT=0
+  SIZE_BEFORE=0
+  SIZE_AFTER=0
+
+  while IFS= read -r -d '' jsonl_file; do
+    filename="$(basename "${jsonl_file}")"
+    # 從檔名前綴提取日期（格式：YYYY-MM-DD-*）
+    file_date="${filename:0:10}"
+
+    if [[ "${file_date}" < "${CUTOFF_DATE}" ]] 2>/dev/null; then
+      # AC2: 確定歸檔目標目錄（YYYY-MM）
+      file_month="${file_date:0:7}"
+      ARCHIVE_DIR="${ARCHIVE_BASE_DIR}/${file_month}"
+      mkdir -p "${ARCHIVE_DIR}" 2>/dev/null || { echo "[LOG-ARCHIVE-WARN] 無法建立目錄 ${ARCHIVE_DIR}，跳過"; continue; }
+
+      # 記錄壓縮前大小
+      file_size=$(wc -c < "${jsonl_file}" 2>/dev/null || echo 0)
+      SIZE_BEFORE=$((SIZE_BEFORE + file_size))
+
+      # 壓縮至歸檔目錄
+      if gzip -c "${jsonl_file}" > "${ARCHIVE_DIR}/${filename}.gz" 2>/dev/null; then
+        # AC3: 歸檔成功後從 git 追蹤移除原始 JSONL
+        git -C "${REPO_PATH}" rm --cached "${jsonl_file#${REPO_PATH}/}" 2>/dev/null || true
+        rm -f "${jsonl_file}" 2>/dev/null || true
+
+        gz_size=$(wc -c < "${ARCHIVE_DIR}/${filename}.gz" 2>/dev/null || echo 0)
+        SIZE_AFTER=$((SIZE_AFTER + gz_size))
+        ARCHIVE_COUNT=$((ARCHIVE_COUNT + 1))
+      else
+        echo "[LOG-ARCHIVE-WARN] 壓縮失敗：${filename}，跳過（NFR2 降級繼續）"
+        rm -f "${ARCHIVE_DIR}/${filename}.gz" 2>/dev/null || true
+      fi
+    fi
+  done < <(find "${CRUISE_LOG_DIR}" -maxdepth 1 -name "*.jsonl" -type f -print0 2>/dev/null)
+
+  # AC4: 歸檔操作結果寫入 cruise log
+  if [[ "${ARCHIVE_COUNT}" -gt 0 ]]; then
+    echo "[LOG-ARCHIVE] 已歸檔 ${ARCHIVE_COUNT} 個 JSONL 檔案（壓縮前 ${SIZE_BEFORE}B → 壓縮後 ${SIZE_AFTER}B）"
+    echo "{\"type\":\"log-archived\",\"count\":${ARCHIVE_COUNT},\"size_before\":${SIZE_BEFORE},\"size_after\":${SIZE_AFTER},\"archive_days\":${ARCHIVE_DAYS},\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "${CRUISE_LOG}"
+  fi
+fi
+```
+
+**適用範圍**：Loop Mode 與 Once Mode 均執行（每次 cruise 啟動時）。
+**NFR1（效能）**：使用 `find -maxdepth 1` 限制掃描範圍，歸檔最多 100 個檔案時在 1 秒內完成。
+**NFR2（可靠性）**：壓縮失敗時輸出 `[LOG-ARCHIVE-WARN]` 並繼續，不阻塞 cruise 主流程。
+**NFR3（可觀察性）**：log entry 包含壓縮前後大小對比（size_before / size_after）。
+
+| AC | 說明 |
+|----|------|
+| AC1 | 本 §4.4 段落新增於 startup-flow.md |
+| AC2 | 超過 7 天（`ARCHIVE_DAYS` 可設定）的 JSONL 壓縮至 `docs/cruise-logs/archive/YYYY-MM/` |
+| AC3 | 歸檔成功後執行 `git rm --cached`，從 git 追蹤移除原始 JSONL |
+| AC4 | 歸檔結果寫入 `${CRUISE_LOG}`，type: log-archived，含 count/size_before/size_after |
+| AC5 | .gitignore 配置：archive 目錄 .gz 保留，原始 JSONL 豁免（見 .gitignore 更新） |
+
+---
+
 ## §4.5 讀取 project_level（#348）
 
 ```bash

--- a/tests/test-708-cruise-log-archive.sh
+++ b/tests/test-708-cruise-log-archive.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# tests/test-708-cruise-log-archive.sh
+# Story #708 — cruise logs 壓縮歸檔機制（長期可觀測性）
+#
+# ── 目的 ──────────────────────────────────────────────────────────────────
+#
+# 驗證 §4.4 Log 歸檔邏輯的三個核心行為：
+#   AC1: startup-flow.md 包含 §4.4 Log 歸檔邏輯
+#   AC2: 超過 7 天的 JSONL 自動壓縮至 archive/YYYY-MM/ 目錄
+#   AC3: 歸檔後原始 JSONL 從 git 追蹤移除（不保留於 repo）
+#   AC4: 歸檔操作結果寫入 cruise log（type: log-archived）
+#   AC5: .gitignore 正確配置
+#
+# ── 使用方式 ─────────────────────────────────────────────────────────────
+#   bash tests/test-708-cruise-log-archive.sh
+# ─────────────────────────────────────────────────────────────────────────
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "  [PASS] $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  [FAIL] $1"; echo "    [DIAG] $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+echo "=== cruise log archive test suite (#708) ==="
+echo ""
+
+# ─── AC1：startup-flow.md 包含 §4.4 Log 歸檔邏輯 ───────────────────────
+echo "--- AC1: startup-flow.md §4.4 Log 歸檔邏輯 ---"
+
+STARTUP_FLOW="${REPO_ROOT}/skills/cruise/references/startup-flow.md"
+
+if [[ -f "${STARTUP_FLOW}" ]]; then
+  pass "AC1a: startup-flow.md 存在"
+
+  if grep -q "§4.4" "${STARTUP_FLOW}"; then
+    pass "AC1b: startup-flow.md 包含 §4.4 標記"
+  else
+    fail "AC1b: startup-flow.md 缺少 §4.4 標記" \
+      "startup-flow.md 中未找到 '§4.4' 字串，請新增 §4.4 Log 歸檔邏輯段落"
+  fi
+
+  if grep -q "log-archive\|log_archive\|LOG_ARCHIVE\|cruise-log-archive\|log-archived" "${STARTUP_FLOW}"; then
+    pass "AC1c: startup-flow.md 包含歸檔邏輯關鍵字"
+  else
+    fail "AC1c: startup-flow.md 缺少歸檔邏輯關鍵字" \
+      "未找到歸檔相關關鍵字（log-archive, log-archived 等）"
+  fi
+
+  if grep -q "archive/\|ARCHIVE_DIR\|archive_dir" "${STARTUP_FLOW}"; then
+    pass "AC1d: startup-flow.md 包含歸檔目錄參照"
+  else
+    fail "AC1d: startup-flow.md 缺少歸檔目錄參照" \
+      "未找到歸檔目錄（archive/ 相關字串）"
+  fi
+else
+  fail "AC1a: startup-flow.md 不存在" \
+    "找不到 ${STARTUP_FLOW}"
+fi
+
+echo ""
+
+# ─── AC2：7 天閾值與目錄結構 ────────────────────────────────────────────
+echo "--- AC2: 7 天閾值與 YYYY-MM 目錄結構 ---"
+
+if grep -q "7\|ARCHIVE_DAYS\|archive_days" "${STARTUP_FLOW}" 2>/dev/null; then
+  pass "AC2a: startup-flow.md 包含 7 天閾值設定"
+else
+  fail "AC2a: startup-flow.md 缺少 7 天閾值設定" \
+    "未找到 7 天或 ARCHIVE_DAYS 相關設定"
+fi
+
+if grep -q "YYYY-MM\|%Y-%m\|archive.*YYYY\|archive.*%Y" "${STARTUP_FLOW}" 2>/dev/null; then
+  pass "AC2b: startup-flow.md 包含 YYYY-MM 月份目錄格式"
+else
+  fail "AC2b: startup-flow.md 缺少 YYYY-MM 目錄格式" \
+    "未找到 YYYY-MM 或 %Y-%m 格式字串"
+fi
+
+echo ""
+
+# ─── AC3：git rm --cached 邏輯 ──────────────────────────────────────────
+echo "--- AC3: git rm --cached 邏輯 ---"
+
+if grep -q "git rm --cached\|git_rm_cached\|GIT_RM" "${STARTUP_FLOW}" 2>/dev/null; then
+  pass "AC3: startup-flow.md 包含 git rm --cached 邏輯"
+else
+  fail "AC3: startup-flow.md 缺少 git rm --cached 邏輯" \
+    "歸檔後需從 git 追蹤移除原始 JSONL"
+fi
+
+echo ""
+
+# ─── AC4：log-archived type 寫入 ────────────────────────────────────────
+echo "--- AC4: log-archived cruise log 寫入 ---"
+
+if grep -q "log-archived\|\"log-archived\"\|type.*log.archived" "${STARTUP_FLOW}" 2>/dev/null; then
+  pass "AC4: startup-flow.md 包含 log-archived log type"
+else
+  fail "AC4: startup-flow.md 缺少 log-archived log type" \
+    "歸檔操作結果須寫入 cruise log，type: log-archived"
+fi
+
+echo ""
+
+# ─── AC5：.gitignore 配置 ───────────────────────────────────────────────
+echo "--- AC5: .gitignore 配置 ---"
+
+GITIGNORE="${REPO_ROOT}/.gitignore"
+
+if grep -q "cruise-logs/archive\|cruise.logs.*archive\|archive.*\.gz" "${GITIGNORE}" 2>/dev/null; then
+  pass "AC5a: .gitignore 包含 cruise-logs 歸檔目錄規則"
+else
+  fail "AC5a: .gitignore 缺少 cruise-logs 歸檔目錄規則" \
+    "需配置 .gitignore 使 .gz 保留、原始 JSONL 豁免"
+fi
+
+echo ""
+
+# ─── 摘要 ────────────────────────────────────────────────────────────────
+echo "=== 摘要 ==="
+echo "PASS: ${PASS_COUNT}, FAIL: ${FAIL_COUNT}"
+echo ""
+
+if [[ "${FAIL_COUNT}" -eq 0 ]]; then
+  echo "[RESULT] PASS — 全部 ${PASS_COUNT} 項測試通過"
+  exit 0
+else
+  echo "[RESULT] FAIL — ${FAIL_COUNT} 項測試失敗，${PASS_COUNT} 項通過"
+  exit 1
+fi


### PR DESCRIPTION
feat: cruise logs 壓縮歸檔機制（長期可觀測性）(#708)

新增 startup-flow.md §4.4 Log 歸檔邏輯，自動壓縮 7 天以上的 JSONL 至 archive 目錄，解決 repo 因 cruise logs 持續膨脹的問題。

## 變更摘要
- 新增 skills/cruise/references/startup-flow.md §4.4 Log 歸檔邏輯
- 跨平台日期計算（GNU date / BSD date / WSL2 相容）
- 超過 7 天 JSONL 自動壓縮至 docs/cruise-logs/archive/YYYY-MM/
- 歸檔後 git rm --cached 從 git 追蹤移除原始 JSONL
- 歸檔結果寫入 cruise log（type: log-archived, size_before, size_after）
- 更新 .gitignore：archive/ .gz 保留，原始 JSONL 豁免
- 新增 tests/test-708-cruise-log-archive.sh（9/9 PASS）

## AC 完成狀態
- [x] AC1: startup-flow.md §4.4 已新增
- [x] AC2: 7 天閾值 + YYYY-MM 目錄結構
- [x] AC3: git rm --cached 邏輯
- [x] AC4: log-archived cruise log 寫入
- [x] AC5: .gitignore 正確配置

Closes #708