### PR TITLE
feat: Backlog 補充頻率調整 — 提前預警機制 (#721)

### DIFF
--- a/.claude/shikigami.local.md
+++ b/.claude/shikigami.local.md
@@ -19,7 +19,7 @@ shikigami:
   oauth:
     warn_threshold_hours: 24          # OAuth Token 過期告警門檻（預設 24 小時）
   backlog_health:
-    threshold: 8                      # sprint-candidate 最少數量閾值，低於此值觸發補充信號（預設 8）
+    threshold: 10                     # sprint-candidate 最少數量閾值，低於此值觸發補充信號（ADR-043 決策：從 8 調整為 10，目標庫存 >= 16）
 ---
 
 # Shikigami 專案配置

--- a/skills/backlog-management/SKILL.md
+++ b/skills/backlog-management/SKILL.md
@@ -108,7 +108,40 @@ RICE（量化排序）與 MoSCoW（標籤分類）雙軌並行：RICE Score = (R
 
 ---
 
-## 8. Subagent 派遣順序
+## 8. Backlog 健康度閾值與提前預警機制（ADR-043）
+
+<!-- #721 Backlog 補充頻率調整 — Sprint 154 -->
+<!-- ADR-043 Backlog Replenishment Strategy (Accepted) -->
+
+**閾值定義**（ADR-043 決策）：
+
+| 指標 | 閾值 | 說明 |
+|------|------|------|
+| 預警閾值 | sprint-candidate < **10** | 觸發 [BACKLOG-REPLENISH-TRIGGER] 信號 |
+| 目標庫存 | sprint-candidate >= **16** | 確保 2-Sprint 提前期（每 Sprint 選約 8pts，2 Sprint = 16 候選） |
+| 觸發時機 | **當前 Sprint 執行中** | 主動觸發，不等到 Sprint Review 後（從「事後補充」改為「提前預警」） |
+
+**預警流程**：
+
+```
+每次 Sprint Review § 2.7 執行時：
+  BACKLOG_THRESHOLD = 10 (ADR-043)
+  SPRINT_CANDIDATE_COUNT = gh issue list --label sprint-candidate --state open | jq length
+
+  SPRINT_CANDIDATE_COUNT < BACKLOG_THRESHOLD
+    → [BACKLOG-REPLENISH-TRIGGER]
+    → project_level=low：自動觸發 /backlog-management 補充（在當前 Sprint 內，不等下一 Sprint）
+    → 目標：補充至 sprint-candidate >= 16（2-Sprint 提前期）
+
+  SPRINT_CANDIDATE_COUNT >= BACKLOG_THRESHOLD
+    → [BACKLOG-HEALTH-OK]
+```
+
+> 決策依據：`docs/adr/ADR-043-backlog-replenishment-strategy.md`
+
+---
+
+## 9. Subagent 派遣順序
 
 > **注意**：Product Discovery 流程已獨立為 `/discovery-phase` Skill，里程碑啟動時請使用 `/discovery-phase`。
 
@@ -117,4 +150,5 @@ RICE（量化排序）與 MoSCoW（標籤分類）雙軌並行：RICE Score = (R
 1. PO → gh issue list 查看 Backlog Issues、關閉過時 Story
 2. PO → gh issue edit 調整 RICE 分數與優先級 labels
 3. PO → gh issue edit 確認 Acceptance Criteria（更新 Issue body）
+4. PO → Backlog 健康度檢查（§8）：sprint-candidate 計數 vs 閾值 10（ADR-043）
 ```

--- a/skills/sprint-review/SKILL.md
+++ b/skills/sprint-review/SKILL.md
@@ -105,8 +105,8 @@ Read: contracts/numerical-consistency-contract.md（若本 Sprint 有數值修�
 
 1. **讀取閾值配置**
    ```bash
-   # 從 .claude/shikigami.local.md 讀取 backlog_health.threshold，預設值 8
-   BACKLOG_THRESHOLD=$(grep -A 2 "backlog_health:" .claude/shikigami.local.md | grep "threshold:" | awk '{print $2}' || echo "8")
+   # 從 .claude/shikigami.local.md 讀取 backlog_health.threshold，預設值 10（ADR-043 決策）
+   BACKLOG_THRESHOLD=$(grep -A 2 "backlog_health:" .claude/shikigami.local.md | grep "threshold:" | awk '{print $2}' || echo "10")
    ```
 
 2. **計算當前 sprint-candidate 數量**（**非阻塞，gh API 失敗時降級**）

--- a/tests/test-721-backlog-replenishment.sh
+++ b/tests/test-721-backlog-replenishment.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# tests/test-721-backlog-replenishment.sh
+# Story #721 — Backlog 補充頻率調整驗收測試
+#
+# ── 目的 ──────────────────────────────────────────────────────────────────
+#
+# 驗收標準：
+#   AC1: skills/backlog-management/SKILL.md 包含調整後的閾值邏輯（< 10）
+#   AC2: .claude/shikigami.local.md backlog_health.threshold = 10
+#   AC3: 參照 ADR-043（不是 ADR-041）記錄決策邏輯
+#
+# ── 使用方式 ─────────────────────────────────────────────────────────────
+#   bash tests/test-721-backlog-replenishment.sh
+# ─────────────────────────────────────────────────────────────────────────
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "  [PASS] $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  [FAIL] $1"; echo "    [DIAG] $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+echo "=== Backlog 補充頻率調整測試套件 (#721) ==="
+echo ""
+
+BACKLOG_SKILL="${REPO_ROOT}/skills/backlog-management/SKILL.md"
+LOCAL_CONFIG="${REPO_ROOT}/.claude/shikigami.local.md"
+SPRINT_REVIEW_SKILL="${REPO_ROOT}/skills/sprint-review/SKILL.md"
+
+# ─── AC1: SKILL.md 閾值邏輯 ──────────────────────────────────────────────
+echo "--- AC1: backlog-management/SKILL.md 閾值邏輯更新 ---"
+
+if [[ -f "${BACKLOG_SKILL}" ]]; then
+  pass "AC1a: backlog-management/SKILL.md 存在"
+else
+  fail "AC1a: backlog-management/SKILL.md 不存在" \
+    "找不到 ${BACKLOG_SKILL}"
+fi
+
+# 驗證 SKILL.md 包含 10 的閾值（proactive threshold）
+if grep -q "sprint.candidate.*10\|10.*sprint.candidate\|threshold.*10\|< 10\|閾值.*10\|10.*閾值\|目標.*16\|16.*目標\|2.Sprint\|proactive" "${BACKLOG_SKILL}" 2>/dev/null; then
+  pass "AC1b: SKILL.md 包含新閾值邏輯（10 / 2-Sprint 提前期）"
+else
+  fail "AC1b: SKILL.md 缺少新閾值邏輯" \
+    "backlog-management/SKILL.md 需要包含 threshold=10 / 目標>=16 / 提前預警機制"
+fi
+
+# 驗證 sprint-review SKILL.md 預設值已更新
+if grep -q "threshold.*10\|default.*10\|預設.*10\|10.*預設\|10.*default" "${SPRINT_REVIEW_SKILL}" 2>/dev/null; then
+  pass "AC1c: sprint-review/SKILL.md 預設閾值已更新為 10"
+else
+  fail "AC1c: sprint-review/SKILL.md 預設閾值仍為 8" \
+    "sprint-review/SKILL.md 需要將預設值 8 改為 10"
+fi
+
+echo ""
+
+# ─── AC2: .claude/shikigami.local.md 閾值設定 ──────────────────────────
+echo "--- AC2: shikigami.local.md 閾值設定 ---"
+
+if [[ -f "${LOCAL_CONFIG}" ]]; then
+  pass "AC2a: shikigami.local.md 存在"
+
+  # 讀取 backlog_health.threshold 值
+  THRESHOLD_VAL=$(grep -A 2 "backlog_health:" "${LOCAL_CONFIG}" | grep "threshold:" | awk '{print $2}' || echo "NOT_FOUND")
+  if [[ "${THRESHOLD_VAL}" == "10" ]]; then
+    pass "AC2b: backlog_health.threshold = 10（已從 8 更新）"
+  else
+    fail "AC2b: backlog_health.threshold = ${THRESHOLD_VAL}（期望 10）" \
+      ".claude/shikigami.local.md 的 backlog_health.threshold 需從 8 改為 10"
+  fi
+else
+  fail "AC2a: shikigami.local.md 不存在" \
+    "找不到 ${LOCAL_CONFIG}"
+fi
+
+echo ""
+
+# ─── AC3: ADR-043 參照 ───────────────────────────────────────────────────
+echo "--- AC3: ADR-043 參照 ---"
+
+ADR_043="${REPO_ROOT}/docs/adr/ADR-043-backlog-replenishment-strategy.md"
+if [[ -f "${ADR_043}" ]]; then
+  pass "AC3a: ADR-043 存在（#723 已建立）"
+else
+  fail "AC3a: ADR-043 不存在" \
+    "需要先完成 #723 建立 ADR-043"
+fi
+
+# 確認 SKILL.md 引用 ADR-043（而非 ADR-041）
+if grep -q "ADR-043\|ADR-043-backlog" "${BACKLOG_SKILL}" 2>/dev/null; then
+  pass "AC3b: backlog-management/SKILL.md 引用 ADR-043"
+elif grep -q "ADR-041" "${BACKLOG_SKILL}" 2>/dev/null; then
+  fail "AC3b: SKILL.md 引用了錯誤的 ADR-041" \
+    "應引用 ADR-043（ADR-041 已被 crash-recovery-design 使用）"
+else
+  fail "AC3b: SKILL.md 未引用 ADR-043" \
+    "backlog-management/SKILL.md 需要引用 ADR-043-backlog-replenishment-strategy.md"
+fi
+
+echo ""
+
+# ─── 摘要 ────────────────────────────────────────────────────────────────
+echo "=== 摘要 ==="
+echo "PASS: ${PASS_COUNT}, FAIL: ${FAIL_COUNT}"
+echo ""
+
+if [[ "${FAIL_COUNT}" -eq 0 ]]; then
+  echo "[RESULT] PASS — 全部 ${PASS_COUNT} 項測試通過"
+  exit 0
+else
+  echo "[RESULT] FAIL — ${FAIL_COUNT} 項測試失敗，${PASS_COUNT} 項通過"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- `skills/backlog-management/SKILL.md` 新增 §8 Backlog 健康度閾值與提前預警機制（ADR-043）
  - 預警閾值從 8 調整為 10（sprint-candidate < 10 → 觸發補充）
  - 目標庫存 >= 16（確保 2-Sprint 提前期）
  - 觸發時機從「Sprint Review 後補充」改為「當前 Sprint 執行中主動補充」
- `skills/sprint-review/SKILL.md` 預設 fallback 值 8 → 10
- `.claude/shikigami.local.md` backlog_health.threshold: 8 → 10
- Depends on: ADR-043 (PR #726, merged)

## Test Results

- test-721-backlog-replenishment.sh: 7/7 PASS
- Regression: #708(9/9) #720(21/21) #722(12/12) — all PASS

## Issue

Closes #721

🤖 Generated with Claude Code