### PR TITLE
feat: #734 Sprint 容量自動計算腳本（基於 3-Sprint Velocity 平均）

### DIFF
--- a/scripts/calculate-sprint-capacity.sh
+++ b/scripts/calculate-sprint-capacity.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# calculate-sprint-capacity.sh — Sprint 容量自動計算（基於 3-Sprint Velocity 平均）
+# Sprint 155 | #734
+# NFR1: 純 bash 實作，僅允許 jq（若可用）
+
+set -euo pipefail
+
+# ── 參數處理 ──────────────────────────────────────────────────────
+METRICS_DIR="docs/km/metrics-log"
+MAX_SPRINTS=3
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --metrics-dir) METRICS_DIR="$2"; shift ;;
+    --max-sprints) MAX_SPRINTS="$2"; shift ;;
+    --help)
+      echo "Usage: $0 [--metrics-dir DIR] [--max-sprints N]"
+      echo "  --metrics-dir DIR  metrics-log 目錄（預設: docs/km/metrics-log）"
+      echo "  --max-sprints N    使用最近 N 個 Sprint（預設: 3）"
+      exit 0
+      ;;
+    *) echo "[WARN] 未知參數: $1" ;;
+  esac
+  shift
+done
+
+# ── 確認目錄存在 ──────────────────────────────────────────────────
+if [ ! -d "$METRICS_DIR" ]; then
+  echo "[CAPACITY-ERROR] metrics-log 目錄不存在: $METRICS_DIR"
+  exit 1
+fi
+
+# ── 讀取最近 N 個 metrics-log 中的 Velocity ───────────────────────
+# 格式：「| Velocity | X pts |」
+VELOCITIES=()
+FILE_COUNT=0
+
+while IFS= read -r file; do
+  # 從 markdown 表格抓取 Velocity pts
+  VELOCITY=$(grep -E "\|\s*Velocity\s*\|\s*[0-9]+ pts" "$file" 2>/dev/null | \
+    grep -oE "[0-9]+ pts" | head -1 | grep -oE "[0-9]+" || echo "")
+
+  if [ -n "$VELOCITY" ]; then
+    VELOCITIES+=("$VELOCITY")
+    FILE_COUNT=$((FILE_COUNT+1))
+    [ $FILE_COUNT -ge $MAX_SPRINTS ] && break
+  fi
+done < <(ls -t "$METRICS_DIR"/*.md 2>/dev/null || true)
+
+# ── 檢查歷史數據是否足夠（AC4）────────────────────────────────────
+if [ "${#VELOCITIES[@]}" -eq 0 ]; then
+  echo "[CAPACITY-ERROR] 無法讀取任何 Velocity 數據，請確認 $METRICS_DIR 格式正確"
+  exit 1
+fi
+
+if [ "${#VELOCITIES[@]}" -lt "$MAX_SPRINTS" ]; then
+  echo "[CAPACITY-WARN] 歷史 metrics-log 不足 ${MAX_SPRINTS} 個（實際: ${#VELOCITIES[@]}），使用現有數量計算"
+fi
+
+# ── 計算平均 Velocity ──────────────────────────────────────────────
+TOTAL=0
+for v in "${VELOCITIES[@]}"; do
+  TOTAL=$((TOTAL + v))
+done
+COUNT="${#VELOCITIES[@]}"
+AVG=$((TOTAL / COUNT))
+
+# ── 計算 ±20% 容量範圍 ────────────────────────────────────────────
+# 推薦容量 = 平均 Velocity（整數）
+RECOMMENDED=$AVG
+LOW=$(( RECOMMENDED * 80 / 100 ))   # -20%
+HIGH=$(( RECOMMENDED * 120 / 100 )) # +20%
+
+# ── 輸出結果（AC2）───────────────────────────────────────────────
+echo "[CAPACITY] avg_velocity=${AVG}pts, recommended_capacity=${RECOMMENDED}pts (±20% range: ${LOW}-${HIGH}pts)"
+echo "[CAPACITY-DETAIL] 基於最近 ${COUNT} 個 Sprint（velocities: ${VELOCITIES[*]}）"

--- a/skills/sprint-planning/references/architect-prompt.md
+++ b/skills/sprint-planning/references/architect-prompt.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 容量基準計算（#734 AC3）
+
+<!-- #734 Sprint 容量自動計算腳本（基於 3-Sprint Velocity 平均）— Sprint 155 -->
+
+Sprint Planning 開始前，Architect 必須執行以下腳本取得容量基準：
+
+```bash
+# 取得基於 3-Sprint 平均 Velocity 的推薦容量
+bash scripts/calculate-sprint-capacity.sh
+# 輸出格式：[CAPACITY] avg_velocity=Npts, recommended_capacity=Mpts (±20% range: L-Hpts)
+# 若歷史數據不足 3 個 Sprint：[CAPACITY-WARN] 使用現有數量計算
+```
+
+容量決策依據：以 `recommended_capacity` 為基準，PO 可在 `±20% range` 內調整。
+
+---
+
 ## 技術評估
 
 對 PO 選取的每個 Story 進行技術可行性評估，給出 T-shirt size 估算（S/M/L），並檢查需要 ADR 的 Story 是否已有對應的 Accepted ADR。若涉及 API 互動的 Story，必須產出 API 契約（參閱 [Architect 角色決策指引 §7](../architect/SKILL.md)）。若發現 Hard Gate 問題，該 Story 退回 Backlog。詳細決策標準（估點策略、ADR 需求判斷、平行分群策略、API 契約產出）請參閱 [Architect 角色決策指引](../architect/SKILL.md)。

--- a/tests/test-sprint-capacity.sh
+++ b/tests/test-sprint-capacity.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# test-sprint-capacity.sh — #734 Sprint 容量自動計算腳本驗證
+# Sprint 155 | AC1-AC4 驗證
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT="scripts/calculate-sprint-capacity.sh"
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" EXIT
+
+log_pass() { echo "[PASS] $1"; PASS=$((PASS+1)); }
+log_fail() { echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+# ── TC-1: calculate-sprint-capacity.sh 存在 ──────────────────────
+if [ -f "$SCRIPT" ]; then
+  log_pass "TC-1: $SCRIPT 存在"
+else
+  log_fail "TC-1: $SCRIPT 不存在（AC1 要求）"
+fi
+
+# ── TC-2: 腳本可執行 ─────────────────────────────────────────────
+if [ -x "$SCRIPT" ]; then
+  log_pass "TC-2: $SCRIPT 有執行權限"
+else
+  log_fail "TC-2: $SCRIPT 沒有執行權限"
+fi
+
+# ── TC-3: 正常模式（3 個 metrics-log）─────────────────────────────
+# 建立 mock metrics-log
+mkdir -p "$TMP_DIR/metrics-log"
+cat > "$TMP_DIR/metrics-log/2026-03-21-session-sprint152.md" << 'MOCK'
+# Sprint 152 Metrics
+## Velocity
+| Metric | Value |
+| Velocity | 6 pts |
+MOCK
+
+cat > "$TMP_DIR/metrics-log/2026-03-22-session-sprint153.md" << 'MOCK'
+# Sprint 153 Metrics
+## Velocity
+| Metric | Value |
+| Velocity | 5 pts |
+MOCK
+
+cat > "$TMP_DIR/metrics-log/2026-03-23-session-sprint154.md" << 'MOCK'
+# Sprint 154 Metrics
+## Velocity
+| Metric | Value |
+| Velocity | 7 pts |
+MOCK
+
+# 執行腳本（指向 mock 目錄）
+if [ -f "$SCRIPT" ]; then
+  OUTPUT=$(bash "$SCRIPT" --metrics-dir "$TMP_DIR/metrics-log" 2>&1 || true)
+  if echo "$OUTPUT" | grep -q "\[CAPACITY\]"; then
+    log_pass "TC-3: 正常模式輸出包含 [CAPACITY] 標籤"
+    # 驗證平均 Velocity = (6+5+7)/3 = 6
+    if echo "$OUTPUT" | grep -q "avg_velocity=6"; then
+      log_pass "TC-3a: 平均 Velocity 計算正確（6pts）"
+    else
+      log_fail "TC-3a: 平均 Velocity 計算錯誤（期望 6pts），輸出：$OUTPUT"
+    fi
+    # 驗證輸出格式包含 ±20% range
+    if echo "$OUTPUT" | grep -qE "range:.*-.*"; then
+      log_pass "TC-3b: 輸出包含 ±20% range"
+    else
+      log_fail "TC-3b: 輸出缺少 ±20% range，輸出：$OUTPUT"
+    fi
+  else
+    log_fail "TC-3: 正常模式輸出缺少 [CAPACITY] 標籤，輸出：$OUTPUT"
+  fi
+else
+  log_fail "TC-3: 腳本不存在，跳過執行測試"
+fi
+
+# ── TC-4: 歷史數據不足 3 個時輸出 [CAPACITY-WARN]（AC4）──────────
+mkdir -p "$TMP_DIR/metrics-log-sparse"
+cat > "$TMP_DIR/metrics-log-sparse/2026-03-23-session-sprint154.md" << 'MOCK'
+# Sprint 154 Metrics
+## Velocity
+| Metric | Value |
+| Velocity | 7 pts |
+MOCK
+
+if [ -f "$SCRIPT" ]; then
+  OUTPUT_SPARSE=$(bash "$SCRIPT" --metrics-dir "$TMP_DIR/metrics-log-sparse" 2>&1 || true)
+  if echo "$OUTPUT_SPARSE" | grep -q "\[CAPACITY-WARN\]"; then
+    log_pass "TC-4: 歷史數據不足 3 個時輸出 [CAPACITY-WARN]（AC4）"
+  else
+    log_fail "TC-4: 歷史數據不足 3 個時未輸出 [CAPACITY-WARN]，輸出：$OUTPUT_SPARSE"
+  fi
+else
+  log_fail "TC-4: 腳本不存在，跳過"
+fi
+
+# ── TC-5: NFR1 — 純 bash 實作，不依賴外部工具（除 jq 外）──────────
+if [ -f "$SCRIPT" ]; then
+  # 檢查是否使用 python, node, ruby 等外部工具
+  FORBIDDEN_TOOLS="python python3 node nodejs ruby perl"
+  FOUND_FORBIDDEN=false
+  for tool in $FORBIDDEN_TOOLS; do
+    if grep -q "^[^#]*\b${tool}\b" "$SCRIPT" 2>/dev/null; then
+      log_fail "TC-5: NFR1 — 腳本使用了禁止的外部工具: $tool"
+      FOUND_FORBIDDEN=true
+    fi
+  done
+  if ! $FOUND_FORBIDDEN; then
+    log_pass "TC-5: NFR1 — 純 bash 實作，無禁止外部工具"
+  fi
+else
+  log_fail "TC-5: 腳本不存在，跳過"
+fi
+
+# ── TC-6: Sprint Planning architect-prompt.md 引用腳本（AC3）──────
+ARCHITECT_PROMPT="skills/sprint-planning/references/architect-prompt.md"
+if grep -q "calculate-sprint-capacity\|sprint-capacity" "$ARCHITECT_PROMPT" 2>/dev/null; then
+  log_pass "TC-6: AC3 — architect-prompt.md 引用 calculate-sprint-capacity.sh"
+else
+  log_fail "TC-6: AC3 — architect-prompt.md 未引用 calculate-sprint-capacity.sh"
+fi
+
+# ── 結果輸出 ─────────────────────────────────────────────────────
+echo ""
+echo "=== test-sprint-capacity.sh 結果 ==="
+echo "PASS: $PASS | FAIL: $FAIL"
+if [ "$FAIL" -eq 0 ]; then
+  echo "[TEST-SUITE-PASS] 全部 $PASS 項通過"
+  exit 0
+else
+  echo "[TEST-SUITE-FAIL] $FAIL 項失敗"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- 新增 `scripts/calculate-sprint-capacity.sh`（AC1+AC2）：讀取最近 3 個 metrics-log 計算平均 Velocity
- 輸出格式：[CAPACITY] avg_velocity=Npts, recommended_capacity=Mpts (±20% range)
- 歷史不足 3 Sprint 時輸出 [CAPACITY-WARN]（AC4）
- `skills/sprint-planning/references/architect-prompt.md` 新增容量基準計算引用（AC3）
- 新增 `tests/test-sprint-capacity.sh`（8 TC 全通過）

## Test Results

PASS: 8 | FAIL: 0 — [TEST-SUITE-PASS]
