### PR TITLE
feat(#777): D3 Debate Protocol 結構化 — Architect vs QA 技術辯論

### DIFF
--- a/docs/km/d3-decisions.md
+++ b/docs/km/d3-decisions.md
@@ -1,0 +1,30 @@
+# D3 Debate Protocol — 決策記錄
+
+D3（Design Disagreement Debate）是 Sprint Planning 中 Architect 與 QA 意見分歧時的結構化辯論機制。
+本文件記錄所有 D3 辯論的過程與最終決策，作為架構決策的歷史參考。
+
+## 格式說明
+
+每筆記錄包含以下欄位：
+
+| 欄位 | 說明 |
+|------|------|
+| **Date** | 辯論日期（YYYY-MM-DD） |
+| **Sprint** | Sprint 編號 |
+| **Story** | Story 編號與標題 |
+| **Advocate Position** | Round 1：Architect 提出的技術方案立場 |
+| **Challenge** | Round 2：QA 提出的挑戰與疑慮 |
+| **Rebuttal** | Round 3：Architect 考量成本後的回應（Cost-aware rebuttal） |
+| **Judge Rationale** | SM 裁決理由 |
+| **Final Decision** | 最終決策結果 |
+
+## 決策記錄
+
+| Date | Sprint | Story | Advocate Position | Challenge | Rebuttal | Judge Rationale | Final Decision |
+|------|--------|-------|-------------------|-----------|----------|-----------------|----------------|
+| *(範例 Example)* | Sprint N | #000 Story Title | Architect 建議採用方案 A，理由：效能較佳、符合現有架構 | QA 質疑：方案 A 測試覆蓋難度高，邊界條件複雜，建議改用方案 B | Architect 回應：考量實作成本，同意部分採用方案 B 的測試策略，維持核心架構不變 | SM 裁決：Architect 的 Cost-aware 回應已充分考量 QA 疑慮，方案 A 為最終決定 | 採用方案 A，並採納 QA 建議的測試策略 |
+
+---
+
+> 說明：本文件由 Sprint Planning 流程自動寫入，手動修改需經 SM 確認。
+> 觸發條件：Architect 與 QA 對同一 Story 的技術方案產生分歧時觸發 D3 流程。

--- a/scripts/predict-conflicts.sh
+++ b/scripts/predict-conflicts.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# scripts/predict-conflicts.sh
+# Story #780 — 平行任務衝突預測靜態分析
+#
+# 使用方式：
+#   # 真實模式（從 GitHub 讀取 Story body）
+#   bash scripts/predict-conflicts.sh 101 102 103
+#
+#   # Mock 模式（測試用，直接傳入 body 檔案，不呼叫 gh API）
+#   bash scripts/predict-conflicts.sh \
+#     --mock-body-1 /path/body1.txt --story-id-1 101 \
+#     --mock-body-2 /path/body2.txt --story-id-2 102
+#
+# 輸出 JSON 格式：
+#   {
+#     "conflicts": [
+#       {"story_a": 101, "story_b": 102, "shared_files": ["path/to/file"]}
+#     ],
+#     "groups": {
+#       "parallel": [103],
+#       "sequential": [101, 102]
+#     }
+#   }
+#
+# NFR1: False positive（預測衝突但實際無衝突）可接受，保守策略
+# NFR2: 輸出 JSON 格式，便於 SKILL.md 組織邏輯解析
+# AC3: 預測基於 Story body 關鍵字，不依賴 git history
+
+set -uo pipefail
+
+REPO_NAME="${REPO_NAME:-kctw-dev/shikigami}"
+
+# ── 使用說明 ──────────────────────────────────────────────────────────────
+usage() {
+  cat <<USAGE
+用法：
+  bash scripts/predict-conflicts.sh <story_id1> [story_id2] ...
+    從 GitHub 讀取 Story body 進行衝突預測
+
+  bash scripts/predict-conflicts.sh \\
+    --mock-body-1 <file> --story-id-1 <id> \\
+    --mock-body-2 <file> --story-id-2 <id> \\
+    [--mock-body-3 <file> --story-id-3 <id>]
+    Mock 模式：直接傳入 body 檔案（測試用，不呼叫 GitHub API）
+
+說明：
+  predict-conflicts.sh 讀取 Story body，萃取提及的檔案路徑與模組名稱，
+  比對各 Story 間的重疊，輸出衝突預測矩陣（JSON）。
+
+  預測基於 Story body 關鍵字（file paths mentioned, module names），
+  不依賴 git history（AC3 MVP 原則）。
+
+輸出：
+  JSON 格式：
+    { "conflicts": [...], "groups": { "parallel": [...], "sequential": [...] } }
+USAGE
+}
+
+# ── 關鍵字萃取：從 Story body 提取檔案路徑與模組名稱 ─────────────────────
+extract_keywords() {
+  local body="$1"
+
+  # 萃取策略（AC3：不依賴 git history，純靜態文字分析）：
+  # 1. backtick 包裹的路徑（`path/to/file.ext`）
+  # 2. 直接提及的路徑（含 / 且含 . 的字串）
+  # 3. 引號包裹的路徑（"path/to/file" 或 'path/to/file'）
+
+  echo "${body}" | grep -oE '\`[^\`]+\`' | sed 's/`//g' | \
+    grep -E '^[a-zA-Z0-9_./-]+[./][a-zA-Z0-9_.-]+$' || true
+
+  echo "${body}" | grep -oE '"[a-zA-Z0-9_./-]+\.[a-zA-Z0-9_.-]+"' | \
+    sed 's/"//g' | grep -E '/' || true
+
+  echo "${body}" | grep -oE "[a-zA-Z0-9_.-]+/[a-zA-Z0-9_./-]+\.[a-zA-Z0-9_-]+" | \
+    grep -vE '^(http|https|ftp)' || true
+}
+
+# ── JSON 輸出工具 ──────────────────────────────────────────────────────────
+json_array_of_nums() {
+  # 輸入：空白分隔的數字
+  local nums="$1"
+  if [[ -z "${nums}" ]]; then
+    echo "[]"
+    return
+  fi
+  local out="["
+  local first=1
+  for n in ${nums}; do
+    if [[ "${first}" -eq 1 ]]; then
+      out+="${n}"
+      first=0
+    else
+      out+=", ${n}"
+    fi
+  done
+  out+="]"
+  echo "${out}"
+}
+
+json_array_of_strs() {
+  # 輸入：換行分隔的字串
+  local strs="$1"
+  if [[ -z "${strs}" ]]; then
+    echo "[]"
+    return
+  fi
+  local out="["
+  local first=1
+  while IFS= read -r s; do
+    [[ -z "${s}" ]] && continue
+    if [[ "${first}" -eq 1 ]]; then
+      out+="\"${s}\""
+      first=0
+    else
+      out+=", \"${s}\""
+    fi
+  done <<< "${strs}"
+  out+="]"
+  echo "${out}"
+}
+
+# ── 主邏輯 ────────────────────────────────────────────────────────────────
+
+# 處理 --help
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+# 偵測 Mock 模式 vs 真實模式
+MOCK_MODE=0
+declare -a STORY_IDS=()
+declare -a BODY_FILES=()
+
+if [[ "${1:-}" == --mock-body-* ]]; then
+  MOCK_MODE=1
+  # 解析 --mock-body-N <file> --story-id-N <id> 參數
+  SLOT=0
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      --mock-body-*)
+        SLOT=$(echo "${1}" | grep -oE '[0-9]+$')
+        BODY_FILES[${SLOT}]="${2}"
+        shift 2
+        ;;
+      --story-id-*)
+        SLOT_ID=$(echo "${1}" | grep -oE '[0-9]+$')
+        STORY_IDS[${SLOT_ID}]="${2}"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+else
+  # 真實模式：從 GitHub 讀取
+  for arg in "$@"; do
+    STORY_IDS+=("${arg}")
+  done
+fi
+
+# 驗證至少有一個 Story
+if [[ ${#STORY_IDS[@]} -eq 0 ]]; then
+  usage >&2
+  exit 1
+fi
+
+# 收集每個 Story 的關鍵字（檔案路徑集合）
+declare -A STORY_FILES  # story_id -> newline-separated file list
+
+MAX_SLOT=0
+for slot in "${!STORY_IDS[@]}"; do
+  [[ "${slot}" -gt "${MAX_SLOT}" ]] && MAX_SLOT="${slot}"
+done
+
+for slot in "${!STORY_IDS[@]}"; do
+  story_id="${STORY_IDS[${slot}]}"
+  body=""
+
+  if [[ "${MOCK_MODE}" -eq 1 ]]; then
+    # Mock 模式：直接讀取 body 檔案
+    body_file="${BODY_FILES[${slot}]:-}"
+    if [[ -n "${body_file}" && -f "${body_file}" ]]; then
+      body=$(cat "${body_file}")
+    fi
+  else
+    # 真實模式：從 GitHub 讀取 Story body
+    body=$(gh issue view "${story_id}" -R "${REPO_NAME}" --json body --jq '.body' 2>/dev/null || echo "")
+  fi
+
+  # 萃取關鍵字（AC3：純靜態文字分析，不依賴 git history）
+  keywords=$(extract_keywords "${body}" | sort -u)
+  STORY_FILES["${story_id}"]="${keywords}"
+done
+
+# 衝突分析：逐對比對
+CONFLICTS_JSON=""
+declare -A IN_CONFLICT  # story_id -> 1 if has conflict
+
+# 取得所有 story_id 清單
+ALL_IDS=()
+for slot in "${!STORY_IDS[@]}"; do
+  ALL_IDS+=("${STORY_IDS[${slot}]}")
+done
+
+NUM_STORIES=${#ALL_IDS[@]}
+
+for ((i = 0; i < NUM_STORIES; i++)); do
+  for ((j = i + 1; j < NUM_STORIES; j++)); do
+    id_a="${ALL_IDS[${i}]}"
+    id_b="${ALL_IDS[${j}]}"
+    files_a="${STORY_FILES[${id_a}]:-}"
+    files_b="${STORY_FILES[${id_b}]:-}"
+
+    # 計算交集
+    shared_files=""
+    if [[ -n "${files_a}" && -n "${files_b}" ]]; then
+      shared_files=$(comm -12 \
+        <(echo "${files_a}" | sort -u) \
+        <(echo "${files_b}" | sort -u) || true)
+    fi
+
+    if [[ -n "${shared_files}" ]]; then
+      IN_CONFLICT["${id_a}"]=1
+      IN_CONFLICT["${id_b}"]=1
+
+      shared_json=$(json_array_of_strs "${shared_files}")
+
+      if [[ -n "${CONFLICTS_JSON}" ]]; then
+        CONFLICTS_JSON+=", "
+      fi
+      CONFLICTS_JSON+="{\"story_a\": ${id_a}, \"story_b\": ${id_b}, \"shared_files\": ${shared_json}}"
+    fi
+  done
+done
+
+# 分組：parallel（無衝突）vs sequential（有衝突）
+PARALLEL_IDS=""
+SEQUENTIAL_IDS=""
+
+for id in "${ALL_IDS[@]}"; do
+  if [[ "${IN_CONFLICT[${id}]:-0}" -eq 1 ]]; then
+    SEQUENTIAL_IDS+=" ${id}"
+  else
+    PARALLEL_IDS+=" ${id}"
+  fi
+done
+
+PARALLEL_JSON=$(json_array_of_nums "${PARALLEL_IDS}")
+SEQUENTIAL_JSON=$(json_array_of_nums "${SEQUENTIAL_IDS}")
+
+# 輸出 JSON（NFR2）
+cat <<JSON
+{
+  "conflicts": [${CONFLICTS_JSON}],
+  "groups": {
+    "parallel": ${PARALLEL_JSON},
+    "sequential": ${SEQUENTIAL_JSON}
+  }
+}
+JSON

--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -305,10 +305,16 @@ Kill Switch 前置檢查（#783，AC2）
 Sprint Backlog 中取出 Story
   |
   v
-Parallel Conflict Prediction 靜態衝突分析（#395，AC1）
+Parallel Conflict Prediction 靜態衝突分析（#395 #780）
   # 取出所有 pending Story 後，靜態比對檔案重疊，分為 Group A（可平行）和 Group B（序列）
   # 輸出 [CONFLICT-PREDICTION] dispatch plan：Group A（平行）| Group B（序列）
   # 詳細分組規則與重評估邏輯：references/conflict-prediction.md
+  #
+  # [#780] Run predict-conflicts.sh before dispatching; use output to pre-arrange batches:
+  #   CONFLICT_JSON=$(bash scripts/predict-conflicts.sh ${story_id_list})
+  #   parallel_stories=$(echo "$CONFLICT_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(' '.join(str(x) for x in d['groups']['parallel']))")
+  #   sequential_stories=$(echo "$CONFLICT_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(' '.join(str(x) for x in d['groups']['sequential']))")
+  #   # 先派遣 parallel_stories（可平行），再序列執行 sequential_stories
   |
   v
 前端 Story 設計資訊 Pre-check（§2.10，story_type=FEATURE 時）

--- a/skills/sprint-planning/SKILL.md
+++ b/skills/sprint-planning/SKILL.md
@@ -143,7 +143,54 @@ project_level=low 時，Sprint Planning commit + push 完成後，必須自動 i
 
 ---
 
-## 9. SBE 範例體系（Specification by Example）
+## 9. D3 Debate Protocol — Architect vs QA 技術辯論（#777）
+
+D3（Design Disagreement Debate）是 **選擇性觸發** 的結構化辯論機制，**僅在 Architect 與 QA 對同一 Story 意見不同（disagree）產生分歧時啟動**。
+
+### 觸發條件
+
+- Architect 技術評估與 QA 驗收確認對同一 Story 的技術方案出現明確衝突
+- 非強制——若雙方無分歧，跳過 D3 直接進入 PO Round 2
+
+### 三輪結構（3-round structure）
+
+| 輪次 | 角色 | 職責 |
+|------|------|------|
+| Round 1 | **Advocate（Architect）** | 提出技術方案立場，說明設計理由與技術可行性 |
+| Round 2 | **Challenge（QA）** | 針對 Architect 方案提出挑戰：測試難度、邊界條件、AC 覆蓋風險 |
+| Round 3 | **Cost-aware rebuttal（Architect）** | 考量實作成本後回應 QA 挑戰，可接受部分讓步 |
+| 裁決 | **Judge decision（SM）** | Scrum Master 綜合三輪輸出，給出最終技術方向裁決 |
+
+> **最多 3 輪（3 rounds maximum）**，禁止無限循環。若 3 輪後仍無共識，SM 強制裁決，記錄 `[D3-UNRESOLVED]` 並升級至 Architect 複審。
+
+### 記錄規則（AC2）
+
+D3 決策必須記錄至 `docs/km/d3-decisions.md`，欄位包含：
+
+- Date、Sprint、Story
+- Round 1 Advocate Position（Architect 立場）
+- Round 2 Challenge（QA 挑戰）
+- Round 3 Rebuttal（Architect Cost-aware 回應）
+- Judge Rationale（SM 裁決理由）
+- Final Decision（最終決策）
+
+### Sprint Planning 文件整合（AC3）
+
+當 D3 被觸發時，Sprint Planning 會議紀錄（§5.1）必須包含 `## D3 Record` 段落，格式如下：
+
+```markdown
+## D3 Record
+
+**Story**: #NNN Story Title
+**觸發原因**: Architect 與 QA 分歧摘要
+**Final Decision**: 最終決策結果
+**Judge Rationale**: SM 裁決理由（簡述）
+**完整記錄**: 見 docs/km/d3-decisions.md
+```
+
+---
+
+## 10. SBE 範例體系（Specification by Example）
 
 Sprint Planning 流程中的業務規則以 SBE 範例作為 ground truth，格式標準與相關文件：
 

--- a/tests/test-780-predict-conflicts.sh
+++ b/tests/test-780-predict-conflicts.sh
@@ -101,7 +101,7 @@ if [[ -f "${PREDICT_SCRIPT}" ]]; then
   fi
 
   # 驗證輸出 JSON 格式（NFR2）
-  if grep -qE '"conflicts"\|json\|JSON\|jq' "${PREDICT_SCRIPT}" 2>/dev/null; then
+  if grep -qE '"conflicts"|json|JSON|jq' "${PREDICT_SCRIPT}" 2>/dev/null; then
     pass "AC3c: predict-conflicts.sh 輸出 JSON 格式（NFR2）"
   else
     fail "AC3c: predict-conflicts.sh 未輸出 JSON 格式" \

--- a/tests/test-780-predict-conflicts.sh
+++ b/tests/test-780-predict-conflicts.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# tests/test-780-predict-conflicts.sh
+# Story #780 — 平行任務衝突預測靜態分析驗收測試
+#
+# ── 目的 ──────────────────────────────────────────────────────────────────
+#
+# 驗收標準：
+#   AC1: scripts/predict-conflicts.sh <story-list> 存在且可執行，輸出衝突預測矩陣（JSON）
+#   AC2: sprint-execution SKILL.md Parallel Grouping 段落新增 predict-conflicts.sh 使用說明
+#   AC3: 預測基於 Story body 關鍵字（檔案路徑、模組名稱），不需要 git history
+#   AC4: 測試三個已知衝突場景，驗證正確分組
+#
+# ── 使用方式 ─────────────────────────────────────────────────────────────
+#   bash tests/test-780-predict-conflicts.sh
+# ─────────────────────────────────────────────────────────────────────────
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "  [PASS] $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  [FAIL] $1"; echo "    [DIAG] $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+PREDICT_SCRIPT="${REPO_ROOT}/scripts/predict-conflicts.sh"
+SPRINT_EXEC_SKILL="${REPO_ROOT}/skills/sprint-execution/SKILL.md"
+
+echo "=== 平行任務衝突預測靜態分析測試套件 (#780) ==="
+echo ""
+
+# ─── AC1: scripts/predict-conflicts.sh 存在且可執行 ──────────────────────
+echo "--- AC1: predict-conflicts.sh 存在、可執行、輸出 JSON ---"
+
+if [[ -f "${PREDICT_SCRIPT}" ]]; then
+  pass "AC1a: predict-conflicts.sh 存在"
+else
+  fail "AC1a: predict-conflicts.sh 不存在" \
+    "找不到 ${PREDICT_SCRIPT}"
+fi
+
+if [[ -x "${PREDICT_SCRIPT}" ]]; then
+  pass "AC1b: predict-conflicts.sh 可執行"
+else
+  fail "AC1b: predict-conflicts.sh 不可執行" \
+    "chmod +x ${PREDICT_SCRIPT}"
+fi
+
+# 驗證腳本接受 story-list 參數（--help 或 -h 不報 usage error）
+if [[ -x "${PREDICT_SCRIPT}" ]]; then
+  HELP_OUTPUT=$(bash "${PREDICT_SCRIPT}" --help 2>&1 || true)
+  if echo "${HELP_OUTPUT}" | grep -qiE "usage|story|conflict|predict|用法|說明"; then
+    pass "AC1c: predict-conflicts.sh 支援 --help 並顯示使用說明"
+  else
+    fail "AC1c: predict-conflicts.sh --help 輸出未包含使用說明" \
+      "輸出：${HELP_OUTPUT:0:200}"
+  fi
+fi
+
+echo ""
+
+# ─── AC2: sprint-execution SKILL.md 含 predict-conflicts.sh 使用說明 ─────
+echo "--- AC2: SKILL.md Parallel Grouping 段落包含 predict-conflicts.sh 說明 ---"
+
+if grep -q "predict-conflicts" "${SPRINT_EXEC_SKILL}" 2>/dev/null; then
+  pass "AC2a: SKILL.md 含 predict-conflicts.sh 引用"
+else
+  fail "AC2a: SKILL.md 未含 predict-conflicts.sh 引用" \
+    "${SPRINT_EXEC_SKILL} 需要在 Parallel Grouping 段落加入 predict-conflicts.sh"
+fi
+
+if grep -qE "predict-conflicts.*before|派遣前.*predict-conflicts|Run predict-conflicts|執行 predict-conflicts|pre-arrange" "${SPRINT_EXEC_SKILL}" 2>/dev/null; then
+  pass "AC2b: SKILL.md 說明派遣前執行 predict-conflicts.sh"
+else
+  fail "AC2b: SKILL.md 未說明派遣前執行時機" \
+    "需要加入 'Run predict-conflicts.sh before dispatching' 或等效說明"
+fi
+
+echo ""
+
+# ─── AC3: 無 git history 也能運作（關鍵字萃取邏輯）─────────────────────
+echo "--- AC3: 基於 Story body 關鍵字預測，不需 git history ---"
+
+if [[ -f "${PREDICT_SCRIPT}" ]]; then
+  # 驗證腳本不依賴 git log / git history
+  if grep -qE "git log|git blame|git show.*HEAD" "${PREDICT_SCRIPT}" 2>/dev/null; then
+    fail "AC3a: predict-conflicts.sh 使用了 git history 指令" \
+      "MVP 不應依賴 git log / git blame / git show"
+  else
+    pass "AC3a: predict-conflicts.sh 不依賴 git history（符合 MVP 原則）"
+  fi
+
+  # 驗證腳本包含關鍵字萃取邏輯（路徑模式 / backtick / 模組名）
+  if grep -qE "grep|sed|awk|extract|keyword|path|backtick|\`" "${PREDICT_SCRIPT}" 2>/dev/null; then
+    pass "AC3b: predict-conflicts.sh 包含關鍵字萃取邏輯"
+  else
+    fail "AC3b: predict-conflicts.sh 缺少關鍵字萃取邏輯" \
+      "需要從 Story body 中萃取路徑、模組名等關鍵字"
+  fi
+
+  # 驗證輸出 JSON 格式（NFR2）
+  if grep -qE '"conflicts"\|json\|JSON\|jq' "${PREDICT_SCRIPT}" 2>/dev/null; then
+    pass "AC3c: predict-conflicts.sh 輸出 JSON 格式（NFR2）"
+  else
+    fail "AC3c: predict-conflicts.sh 未輸出 JSON 格式" \
+      "需要輸出 {conflicts: [...], groups: {...}} JSON"
+  fi
+fi
+
+echo ""
+
+# ─── AC4: 三個已知衝突場景的正確分組 ───────────────────────────────────
+echo "--- AC4: 三個衝突場景本地模擬測試 ---"
+
+# 測試場景使用本地 mock story body，不依賴 GitHub API
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "${TMPDIR_TEST}"' EXIT
+
+# 場景 1：兩個 Story 都修改同一個 SKILL.md → 預測衝突
+BODY_A="${TMPDIR_TEST}/body_A.txt"
+BODY_B="${TMPDIR_TEST}/body_B.txt"
+cat > "${BODY_A}" <<'BODY'
+## Story A
+AC1: 修改 `skills/sprint-execution/SKILL.md` 的 Parallel Grouping 段落
+AC2: 更新 `docs/adr/ADR-033.md` 新增欄位
+BODY
+
+cat > "${BODY_B}" <<'BODY'
+## Story B
+AC1: 更新 `skills/sprint-execution/SKILL.md` 的衝突預測演算法
+AC2: 新增 `scripts/predict-conflicts.sh`
+BODY
+
+if [[ -x "${PREDICT_SCRIPT}" ]]; then
+  # 使用 --mock-bodies 模式（直接傳入 body 檔案，不呼叫 gh API）
+  SCENARIO1_OUTPUT=$(bash "${PREDICT_SCRIPT}" \
+    --mock-body-1 "${BODY_A}" --story-id-1 "101" \
+    --mock-body-2 "${BODY_B}" --story-id-2 "102" \
+    2>/dev/null || true)
+
+  if echo "${SCENARIO1_OUTPUT}" | grep -qE '"conflicts".*\[.*\]|"story_a".*101|"story_b".*102'; then
+    pass "AC4a: 場景 1（同 SKILL.md）— 輸出包含衝突預測結構"
+  else
+    fail "AC4a: 場景 1（同 SKILL.md）— 輸出格式不符" \
+      "輸出：${SCENARIO1_OUTPUT:0:300}"
+  fi
+
+  if echo "${SCENARIO1_OUTPUT}" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('conflicts') else 1)" 2>/dev/null; then
+    pass "AC4b: 場景 1 — 輸出為合法 JSON"
+  else
+    fail "AC4b: 場景 1 — 輸出非合法 JSON" \
+      "輸出：${SCENARIO1_OUTPUT:0:300}"
+  fi
+
+  # 場景 2：Story 修改不同目錄 → 預測無衝突（應在 parallel group）
+  BODY_C="${TMPDIR_TEST}/body_C.txt"
+  BODY_D="${TMPDIR_TEST}/body_D.txt"
+  cat > "${BODY_C}" <<'BODY'
+## Story C
+AC1: 更新 `docs/adr/ADR-040.md` 決策紀錄
+AC2: 修改 `docs/km/knowledge-base.md`
+BODY
+
+  cat > "${BODY_D}" <<'BODY'
+## Story D
+AC1: 新增 `scripts/validate-new-feature.sh`
+AC2: 更新 `tests/test-new-feature.sh`
+BODY
+
+  SCENARIO2_OUTPUT=$(bash "${PREDICT_SCRIPT}" \
+    --mock-body-1 "${BODY_C}" --story-id-1 "103" \
+    --mock-body-2 "${BODY_D}" --story-id-2 "104" \
+    2>/dev/null || true)
+
+  if echo "${SCENARIO2_OUTPUT}" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+# 無衝突時 conflicts 陣列應為空，或 groups.parallel 含兩者
+conflicts = d.get('conflicts', [])
+groups = d.get('groups', {})
+parallel = groups.get('parallel', [])
+no_conflict = len(conflicts) == 0
+sys.exit(0 if no_conflict else 1)
+" 2>/dev/null; then
+    pass "AC4c: 場景 2（不同目錄）— 正確預測無衝突（parallel group）"
+  else
+    fail "AC4c: 場景 2（不同目錄）— 未能正確預測無衝突" \
+      "輸出：${SCENARIO2_OUTPUT:0:300}"
+  fi
+
+  # 場景 3：三個 Story，其中兩個衝突，一個獨立
+  BODY_E="${TMPDIR_TEST}/body_E.txt"
+  BODY_F="${TMPDIR_TEST}/body_F.txt"
+  BODY_G="${TMPDIR_TEST}/body_G.txt"
+
+  cat > "${BODY_E}" <<'BODY'
+## Story E
+AC1: 修改 `skills/health-check/SKILL.md` 新增監控項目
+BODY
+
+  cat > "${BODY_F}" <<'BODY'
+## Story F
+AC1: 更新 `skills/health-check/SKILL.md` 健康檢查順序
+BODY
+
+  cat > "${BODY_G}" <<'BODY'
+## Story G
+AC1: 新增 `docs/tutorial/onboarding-guide.md`
+AC2: 更新 `README.md` 安裝說明
+BODY
+
+  SCENARIO3_OUTPUT=$(bash "${PREDICT_SCRIPT}" \
+    --mock-body-1 "${BODY_E}" --story-id-1 "105" \
+    --mock-body-2 "${BODY_F}" --story-id-2 "106" \
+    --mock-body-3 "${BODY_G}" --story-id-3 "107" \
+    2>/dev/null || true)
+
+  if echo "${SCENARIO3_OUTPUT}" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+conflicts = d.get('conflicts', [])
+# E(105) 和 F(106) 應衝突
+conflict_pairs = [(c.get('story_a'), c.get('story_b')) for c in conflicts]
+has_ef_conflict = (105, 106) in conflict_pairs or (106, 105) in conflict_pairs
+sys.exit(0 if has_ef_conflict else 1)
+" 2>/dev/null; then
+    pass "AC4d: 場景 3（三 Story）— 正確識別 #105/#106 衝突對"
+  else
+    fail "AC4d: 場景 3（三 Story）— 未識別出 #105/#106 衝突對" \
+      "輸出：${SCENARIO3_OUTPUT:0:300}"
+  fi
+
+  if echo "${SCENARIO3_OUTPUT}" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+groups = d.get('groups', {})
+parallel = groups.get('parallel', [])
+sequential = groups.get('sequential', [])
+# G(107) 應在 parallel group（無衝突）
+g_in_parallel = 107 in parallel
+sys.exit(0 if g_in_parallel else 1)
+" 2>/dev/null; then
+    pass "AC4e: 場景 3（三 Story）— #107 正確歸入 parallel group"
+  else
+    fail "AC4e: 場景 3（三 Story）— #107 分組不正確" \
+      "輸出：${SCENARIO3_OUTPUT:0:300}"
+  fi
+else
+  fail "AC4a: predict-conflicts.sh 不可執行，跳過場景測試" \
+    "先修正 AC1b"
+  fail "AC4b: 跳過" "腳本不可執行"
+  fail "AC4c: 跳過" "腳本不可執行"
+  fail "AC4d: 跳過" "腳本不可執行"
+  fail "AC4e: 跳過" "腳本不可執行"
+fi
+
+echo ""
+
+# ─── 摘要 ────────────────────────────────────────────────────────────────
+echo "=== 摘要 ==="
+echo "PASS: ${PASS_COUNT}, FAIL: ${FAIL_COUNT}"
+echo ""
+
+if [[ "${FAIL_COUNT}" -eq 0 ]]; then
+  echo "[RESULT] PASS — 全部 ${PASS_COUNT} 項測試通過"
+  exit 0
+else
+  echo "[RESULT] FAIL — ${FAIL_COUNT} 項測試失敗，${PASS_COUNT} 項通過"
+  exit 1
+fi

--- a/tests/test-d3-record.sh
+++ b/tests/test-d3-record.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# test-d3-record.sh — D3 Debate Protocol 格式驗證測試（Story #777）
+# AC4: 驗證 docs/km/d3-decisions.md 的格式正確性
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== test-d3-record.sh ==="
+echo ""
+
+D3_FILE="$REPO_ROOT/docs/km/d3-decisions.md"
+SPRINT_PLANNING="$REPO_ROOT/skills/sprint-planning/SKILL.md"
+
+# -------------------------------------------------------
+# AC4: docs/km/d3-decisions.md 格式驗證
+# -------------------------------------------------------
+echo "[AC4-1] d3-decisions.md 檔案存在"
+
+if [[ -f "$D3_FILE" ]]; then
+  pass "docs/km/d3-decisions.md 存在"
+else
+  fail "docs/km/d3-decisions.md 不存在"
+fi
+
+echo ""
+echo "[AC4-2] d3-decisions.md 包含必要欄位標題"
+
+REQUIRED_COLS=("Date" "Sprint" "Story" "Advocate Position" "Challenge" "Rebuttal" "Judge Rationale" "Final Decision")
+
+for col in "${REQUIRED_COLS[@]}"; do
+  if grep -q "$col" "$D3_FILE" 2>/dev/null; then
+    pass "欄位存在：$col"
+  else
+    fail "欄位缺失：$col"
+  fi
+done
+
+echo ""
+echo "[AC4-3] d3-decisions.md 包含 Markdown 表格格式"
+
+if grep -q "^|" "$D3_FILE" 2>/dev/null; then
+  pass "包含 Markdown 表格（以 | 開頭的行）"
+else
+  fail "缺少 Markdown 表格格式"
+fi
+
+if grep -q "^|[-| ]*|" "$D3_FILE" 2>/dev/null; then
+  pass "包含表格分隔行（---）"
+else
+  fail "缺少表格分隔行"
+fi
+
+echo ""
+echo "[AC4-4] d3-decisions.md 包含範例條目"
+
+if grep -q "範例\|Example\|example" "$D3_FILE" 2>/dev/null; then
+  pass "包含範例條目說明"
+else
+  fail "缺少範例條目說明"
+fi
+
+echo ""
+# -------------------------------------------------------
+# AC1: sprint-planning SKILL.md 定義 D3 三輪結構
+# -------------------------------------------------------
+echo "[AC1-1] sprint-planning SKILL.md 包含 D3 Debate Protocol 段落"
+
+if grep -q "D3 Debate Protocol\|D3 Protocol" "$SPRINT_PLANNING" 2>/dev/null; then
+  pass "SKILL.md 包含 D3 Debate Protocol 段落"
+else
+  fail "SKILL.md 缺少 D3 Debate Protocol 段落"
+fi
+
+echo ""
+echo "[AC1-2] 定義三輪結構：Advocate（Architect）"
+
+if grep -q "Advocate.*Architect\|Architect.*Advocate" "$SPRINT_PLANNING" 2>/dev/null; then
+  pass "定義 Advocate（Architect）角色"
+else
+  fail "缺少 Advocate（Architect）角色定義"
+fi
+
+echo ""
+echo "[AC1-3] 定義三輪結構：Challenge（QA）"
+
+if grep -q "Challenge.*QA\|QA.*Challenge" "$SPRINT_PLANNING" 2>/dev/null; then
+  pass "定義 Challenge（QA）角色"
+else
+  fail "缺少 Challenge（QA）角色定義"
+fi
+
+echo ""
+echo "[AC1-4] 定義三輪結構：Cost-aware rebuttal（Architect）"
+
+if grep -q "Cost-aware\|cost-aware\|成本意識\|Rebuttal.*Architect\|Architect.*Rebuttal" "$SPRINT_PLANNING" 2>/dev/null; then
+  pass "定義 Cost-aware rebuttal（Architect）"
+else
+  fail "缺少 Cost-aware rebuttal 定義"
+fi
+
+echo ""
+echo "[AC1-5] 定義三輪結構：Judge decision（SM）"
+
+if grep -q "Judge.*SM\|SM.*Judge\|Judge decision\|裁決.*SM\|SM.*裁決" "$SPRINT_PLANNING" 2>/dev/null; then
+  pass "定義 Judge decision（SM）"
+else
+  fail "缺少 Judge decision（SM）定義"
+fi
+
+echo ""
+# -------------------------------------------------------
+# AC2: D3 記錄格式定義
+# -------------------------------------------------------
+echo "[AC2-1] SKILL.md 提及 d3-decisions.md 記錄路徑"
+
+if grep -q "d3-decisions.md\|docs/km/d3" "$SPRINT_PLANNING" 2>/dev/null; then
+  pass "SKILL.md 定義 d3-decisions.md 記錄路徑"
+else
+  fail "SKILL.md 缺少 d3-decisions.md 記錄路徑"
+fi
+
+echo ""
+# -------------------------------------------------------
+# AC3: D3 觸發時 sprint planning 文件包含 ## D3 Record
+# -------------------------------------------------------
+echo "[AC3-1] SKILL.md 定義 D3 Record 段落格式"
+
+if grep -q "## D3 Record\|D3 Record" "$SPRINT_PLANNING" 2>/dev/null; then
+  pass "SKILL.md 定義 ## D3 Record 段落"
+else
+  fail "SKILL.md 缺少 ## D3 Record 段落定義"
+fi
+
+echo ""
+# -------------------------------------------------------
+# NFR 驗證
+# -------------------------------------------------------
+echo "[NFR1] D3 是選擇性觸發（僅在 Architect 和 QA 意見不同時）"
+
+if grep -q "optional\|選擇性\|意見不同\|disagree\|不同意\|分歧" "$SPRINT_PLANNING" 2>/dev/null; then
+  pass "SKILL.md 說明 D3 為選擇性觸發"
+else
+  fail "SKILL.md 未說明 D3 的選擇性觸發條件"
+fi
+
+echo ""
+echo "[NFR2] 最多 3 輪，無無限循環"
+
+if grep -q "最多 3 輪\|maximum 3\|Maximum 3\|3 輪\|3-round\|3 rounds" "$SPRINT_PLANNING" 2>/dev/null; then
+  pass "SKILL.md 定義最多 3 輪上限"
+else
+  fail "SKILL.md 未定義 3 輪上限"
+fi
+
+echo ""
+
+# -------------------------------------------------------
+# 結果統計
+# -------------------------------------------------------
+TOTAL=$((PASS + FAIL))
+echo "=== 結果：$PASS/$TOTAL PASS ==="
+echo ""
+
+if [[ $FAIL -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED ($FAIL/$TOTAL)"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- 實作 D3 Debate Protocol：Sprint Planning 中 Architect vs QA 技術辯論的結構化機制
- 新增 `docs/km/d3-decisions.md`：D3 辯論決策記錄格式，含必要欄位與範例條目
- 更新 `skills/sprint-planning/SKILL.md` §9：定義三輪辯論結構（Advocate→Challenge→Rebuttal→Judge）
- 新增 `tests/test-d3-record.sh`：21 個測試案例，覆蓋 AC1/AC2/AC3/AC4/NFR1/NFR2

## Test Plan

- [x] `bash tests/test-d3-record.sh` — 21/21 PASS
- [x] `bash scripts/validate-skills.sh` — 31 個 Skill 全部通過
- [x] 所有 AC 驗收：AC1（三輪結構）AC2（記錄格式）AC3（D3 Record 段落）AC4（測試驗證）
- [x] NFR1（選擇性觸發）NFR2（最多 3 輪）皆有對應定義

## 與現有 debate SKILL 的區分

- 現有 `skills/debate/SKILL.md`：通用技術辯論，QA 為 Advocate，透過 /debate 觸發
- 本 D3 Protocol：Sprint Planning 特定情境，Architect 為 Advocate，僅在意見分歧時觸發

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)
