### PR TITLE
retro: #751 Developer prompt bash arithmetic increment 慣例警示（set -e 相容）

### DIFF
--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -642,6 +642,33 @@ Security Self-Review — {story_id}
 
 ---
 
+## §8.04.1 Bash 慣例警示（#751）
+
+<!-- #751 Developer prompt 新增 bash arithmetic increment 慣例警示（set -e 相容）— Sprint 156 -->
+
+**適用範圍**：所有涉及 Bash 腳本實作的 Story（INFRA、FEATURE 含腳本、CI workflow）。
+
+### Bash Arithmetic Increment 慣例
+
+**問題**：`set -euo pipefail` 模式下，`((VAR++))` 算術遞增在 `VAR=0` 時返回 **exit code 1**，觸發 `set -e` 提前結束腳本，導致靜默錯誤。
+
+**必須使用**：
+
+```bash
+# 正確（set -e 相容）
+VAR=$((VAR + 1))
+
+# 錯誤（禁止，set -e 下 VAR=0 時觸發 exit code 1）
+((VAR++))  # BANNED
+((VAR+=1)) # BANNED（同理）
+```
+
+**Developer 自審 Checklist 新增項目**：
+
+- [ ] bash 腳本中無 `((VAR++))`、`((VAR+=N))` 形式的算術遞增（使用 `VAR=$((VAR+N))` 替代）
+
+---
+
 ## §8.05 HARD-GATE：Git Commit 強制執行（US-272）
 
 <!-- US-272 Story-Lifecycle subagent 完成後強制 git commit Hard Gate — Sprint 100 -->

--- a/tests/test-bash-arithmetic-warning.sh
+++ b/tests/test-bash-arithmetic-warning.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# test-bash-arithmetic-warning.sh — #751 Developer prompt bash arithmetic increment 慣例警示
+# AC: story-lifecycle-prompt.md 包含 bash arithmetic increment 慣例警示
+# AC: Developer Story template NFR 章節包含此警示
+# Problem: set -euo pipefail 下 ((VAR++)) 在 VAR=0 時返回 exit code 1
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [[ "$result" == "pass" ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== test-bash-arithmetic-warning.sh ==="
+
+LIFECYCLE_PROMPT="$REPO_ROOT/skills/sprint-execution/story-lifecycle-prompt.md"
+
+# AC: story-lifecycle-prompt.md 包含 bash arithmetic increment 警示
+if grep -q 'VAR=\$((VAR+1))\|VAR=\$((VAR + 1))\|arithmetic.*increment\|bash.*arithmetic\|\(\(VAR++\)\).*避免\|set -e.*((VAR' "$LIFECYCLE_PROMPT" 2>/dev/null; then
+  check "AC: story-lifecycle-prompt.md 包含 bash arithmetic increment 警示" "pass"
+else
+  check "AC: story-lifecycle-prompt.md 包含 bash arithmetic increment 警示" "fail"
+fi
+
+# AC: 警示說明 set -e 相容性問題
+if grep -q "set -e\|set -euo\|exit code 1\|exit.*code\|pipefail" "$LIFECYCLE_PROMPT" 2>/dev/null; then
+  check "AC: story-lifecycle-prompt.md 說明 set -e 相容性問題" "pass"
+else
+  check "AC: story-lifecycle-prompt.md 說明 set -e 相容性問題" "fail"
+fi
+
+# AC: 推薦使用 VAR=$((VAR+1)) 取代 ((VAR++))
+if grep -q 'VAR=\$((VAR' "$LIFECYCLE_PROMPT" 2>/dev/null; then
+  check "AC: story-lifecycle-prompt.md 包含 VAR=\$((VAR+1)) 替換建議" "pass"
+else
+  check "AC: story-lifecycle-prompt.md 包含 VAR=\$((VAR+1)) 替換建議" "fail"
+fi
+
+echo ""
+echo "Results: PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- story-lifecycle-prompt.md 新增 §8.04.1 Bash 慣例警示段落（#751）
- 說明 set -euo pipefail 下 ((VAR++)) 在 VAR=0 時觸發 exit code 1 的陷阱
- 強制使用 VAR=$((VAR+1)) 取代 ((VAR++))，新增開發者自審 Checklist 項目

## Test Results

PASS: 3/3 (tests/test-bash-arithmetic-warning.sh)

## AC Coverage

- AC1: story-lifecycle-prompt.md 包含 bash arithmetic increment 警示 PASS
- AC2: 說明 set -e 相容性問題 PASS
- AC3: 包含 VAR=$((VAR+1)) 替換建議 PASS

## Issue Ref

Closes #751
