### PR TITLE
retro: #811 shell test 腳本最佳實踐 — 禁用 set -e + 統一 counter 模式

### DIFF
--- a/skills/qa-engineer/SKILL.md
+++ b/skills/qa-engineer/SKILL.md
@@ -124,6 +124,41 @@ QA 在 AC Review 時逐一比對：
 
 ---
 
+## §1.18 Shell Test 腳本最佳實踐（#811，Sprint 161）
+
+<!-- #811 Shell test 最佳實踐 — 禁用 set -e + 統一 counter 模式 -->
+<!-- Sprint 160 Retro Action：多個 test 腳本因 bash ((PASS++)) 與 set -e 相互作用觸發意外退出 -->
+
+**QA 在 Code Review 時，必須確認所有 Shell test 腳本（`tests/*.sh`）遵循以下最佳實踐**：
+
+### 禁用 `set -e`
+
+| 規則 | 說明 |
+|------|------|
+| 禁止在 test 腳本中使用 `set -e` | `set -e` 在 counter 操作（如 `((PASS++))` 當 PASS=0 時）返回 exit code 1，導致意外中止 |
+| 允許 `set -u` | 未定義變量保護，不影響 counter 邏輯 |
+| 允許 `set -uo pipefail`（不含 `-e`）| 可用於嚴格管道錯誤偵測 |
+
+### Counter 變量遞增模式
+
+| 模式 | 狀態 | 說明 |
+|------|------|------|
+| `PASS=$((PASS+1))` | **正確** | 算術展開，始終返回 0 |
+| `FAIL=$((FAIL+1))` | **正確** | 算術展開，始終返回 0 |
+| `((PASS++))` | **禁止** | 當 PASS=0 時，`((0++))` 結果為 0（假值），set -e 環境下觸發退出 |
+| `((PASS++)) || true` | **可接受（但建議改用正確模式）** | `|| true` workaround 有效但不清晰 |
+
+### QA Code Review Checklist（Shell test 腳本）
+
+- [ ] 無 `set -e` 出現（`set -u`, `set -o pipefail` 不受影響）
+- [ ] Counter 遞增使用 `$((VAR+1))` 模式（無 `((VAR++))` 殘留）
+- [ ] 最終輸出 `PASS=N FAIL=N Total=N` 格式
+- [ ] 檔案末尾 `[[ $FAIL -eq 0 ]]` 或 `exit $FAIL` 作為 exit code
+
+**參考模板**：`templates/test-template.sh`（Sprint 161 建立）
+
+---
+
 ## §1.2 AC 驗證策略
 
 > 詳細規則：[`references/ac-verification-strategy.md`](references/ac-verification-strategy.md)

--- a/templates/test-template.sh
+++ b/templates/test-template.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# templates/test-template.sh — Shell Test 腳本範本
+# Story #811（Sprint 161）| QA Engineer §1.18 最佳實踐
+#
+# 使用說明：
+#   複製此檔案至 tests/test-<feature-name>.sh 並填入實際測試案例
+#
+# 最佳實踐重點：
+#   1. 禁止使用 set -e（會因 ((VAR++)) 在 VAR=0 時觸發意外退出）
+#   2. Counter 遞增使用 $((VAR+1)) 取代 ((VAR++))
+#   3. 使用 set -u 保護未定義變量
+#   4. 每個測試函式呼叫 pass/fail 輔助函式
+
+# shellcheck disable=SC2034  # 範本變數聲明
+
+set -u  # 啟用：未定義變量報錯
+# 禁止：set -e（會破壞 counter 邏輯）
+# 可選：set -o pipefail（管道錯誤偵測，不影響 counter）
+
+# Counter 初始化
+PASS=0
+FAIL=0
+
+# 輔助函式
+pass() {
+  echo "PASS: $1"
+  PASS=$((PASS+1))  # 正確：$((VAR+1)) 模式
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAIL=$((FAIL+1))  # 正確：$((VAR+1)) 模式
+}
+
+# ── 測試案例（填入實際測試）──
+
+test_example_pass() {
+  # 範例：測試某個腳本存在
+  if [[ -f "scripts/example.sh" ]]; then
+    pass "example.sh exists"
+  else
+    # 範本中用 pass 模擬（實際請改為 fail）
+    pass "example (template placeholder)"
+  fi
+}
+
+test_example_condition() {
+  # 範例：測試某個條件
+  local result
+  result="expected_output"  # 替換為實際指令輸出
+  if [[ "$result" == "expected_output" ]]; then
+    pass "condition is met"
+  else
+    fail "condition not met (got: $result)"
+  fi
+}
+
+# ── 執行所有測試 ──
+
+test_example_pass
+test_example_condition
+
+# ── 結果摘要 ──
+
+echo ""
+echo "Results: PASS=$PASS FAIL=$FAIL Total=$((PASS+FAIL))"
+
+# 正確的 exit code：FAIL 為 0 則成功，否則失敗
+[[ $FAIL -eq 0 ]]

--- a/tests/test-588-live-log-file-var.sh
+++ b/tests/test-588-live-log-file-var.sh
@@ -13,10 +13,10 @@ assert() {
   local result="$2"
   if [[ "$result" == "0" ]]; then
     echo "PASS: $desc"
-    ((PASS++)) || true
+    PASS=$((PASS+1))
   else
     echo "FAIL: $desc"
-    ((FAIL++)) || true
+    FAIL=$((FAIL+1))
   fi
 }
 
@@ -38,10 +38,10 @@ FIRST_REF_LINE=$(grep -n '>> "${LIVE_LOG_FILE}"' "$FILE" | head -1 | cut -d: -f1
 
 if [[ -n "$DEF_LINE" && -n "$FIRST_REF_LINE" && "$DEF_LINE" -lt "$FIRST_REF_LINE" ]]; then
   echo "PASS: AC2: 定義 (L${DEF_LINE}) 在第一個引用 (L${FIRST_REF_LINE}) 之前"
-  ((PASS++)) || true
+  PASS=$((PASS+1))
 else
   echo "FAIL: AC2: 定義 (L${DEF_LINE:-?}) 不在第一個引用 (L${FIRST_REF_LINE:-?}) 之前"
-  ((FAIL++)) || true
+  FAIL=$((FAIL+1))
 fi
 
 echo ""

--- a/tests/test-agent-skills-standard.sh
+++ b/tests/test-agent-skills-standard.sh
@@ -16,8 +16,8 @@ if [[ -n "$REPO_ROOT" ]]; then
   cd "$REPO_ROOT"
 fi
 
-pass() { echo "  PASS: $1"; ((PASS++)); }
-fail() { echo "  FAIL: $1"; ((FAIL++)); }
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
 
 GAP_DOC="docs/research/agent-skills-standard-gap-analysis.md"
 

--- a/tests/test-ci-token-rotation.sh
+++ b/tests/test-ci-token-rotation.sh
@@ -17,10 +17,10 @@ check() {
   local result="$2"
   if [[ "$result" == "PASS" ]]; then
     echo "  PASS: $desc"
-    ((PASS++)) || true
+    PASS=$((PASS+1))
   else
     echo "  FAIL: $desc"
-    ((FAIL++)) || true
+    FAIL=$((FAIL+1))
   fi
 }
 

--- a/tests/test-context-engineering.sh
+++ b/tests/test-context-engineering.sh
@@ -21,8 +21,8 @@ if [[ -n "$REPO_ROOT" ]]; then
   cd "$REPO_ROOT"
 fi
 
-pass() { echo "  PASS: $1"; ((PASS++)); }
-fail() { echo "  FAIL: $1"; ((FAIL++)); }
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
 
 MANIFEST="agents/context-manifest.yaml"
 ADR_FILE="docs/adr/ADR-037-context-engineering-jit.md"

--- a/tests/test-crash-recovery.sh
+++ b/tests/test-crash-recovery.sh
@@ -20,10 +20,10 @@ check() {
   local result="$2"
   if [[ "$result" == "PASS" ]]; then
     echo "  PASS: $desc"
-    ((PASS++)) || true
+    PASS=$((PASS+1))
   else
     echo "  FAIL: $desc"
-    ((FAIL++)) || true
+    FAIL=$((FAIL+1))
   fi
 }
 

--- a/tests/test-shell-best-practices.sh
+++ b/tests/test-shell-best-practices.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# tests/test-shell-best-practices.sh — Shell test 最佳實踐 AC validation
+
+set -u
+PASS=0
+FAIL=0
+
+# AC1: QA Engineer SKILL.md has shell test best practices section
+test_ac1_skill_has_section() {
+  if grep -q "set -e\|counter\|最佳實踐\|VAR+1\|VAR++\|shell test" \
+      skills/qa-engineer/SKILL.md 2>/dev/null; then
+    echo "PASS: AC1 qa-engineer SKILL.md contains shell test best practices"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC1 qa-engineer SKILL.md missing shell test best practices"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# AC2: templates/test-template.sh exists
+test_ac2_template_exists() {
+  if [[ -f "templates/test-template.sh" ]]; then
+    echo "PASS: AC2 templates/test-template.sh exists"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC2 templates/test-template.sh not found"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# AC2: template demonstrates correct counter pattern (no ((VAR++)))
+test_ac2_template_correct_pattern() {
+  if [[ -f "templates/test-template.sh" ]] && \
+     grep -q '\$((.*+1))' templates/test-template.sh && \
+     ! grep -v '^#' templates/test-template.sh | grep -q '(([A-Z]*++))'; then
+    echo "PASS: AC2 template uses \$((VAR+1)) pattern, no ((VAR++)) found"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC2 template has wrong counter pattern or missing"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# AC2: template does not use set -e
+test_ac2_no_set_e() {
+  if [[ -f "templates/test-template.sh" ]] && \
+     ! grep -qE '^set -e|^set -.*e' templates/test-template.sh; then
+    echo "PASS: AC2 template does not use 'set -e'"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC2 template uses 'set -e' (prohibited per best practices)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# AC3: scan tests/*.sh for ((VAR++)) residuals
+test_ac3_no_counter_plus_plus() {
+  # Find any ((VAR++)) patterns in test files (excluding the template which shows it as bad example)
+  local violating_files
+  violating_files=$(grep -rl '(([A-Z]*++))' tests/ 2>/dev/null \
+    | grep -v test-template.sh \
+    | grep -v test-shell-best-practices.sh \
+    | grep -v test-bash-arithmetic-warning.sh \
+    || true)
+  if [[ -z "$violating_files" ]]; then
+    echo "PASS: AC3 no ((VAR++)) residuals in tests/*.sh"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: AC3 found ((VAR++)) in: $violating_files"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+test_ac1_skill_has_section
+test_ac2_template_exists
+test_ac2_template_correct_pattern
+test_ac2_no_set_e
+test_ac3_no_counter_plus_plus
+
+echo ""
+echo "Results: PASS=$PASS FAIL=$FAIL Total=$((PASS+FAIL))"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- 修改 skills/qa-engineer/SKILL.md：新增 §1.18 Shell Test 最佳實踐段落（禁用 set -e + counter 模式規則）
- 新建 templates/test-template.sh：含中文說明的正確 $((VAR+1)) 範本
- 修正 5 個 tests/*.sh：統一使用 $((VAR+1)) 取代 ((VAR++))
- 新建 tests/test-shell-best-practices.sh：5 test cases 全數通過

Closes #811

🤖 Generated with Claude Code
