### PR TITLE
feat: #775 DM-4 Write Gateway 系統化 — coordinator-only 文件禁寫規則

### DIFF
--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -46,6 +46,16 @@ Sprint 執行支援**雙軌派遣機制**：由環境變數 `SHIKIGAMI_MODEL_PRO
 
 <HARD-GATE>
 **平行 Story-Lifecycle subagent 禁止直接修改 `docs/PROJECT_BOARD.md` 和 `docs/sprints/sprint_N.md`**（競態條件防護）。所有平行 subagent 完成後，主 session 統一批次更新。`SHIKIGAMI_MAX_PARALLEL` 環境變數控制最大平行數量（**預設值 2**，未設定時視為 2，OOM 防護，#536）。派遣前必須：(1) 執行 **Worktree 唯一性檢查**：以 `git worktree list --porcelain` 確認同 Story ID 的 worktree 不存在，若已存在則輸出 `[DISPATCH-SKIP]` 跳過（#537）；(2) **自動執行 memory-aware-dispatch.sh** 取得 FINAL_MAX，超限時輸出 `[OOM-WARN]` 並等待釋放（#536 / #712）。Git Worktree 隔離（`isolation: "worktree"`）消除大部分並發衝突。
+
+<!-- #775 DM-4 Write Gateway 系統化 — Sprint 159 -->
+
+**Coordinator-only 檔案清單**（#775 AC1）：subagent 禁止直接寫入下列檔案，所有寫入須透過主 session 批次更新：
+
+| 檔案 | 說明 |
+|------|------|
+| `docs/PROJECT_BOARD.md` | Sprint 看板狀態（coordinator-only） |
+| `docs/sprints/sprint_N.md` | Sprint Backlog 與結果文件（coordinator-only） |
+| `docs/sprints/sprint-checkpoint.json` | Sprint 進度 checkpoint（coordinator-only） |
 </HARD-GATE>
 
 ### 自動記憶體感知派遣（#712 / #722）

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -755,9 +755,18 @@ bash scripts/update-adr-index.sh
 ## §8.3 共用文件更新（平行執行路徑）
 
 <!-- US-188 平行 subagent 禁止直接修改共用文件 — Sprint 72 -->
+<!-- #775 DM-4 Write Gateway 系統化 — Sprint 159 -->
 
 <HARD-GATE>
-**禁止行為**：平行執行時，本 subagent 不得直接寫入 `docs/PROJECT_BOARD.md` 或 `docs/sprints/sprint_N.md`（競態條件 → 互相覆蓋）。
+**DM-4 Write Gateway — 禁止 subagent 直接寫入以下協調者專屬（coordinator-only）文件**：
+
+| 文件 | 原因 |
+|------|------|
+| `docs/PROJECT_BOARD.md` | 多 subagent 並行覆蓋 → 競態條件 |
+| `docs/sprints/sprint_N.md` | 多 subagent 並行覆蓋 → 競態條件 |
+| `docs/sprints/sprint-checkpoint.json` | Checkpoint 狀態由主 session 統一維護 |
+
+所有對上述文件的寫入，**必須透過主 session 批次更新機制處理（DM-4，#775）**。subagent 直接呼叫 Write/Edit 工具修改上述文件屬於流程違規。
 </HARD-GATE>
 
 **平行模式**：跳過共用文件直接寫入，在 §9 摘要中包含（story_id、應更新狀態、modified_files），供主 session 所有 subagent 完成後統一批次更新（`SKILL.md` §2.2）。§8.1 Done checkbox 仍可直接執行（各 Story 操作不同區段，無衝突）。

--- a/tests/test-dm4-write-gateway.sh
+++ b/tests/test-dm4-write-gateway.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+pass() { echo "[PASS] $1"; }
+fail() { echo "[FAIL] $1 — $2"; exit 1; }
+
+echo "=== test-dm4-write-gateway.sh ==="
+
+# TC1: SKILL.md contains coordinator-only file list
+SKILL_CONTENT=$(cat "$REPO_ROOT/skills/sprint-execution/SKILL.md")
+echo "$SKILL_CONTENT" | grep -q "coordinator-only" || fail "TC1" "SKILL.md missing coordinator-only reference"
+pass "TC1: SKILL.md contains coordinator-only reference"
+
+# TC2: story-lifecycle-prompt.md contains DM-4 HARD-GATE
+LIFECYCLE_CONTENT=$(cat "$REPO_ROOT/skills/sprint-execution/story-lifecycle-prompt.md")
+echo "$LIFECYCLE_CONTENT" | grep -q "coordinator-only\|DM-4\|禁止直接修改" || \
+  fail "TC2" "story-lifecycle-prompt.md missing DM-4 hard gate"
+pass "TC2: story-lifecycle-prompt.md contains DM-4 hard gate"
+
+# TC3: Coordinator-only files are listed: PROJECT_BOARD.md, sprint_N.md, sprint-checkpoint.json
+echo "$SKILL_CONTENT" | grep -qE "PROJECT_BOARD\.md" || fail "TC3a" "Missing PROJECT_BOARD.md in coordinator-only list"
+echo "$SKILL_CONTENT" | grep -qE "sprint_N\.md|sprint_\[N\]\.md|sprint.*\.md" || fail "TC3b" "Missing sprint_N.md in coordinator-only list"
+echo "$SKILL_CONTENT" | grep -qE "sprint-checkpoint\.json|checkpoint\.json" || fail "TC3c" "Missing checkpoint.json in coordinator-only list"
+pass "TC3: All coordinator-only files listed in SKILL.md"
+
+echo "=== All DM-4 Write Gateway tests PASS ==="


### PR DESCRIPTION
## Summary
- SKILL.md §2.2 新增 coordinator-only 文件表格（PROJECT_BOARD.md / sprint_N.md / sprint-checkpoint.json）
- story-lifecycle-prompt.md §8.3 升級 HARD-GATE，納入所有三個 coordinator-only 文件，明確 DM-4 Write Gateway 規則
- 新增 tests/test-dm4-write-gateway.sh（TC1-TC3 全 PASS）

## Test plan
- [x] TC1: SKILL.md 包含 coordinator-only 參照
- [x] TC2: story-lifecycle-prompt.md 包含 DM-4 HARD-GATE
- [x] TC3: 三個 coordinator-only 文件皆列於 SKILL.md

Closes #775

Generated with Claude Code
