### PR TITLE
feat: #799 Review Suggestions 追蹤 — 非阻塞建議跨 Sprint 模式識別台帳

### DIFF
--- a/docs/km/review-suggestions.md
+++ b/docs/km/review-suggestions.md
@@ -1,0 +1,19 @@
+# Review Suggestions Log
+
+> **用途**：記錄 Sprint 執行中 Code Review 的 SUGGESTION tier 建議，用於跨 Sprint 模式識別。
+> **規則**：僅允許 append — 不得截斷或刪除已有記錄（NFR1）。
+> **記錄時機**：PR merge 後，story-lifecycle-prompt.md 中的可選 SUGGESTION 記錄步驟觸發（AC2）。
+>
+> 稽核指令：`bash scripts/review-suggestion-audit.sh docs/km/review-suggestions.md`
+
+## 記錄格式
+
+```
+| Date | Story | Suggestion | Type | Status | Sprint |
+|------|-------|------------|------|--------|--------|
+```
+
+## 記錄
+
+| Date | Story | Suggestion | Type | Status | Sprint |
+|------|-------|------------|------|--------|--------|

--- a/scripts/review-suggestion-audit.sh
+++ b/scripts/review-suggestion-audit.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# scripts/review-suggestion-audit.sh — Review Suggestions 模式分析
+# Story #799 (Sprint 161) | AC3
+#
+# Usage: bash scripts/review-suggestion-audit.sh [log-file]
+# Output: Top recurring suggestions ranked by frequency
+# Default log: docs/km/review-suggestions.md
+
+set -u
+
+LOG_FILE="${1:-docs/km/review-suggestions.md}"
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  echo "[SUGGESTION-AUDIT-WARN] Log file not found: $LOG_FILE"
+  exit 0
+fi
+
+echo "# Review Suggestions Audit Report"
+echo "# Generated: $(date '+%Y-%m-%dT%H:%M:%S')"
+echo "# Source: $LOG_FILE"
+echo ""
+
+# Extract suggestion text from table rows (skip header and non-data lines)
+# Format: | Date | Story | Suggestion | Type | Status | Sprint |
+SUGGESTIONS=$(grep -E '^\| [0-9]{4}-[0-9]{2}-[0-9]{2}' "$LOG_FILE" 2>/dev/null \
+  | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4}' \
+  | sort | uniq -c | sort -rn)
+
+if [[ -z "$SUGGESTIONS" ]]; then
+  echo "No suggestions recorded yet."
+  exit 0
+fi
+
+TOTAL=$(grep -cE '^\| [0-9]{4}-[0-9]{2}-[0-9]{2}' "$LOG_FILE" 2>/dev/null || echo 0)
+echo "## Summary"
+echo "Total suggestions recorded: $TOTAL"
+echo ""
+echo "## Top Recurring Suggestions"
+echo ""
+echo "| Count | Suggestion |"
+echo "|-------|------------|"
+echo "$SUGGESTIONS" | while read -r count suggestion; do
+  echo "| $count | $suggestion |"
+done
+echo ""
+
+# By Story breakdown
+echo "## By Story"
+echo ""
+grep -E '^\| [0-9]{4}-[0-9]{2}-[0-9]{2}' "$LOG_FILE" 2>/dev/null \
+  | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); print $3}' \
+  | sort | uniq -c | sort -rn \
+  | while read -r count story; do
+    echo "  Story $story: $count suggestion(s)"
+  done

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -752,6 +752,35 @@ bash scripts/update-adr-index.sh
 4. 以 Edit 工具寫回（old_string = 原始資料列全文，new_string = 替換後全文）
    - 使用完整資料列作為 old_string 確保精確定位
 
+## §8.2.5 SUGGESTION 記錄（可選，#799，NFR1：永不阻塞 merge）
+
+<!-- #799 Review Suggestions 追蹤 — Sprint 161 -->
+
+**觸發條件**：PR merge 完成後，若本 Story 的 Code Review 中有任何 SUGGESTION tier 建議（非阻塞性改善建議），**可選擇**記錄至 `docs/km/review-suggestions.md`。
+
+**規則**：
+- 此步驟為**完全可選（optional）**，跳過不影響 Story 完成狀態
+- **永不阻塞 merge**：即使記錄失敗（文件不存在、寫入錯誤），Story 仍標記完成
+- append-only：僅允許新增記錄，不可刪除或修改已有記錄
+
+**記錄格式**：
+
+```bash
+# 記錄 SUGGESTION（可選，merge 後執行）
+REVIEW_SUGGESTIONS_LOG="docs/km/review-suggestions.md"
+if [[ -f "$REVIEW_SUGGESTIONS_LOG" && -n "${SUGGESTION_TEXT:-}" ]]; then
+  printf "| %s | #%s | %s | SUGGESTION | open | Sprint %s |\n" \
+    "$(date '+%Y-%m-%d')" "${STORY_ID}" "${SUGGESTION_TEXT}" "${SPRINT_NUM}" \
+    >> "$REVIEW_SUGGESTIONS_LOG" || true  # 永不阻塞
+  echo "[SUGGESTION-RECORDED] #${STORY_ID}: ${SUGGESTION_TEXT}"
+fi
+# 若無 SUGGESTION 或記錄失敗：靜默跳過（不輸出任何 warning）
+```
+
+**稽核**：`bash scripts/review-suggestion-audit.sh docs/km/review-suggestions.md`
+
+---
+
 ## §8.3 共用文件更新（平行執行路徑）
 
 <!-- US-188 平行 subagent 禁止直接修改共用文件 — Sprint 72 -->

--- a/tests/test-review-suggestions.sh
+++ b/tests/test-review-suggestions.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# tests/test-review-suggestions.sh — Review Suggestions tracking validation
+# Tests AC1, AC2, AC3
+
+set -u
+PASS=0
+FAIL=0
+
+# AC1: docs/km/review-suggestions.md exists and is append-only log
+test_ac1_file_exists() {
+  if [[ -f "docs/km/review-suggestions.md" ]]; then
+    echo "PASS: AC1 docs/km/review-suggestions.md exists"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC1 docs/km/review-suggestions.md not found"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# AC1: append-only — header mentions append-only
+test_ac1_append_only() {
+  if grep -qi "append" docs/km/review-suggestions.md 2>/dev/null; then
+    echo "PASS: AC1 review-suggestions.md mentions append-only"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC1 review-suggestions.md does not mention append-only"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# AC2: story-lifecycle-prompt.md has SUGGESTION recording step
+test_ac2_suggestion_step() {
+  if grep -q "SUGGESTION" skills/sprint-execution/story-lifecycle-prompt.md 2>/dev/null; then
+    echo "PASS: AC2 story-lifecycle-prompt.md contains SUGGESTION recording"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC2 story-lifecycle-prompt.md missing SUGGESTION recording"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# AC2: optional (never blocks)
+test_ac2_optional() {
+  if grep -qi "optional\|never block" skills/sprint-execution/story-lifecycle-prompt.md 2>/dev/null; then
+    echo "PASS: AC2 SUGGESTION step is marked optional/non-blocking"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC2 SUGGESTION step not clearly optional"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# AC3: scripts/review-suggestion-audit.sh exists and is executable
+test_ac3_audit_script() {
+  if [[ -x "scripts/review-suggestion-audit.sh" ]]; then
+    echo "PASS: AC3 scripts/review-suggestion-audit.sh exists and is executable"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC3 scripts/review-suggestion-audit.sh missing or not executable"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# AC3: audit script produces output
+test_ac3_audit_output() {
+  local tmplog
+  tmplog=$(mktemp --suffix=.md)
+  cat >> "$tmplog" << 'LOGEOF'
+| 2026-03-25 | #776 | Use consistent exit codes | SUGGESTION | open | Sprint 161 |
+| 2026-03-25 | #776 | Use consistent exit codes | SUGGESTION | open | Sprint 161 |
+| 2026-03-25 | #799 | Add error handling | SUGGESTION | open | Sprint 161 |
+LOGEOF
+  output=$(bash scripts/review-suggestion-audit.sh "$tmplog" 2>/dev/null)
+  rm -f "$tmplog"
+  if echo "$output" | grep -q "Use consistent exit codes"; then
+    echo "PASS: AC3 audit script outputs recurring suggestions"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC3 audit script did not identify recurring suggestion"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+test_ac1_file_exists
+test_ac1_append_only
+test_ac2_suggestion_step
+test_ac2_optional
+test_ac3_audit_script
+test_ac3_audit_output
+
+echo ""
+echo "Results: PASS=$PASS FAIL=$FAIL Total=$((PASS+FAIL))"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- 新建 `docs/km/review-suggestions.md`：append-only SUGGESTION tier 建議記錄台帳
- 修改 `skills/sprint-execution/story-lifecycle-prompt.md`：§8.2.5 可選 SUGGESTION 記錄步驟（PR merge 後）
- 新建 `scripts/review-suggestion-audit.sh`：分析 top recurring suggestions
- 新建 `tests/test-review-suggestions.sh`：6 test cases AC1-AC3 全部通過

Closes #799

## AC 驗收
- AC1 PASS: review-suggestions.md 建立，append-only ✓
- AC2 PASS: story-lifecycle-prompt.md §8.2.5 optional SUGGESTION step ✓
- AC3 PASS: review-suggestion-audit.sh 輸出 top recurring ✓
- AC4 PASS: tests/test-review-suggestions.sh 6/6 PASS ✓

🤖 Generated with Claude Code
