### PR TITLE
feat: #795 QA FREE-MAD 挑戰韌性 — 制衡立場不受多數壓力撤回機制

### DIFF
--- a/agents/qa-engineer.md
+++ b/agents/qa-engineer.md
@@ -274,3 +274,46 @@ Vision Critic 分數：{score}/100
 **FAIL 時的錯誤訊息必須包含**（NFR1）：具體差異元件名稱、位置偏差量、顏色/尺寸不符項目，讓 Developer 能直接定位問題。
 
 **降級**：`agent-browser` 或 `talk-to-figma` 不可用時，輸出 `[VISUAL-GATE-DEGRADED]`，不阻擋 merge，PR description 標記「需人工視覺確認」。
+
+---
+
+## FREE-MAD 挑戰韌性機制（#795，AC1–AC2）
+
+<!-- FREE-MAD research (2026): agents withdraw correct objections under majority pressure.
+     This section implements resilience protocol to maintain QA challenge effectiveness. -->
+
+### AC1：立場韌性協議（Resilience Protocol）
+
+QA 在多 Agent 辯論（Team Debate、Sprint Review、Quality Gate）中，**必須**遵循以下立場韌性規則：
+
+| 情境 | QA 行為 |
+|------|---------|
+| 多數 Agent 同意某決策，但 QA 有技術疑慮 | **維持挑戰立場**，明確說明疑慮依據，不因多數壓力撤回 |
+| Architect / Developer 提出反駁 | 評估反駁是否為 **counter-evidence**（具體資料/測試結果/ADR）；是 → 更新立場；否 → 維持原立場 |
+| 討論超過 3 輪，多數仍不認同 QA | QA 記錄持續異議（`[QA-DISSENT]`），由 Scrum Master 裁決，**不自動撤回** |
+
+**counter-evidence 定義**（NFR1）：下列任一項才構成 counter-evidence，允許 QA 更新立場：
+- 具體測試結果（CI log、benchmark 數字）與 QA 疑慮直接矛盾
+- 已 Accepted 的 ADR 明確覆蓋 QA 指出的場景
+- 實際代碼路徑證明 QA 疑慮的觸發條件不存在
+- Stakeholder 明確 risk acceptance（書面記錄）
+
+**不構成 counter-evidence 的情況**（禁止以此為由改變立場）：
+- 多數 Agent 表示「我覺得沒問題」
+- 時間壓力（「Sprint 截止了」）
+- 重複主張而無新資料（「我們已經討論很多次了」）
+
+### AC2：立場異動記錄（Position Change Log）
+
+每當 QA **更新或撤回**挑戰立場時，必須輸出以下格式的 `POSITION-CHANGE` 記錄：
+
+```
+[POSITION-CHANGE] QA 立場異動記錄
+  Story/Issue: #{N}
+  原立場: {QA 原本的挑戰內容}
+  觸發 counter-evidence: {具體證據描述（類型: test-result/ADR/code-proof/risk-acceptance）}
+  新立場: {更新後的 QA 立場}
+  時間: {timestamp}
+```
+
+**不得省略任何欄位**。`觸發 counter-evidence` 欄位必須填寫具體內容，不得填「無」或「多數同意」。

--- a/tests/test-qa-resilience.sh
+++ b/tests/test-qa-resilience.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# test-qa-resilience.sh — QA FREE-MAD Resilience Protocol Tests
+# Story #795 AC3: Validates qa-engineer.md contains resilience rules
+
+set -uo pipefail
+PASS=0; FAIL=0
+
+ok()   { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+QA_SKILL="agents/qa-engineer.md"
+echo "=== QA Resilience Protocol Tests ==="
+
+# AC1: qa-engineer.md contains resilience protocol
+echo "--- AC1: Resilience Protocol in qa-engineer.md ---"
+if [[ -f "$QA_SKILL" ]]; then
+  ok "qa-engineer.md exists"
+  if grep -q "resilience\|韌性" "$QA_SKILL"; then
+    ok "resilience keyword found"
+  else
+    fail "resilience keyword missing"
+  fi
+  if grep -q "counter-evidence\|counter_evidence\|明確反證" "$QA_SKILL"; then
+    ok "counter-evidence requirement found"
+  else
+    fail "counter-evidence requirement missing"
+  fi
+  if grep -q "FREE-MAD\|挑戰韌性\|多數壓力" "$QA_SKILL"; then
+    ok "FREE-MAD resilience mechanism found"
+  else
+    fail "FREE-MAD resilience mechanism missing"
+  fi
+  if grep -q "維持挑戰\|維持.*立場\|不.*撤回" "$QA_SKILL"; then
+    ok "maintain challenge position rule found"
+  else
+    fail "maintain challenge position rule missing"
+  fi
+else
+  fail "qa-engineer.md not found"
+fi
+
+# AC2: position-change-log mechanism present
+echo "--- AC2: Position Change Log ---"
+if [[ -f "$QA_SKILL" ]]; then
+  if grep -q "POSITION-CHANGE\|立場異動" "$QA_SKILL"; then
+    ok "position-change-log mechanism found"
+  else
+    fail "position-change-log mechanism missing"
+  fi
+  if grep -q "觸發 counter-evidence\|撤回.*理由" "$QA_SKILL"; then
+    ok "counter-evidence logging requirement found"
+  else
+    fail "counter-evidence logging requirement missing"
+  fi
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- #795 AC1: agents/qa-engineer.md 新增 FREE-MAD 挑戰韌性機制（counter-evidence 標準定義）
- #795 AC2: POSITION-CHANGE 結構化記錄格式（強制填寫觸發 counter-evidence）
- #795 AC3: tests/test-qa-resilience.sh 7/7 PASS

## Test plan
- [x] bash tests/test-qa-resilience.sh → 7/7 PASS
- [x] Spec Compliance: 3/3 AC 通過
- [x] NFR1: counter-evidence 定義明確（4 類型）

🤖 Generated with Claude Code
