### PR TITLE
feat: #773 quality-gate CRITICAL 互動決策點 — 結構化風險接受/拒絕/延後機制

### DIFF
--- a/scripts/interactive-review.sh
+++ b/scripts/interactive-review.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# interactive-review.sh — #773 AC1, AC2, AC3
+# CRITICAL quality-gate interactive decision point
+# Usage:
+#   interactive-review.sh --story "#N" --finding "summary" --severity "CRITICAL" \
+#     [--decision "A|B|C"] [--rationale "text"] [--decisions-file "path"] [--sprint "N"]
+#
+# Decision options:
+#   A = Accept Risk (requires non-empty rationale)
+#   B = Reject & Fix
+#   C = Defer to Next Sprint
+#
+# project_level=low auto-selects B (Reject) without prompt
+
+set -euo pipefail
+
+STORY=""
+FINDING=""
+SEVERITY="CRITICAL"
+DECISION=""
+RATIONALE=""
+DECISIONS_FILE="docs/km/quality-gate-decisions.md"
+SPRINT=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --story)       STORY="$2";          shift 2 ;;
+    --finding)     FINDING="$2";        shift 2 ;;
+    --severity)    SEVERITY="$2";       shift 2 ;;
+    --decision)    DECISION="$2";       shift 2 ;;
+    --rationale)   RATIONALE="$2";      shift 2 ;;
+    --decisions-file) DECISIONS_FILE="$2"; shift 2 ;;
+    --sprint)      SPRINT="$2";         shift 2 ;;
+    *) echo "[ERROR] Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Validate required
+if [[ -z "$STORY" || -z "$FINDING" ]]; then
+  echo "[ERROR] --story and --finding are required" >&2
+  exit 1
+fi
+
+if [[ -z "$SPRINT" ]]; then
+  SPRINT=$(date '+%Y')
+fi
+
+# project_level=low: auto-select B (Reject)
+PROJECT_LEVEL="${SHIKIGAMI_PROJECT_LEVEL:-}"
+if [[ "$PROJECT_LEVEL" == "low" && -z "$DECISION" ]]; then
+  echo "[INTERACTIVE-REVIEW] project_level=low — auto-selecting [B] Reject (unattended risk acceptance prohibited)"
+  DECISION="B"
+  RATIONALE="Auto-rejected by project_level=low policy"
+fi
+
+# If decision not provided, output prompt and exit (for human-driven mode)
+if [[ -z "$DECISION" ]]; then
+  echo ""
+  echo "=== [CRITICAL] Quality Gate Interactive Decision Point ==="
+  echo "Story    : $STORY"
+  echo "Finding  : $FINDING"
+  echo "Severity : $SEVERITY"
+  echo ""
+  echo "Choose a decision:"
+  echo "  [A] Accept Risk + Reason"
+  echo "  [B] Reject & Fix (recommended)"
+  echo "  [C] Defer to Next Sprint"
+  echo ""
+  echo "Provide decision via --decision A|B|C and --rationale <text>"
+  exit 0
+fi
+
+# Normalize decision
+DECISION=$(echo "$DECISION" | tr '[:lower:]' '[:upper:]')
+
+# Validate decision value
+if [[ "$DECISION" != "A" && "$DECISION" != "B" && "$DECISION" != "C" ]]; then
+  echo "[ERROR] Decision must be A, B, or C. Got: $DECISION" >&2
+  exit 1
+fi
+
+# AC3: Accept requires non-empty rationale
+if [[ "$DECISION" == "A" && -z "$RATIONALE" ]]; then
+  echo "[ERROR] Decision [A] Accept Risk requires a non-empty --rationale" >&2
+  exit 1
+fi
+
+# Map decision letter to label
+case "$DECISION" in
+  A) DECISION_LABEL="Accept" ;;
+  B) DECISION_LABEL="Reject" ;;
+  C) DECISION_LABEL="Defer" ;;
+esac
+
+if [[ -z "$RATIONALE" ]]; then
+  RATIONALE="(no rationale provided)"
+fi
+
+DATE=$(date '+%Y-%m-%d')
+
+# Ensure decisions file exists (append-only, never truncated)
+if [[ ! -f "$DECISIONS_FILE" ]]; then
+  echo "[WARN] decisions file not found: $DECISIONS_FILE — creating" >&2
+  mkdir -p "$(dirname "$DECISIONS_FILE")"
+  printf '%s\n' "# Quality Gate Decisions" "" "| Date | Story | Finding | Severity | Decision | Rationale | Sprint |" "|------|-------|---------|----------|----------|-----------|--------|" > "$DECISIONS_FILE"
+fi
+
+# AC2: Append record (never overwrite)
+printf '| %s | %s | %s | %s | %s | %s | %s |\n' \
+  "$DATE" "$STORY" "$FINDING" "$SEVERITY" "$DECISION_LABEL" "$RATIONALE" "$SPRINT" \
+  >> "$DECISIONS_FILE"
+
+echo "[INTERACTIVE-REVIEW] Decision recorded: $STORY → $DECISION_LABEL ($SEVERITY)"
+echo "  Finding  : $FINDING"
+echo "  Rationale: $RATIONALE"
+echo "  Sprint   : $SPRINT"
+echo "  File     : $DECISIONS_FILE"

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -111,17 +111,51 @@ QA Engineer 在品質門禁之外，還承擔 **Decision Challenger**（Devil's 
 ## 7. 審查失敗處理
 
 <!-- US-384 Review 建議清單分層（MUST FIX vs SUGGESTION）— Sprint 119 -->
+<!-- #773 quality-gate CRITICAL 互動決策點 — Sprint 159 -->
 
 當品質門禁發現問題時，依分層處理：
 
 **MUST FIX 層（阻塞）**：
 
 1. QA subagent 產出問題清單，每個 MUST FIX 問題標注嚴重度（Critical / Important）
-2. **Critical 問題**：進入 `references/review-checklist.md §7.1` CRITICAL 互動決策點，使用者選擇 A/B/C
-3. 選擇 A（修復）：Developer subagent 接收問題清單進行修復，修復完成後重新執行品質門禁審查
-4. 選擇 B/C：強制寫入決策記錄（`references/review-checklist.md §7.2`），流程繼續
-5. 同一門禁連續失敗 3 次（選擇 A 後仍 FAIL），升級至 Architect 評估是否存在設計層面的問題
-6. 同一 Story/PR 連續選擇 B/C 超過 2 次，強制升級至 Architect 審查
+2. **Critical 問題**：執行 CRITICAL 互動決策點（§7.1），使用者選擇 A/B/C（AC1）
+3. 選擇 A（Accept Risk）：需提供非空 rationale，記錄至 `docs/km/quality-gate-decisions.md`，流程繼續（AC2/AC3）
+4. 選擇 B（Reject & Fix）：Developer subagent 接收問題清單進行修復，修復完成後重新執行品質門禁審查；記錄至 `docs/km/quality-gate-decisions.md`（AC2）
+5. 選擇 C（Defer）：強制寫入決策記錄，流程繼續（AC2）
+6. 同一門禁連續失敗 3 次（選擇 B 後仍 FAIL），升級至 Architect 評估是否存在設計層面的問題
+7. 同一 Story/PR 連續選擇 A/C 超過 2 次，強制升級至 Architect 審查
+
+### §7.1 CRITICAL 互動決策點（#773 AC1）
+
+CRITICAL 發現時，呼叫 `scripts/interactive-review.sh`：
+
+```bash
+# project_level=low：自動選 B（Reject），不中斷自動執行
+# project_level=medium/high：輸出互動提示，等待決策
+bash scripts/interactive-review.sh \
+  --story "#<story_id>" \
+  --finding "<finding_summary>" \
+  --severity "CRITICAL" \
+  --decision "<A|B|C>" \          # 使用者決策或 auto-reject
+  --rationale "<non-empty text>"  # A 選項必填
+  --decisions-file "docs/km/quality-gate-decisions.md" \
+  --sprint "<sprint_N>"
+```
+
+**輸出格式（AC1）**：
+```
+=== [CRITICAL] Quality Gate Interactive Decision Point ===
+Story    : #<N>
+Finding  : <finding summary>
+Severity : CRITICAL
+
+Choose a decision:
+  [A] Accept Risk + Reason
+  [B] Reject & Fix (recommended)
+  [C] Defer to Next Sprint
+```
+
+**project_level=low 自動行為（NFR2）**：自動選擇 [B] Reject，輸出 `[INTERACTIVE-REVIEW] project_level=low — auto-selecting [B] Reject`，不停下等待人工介入。
 
 **SUGGESTION 層（非阻塞）**：
 

--- a/tests/test-interactive-review.sh
+++ b/tests/test-interactive-review.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# test-interactive-review.sh — #773 AC4
+# Tests for quality-gate CRITICAL interactive decision point
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "[PASS] $1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+echo "=== test-interactive-review.sh ==="
+
+DECISIONS_FILE="${REPO_ROOT}/docs/km/quality-gate-decisions.md"
+IR_SCRIPT="${REPO_ROOT}/scripts/interactive-review.sh"
+
+# TC1: interactive-review.sh exists and is executable
+if [[ -x "$IR_SCRIPT" ]]; then
+  pass "TC1: interactive-review.sh exists and is executable"
+else
+  fail "TC1" "scripts/interactive-review.sh not found or not executable"
+fi
+
+# TC2: [A] Accept Risk with rationale records to decisions file
+if [[ -x "$IR_SCRIPT" ]]; then
+  TEMP_DECISIONS=$(mktemp /tmp/qg-test-XXXXXX.md)
+  cat > "$TEMP_DECISIONS" << 'HEADER'
+# Quality Gate Decisions
+
+| Date | Story | Finding | Severity | Decision | Rationale | Sprint |
+|------|-------|---------|----------|----------|-----------|--------|
+HEADER
+
+  "$IR_SCRIPT" --story "#700" --finding "SQL injection vector" --severity "CRITICAL" \
+    --decision "A" --rationale "Low exposure endpoint, no user data" \
+    --decisions-file "$TEMP_DECISIONS" --sprint "159" 2>&1
+
+  if grep -q "Accept" "$TEMP_DECISIONS" && grep -q "#700" "$TEMP_DECISIONS"; then
+    pass "TC2: [A] Accept decision recorded correctly"
+  else
+    fail "TC2" "Accept decision not recorded in decisions file"
+  fi
+  rm -f "$TEMP_DECISIONS"
+else
+  fail "TC2" "interactive-review.sh not executable, skipping"
+fi
+
+# TC3: [B] Reject decision records to decisions file
+if [[ -x "$IR_SCRIPT" ]]; then
+  TEMP_DECISIONS=$(mktemp /tmp/qg-test-XXXXXX.md)
+  cat > "$TEMP_DECISIONS" << 'HEADER'
+# Quality Gate Decisions
+
+| Date | Story | Finding | Severity | Decision | Rationale | Sprint |
+|------|-------|---------|----------|----------|-----------|--------|
+HEADER
+
+  "$IR_SCRIPT" --story "#701" --finding "XSS via template" --severity "CRITICAL" \
+    --decision "B" --rationale "Must fix" \
+    --decisions-file "$TEMP_DECISIONS" --sprint "159" 2>&1
+
+  if grep -q "Reject" "$TEMP_DECISIONS" && grep -q "#701" "$TEMP_DECISIONS"; then
+    pass "TC3: [B] Reject decision recorded correctly"
+  else
+    fail "TC3" "Reject decision not recorded in decisions file"
+  fi
+  rm -f "$TEMP_DECISIONS"
+else
+  fail "TC3" "interactive-review.sh not executable, skipping"
+fi
+
+# TC4: [A] Accept with empty rationale is rejected (non-zero exit)
+if [[ -x "$IR_SCRIPT" ]]; then
+  TEMP_DECISIONS=$(mktemp /tmp/qg-test-XXXXXX.md)
+  cat > "$TEMP_DECISIONS" << 'HEADER'
+# Quality Gate Decisions
+
+| Date | Story | Finding | Severity | Decision | Rationale | Sprint |
+|------|-------|---------|----------|----------|-----------|--------|
+HEADER
+
+  EXIT_CODE=0
+  "$IR_SCRIPT" --story "#702" --finding "Race condition" --severity "CRITICAL" \
+    --decision "A" --rationale "" \
+    --decisions-file "$TEMP_DECISIONS" --sprint "159" 2>&1 || EXIT_CODE=$?
+
+  if [[ $EXIT_CODE -ne 0 ]]; then
+    pass "TC4: [A] Accept with empty rationale is rejected (exit non-zero)"
+  else
+    fail "TC4" "Expected non-zero exit for empty rationale, got 0"
+  fi
+  rm -f "$TEMP_DECISIONS"
+else
+  fail "TC4" "interactive-review.sh not executable, skipping"
+fi
+
+# TC5: project_level=low auto-selects [B] Reject
+if [[ -x "$IR_SCRIPT" ]]; then
+  TEMP_DECISIONS=$(mktemp /tmp/qg-test-XXXXXX.md)
+  cat > "$TEMP_DECISIONS" << 'HEADER'
+# Quality Gate Decisions
+
+| Date | Story | Finding | Severity | Decision | Rationale | Sprint |
+|------|-------|---------|----------|----------|-----------|--------|
+HEADER
+
+  OUTPUT=$(SHIKIGAMI_PROJECT_LEVEL=low "$IR_SCRIPT" --story "#703" --finding "Memory leak" \
+    --severity "CRITICAL" --decisions-file "$TEMP_DECISIONS" --sprint "159" 2>&1)
+
+  if echo "$OUTPUT" | grep -qi "auto.*reject\|project_level=low.*reject\|Reject" && \
+     grep -q "Reject" "$TEMP_DECISIONS"; then
+    pass "TC5: project_level=low auto-selects [B] Reject"
+  else
+    fail "TC5" "project_level=low did not auto-reject. Output: $OUTPUT"
+  fi
+  rm -f "$TEMP_DECISIONS"
+else
+  fail "TC5" "interactive-review.sh not executable, skipping"
+fi
+
+echo ""
+if [[ $FAIL_COUNT -eq 0 ]]; then
+  echo "=== All interactive review tests PASS ==="
+  exit 0
+else
+  echo "=== ${FAIL_COUNT} test(s) FAILED, ${PASS_COUNT} PASS ==="
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- scripts/interactive-review.sh: CRITICAL 互動決策腳本（AC1）
  - 支援 [A] Accept Risk（需非空 rationale，AC3）、[B] Reject and Fix、[C] Defer to Next Sprint
  - project_level=low 自動選 [B] Reject 不中斷自動執行（NFR2）
  - append-only 記錄至 docs/km/quality-gate-decisions.md（AC2）
- skills/quality-gate/SKILL.md: 新增 §7.1 完整互動決策點流程文件
- tests/test-interactive-review.sh: TC1-TC5 全 PASS（AC4）

## Test plan
- [x] TC1: interactive-review.sh 存在且可執行
- [x] TC2: [A] Accept 正確記錄至決策文件
- [x] TC3: [B] Reject 正確記錄至決策文件
- [x] TC4: [A] Accept 空 rationale 被拒絕（exit non-zero）
- [x] TC5: project_level=low 自動選 [B] Reject

Closes #773

Generated with Claude Code
