### PR TITLE
feat(#782): Structured Trace Log JSONL 格式

### DIFF
--- a/scripts/trace-analyzer.sh
+++ b/scripts/trace-analyzer.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# trace-analyzer.sh — #782 Structured Trace Log 分析工具
+#
+# 用途（Post-hoc analysis，非 Sprint 中執行）：
+#   讀取 cruise log JSONL，篩選 [TRACE] 條目，
+#   按 Story 分組輸出 action timeline 與統計摘要。
+#
+# NFR2: 本工具為後分析（post-hoc）用途，不在 Sprint 執行期間載入，永不阻塞執行路徑。
+#
+# 使用方式：
+#   bash scripts/trace-analyzer.sh <session-id>
+#   CRUISE_LOG_DIR=<dir> bash scripts/trace-analyzer.sh <session-id>
+#
+# 環境變數：
+#   CRUISE_LOG_DIR  — cruise log 目錄（預設：docs/cruise-logs）
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# 預設 cruise log 目錄（可透過環境變數覆蓋，用於測試）
+CRUISE_LOG_DIR="${CRUISE_LOG_DIR:-${REPO_ROOT}/docs/cruise-logs}"
+
+# ── 用法說明 ─────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<USAGE
+用法：bash scripts/trace-analyzer.sh <session-id>
+
+  <session-id>    cruise log 的 session 識別碼
+
+  讀取 CRUISE_LOG_DIR（預設：docs/cruise-logs）中符合
+  *-session-<session-id>.jsonl 的檔案，篩選 [TRACE] 條目，
+  輸出每個 Story 的 action timeline 與統計摘要。
+
+環境變數：
+  CRUISE_LOG_DIR  覆蓋 cruise log 目錄路徑（用於測試）
+
+範例：
+  bash scripts/trace-analyzer.sh 20260325-153501
+  CRUISE_LOG_DIR=/tmp/test-logs bash scripts/trace-analyzer.sh test-session
+
+USAGE
+}
+
+# ── 參數檢查 ──────────────────────────────────────────────────────────────
+
+if [[ $# -eq 0 ]]; then
+  usage >&2
+  exit 1
+fi
+
+SESSION_ID="$1"
+
+# ── 找出對應的 JSONL 檔案 ─────────────────────────────────────────────────
+
+JSONL_FILE=""
+
+# 精確比對：*-session-<session-id>.jsonl
+if ls "${CRUISE_LOG_DIR}"/*-session-"${SESSION_ID}".jsonl 2>/dev/null | head -1 | grep -q .; then
+  JSONL_FILE="$(ls "${CRUISE_LOG_DIR}"/*-session-"${SESSION_ID}".jsonl 2>/dev/null | head -1)"
+fi
+
+# 若找不到，嘗試模糊比對（session-id 為部分字串）
+if [[ -z "${JSONL_FILE}" ]]; then
+  JSONL_FILE="$(ls "${CRUISE_LOG_DIR}"/*"${SESSION_ID}"*.jsonl 2>/dev/null | head -1 || true)"
+fi
+
+if [[ -z "${JSONL_FILE}" ]] || [[ ! -f "${JSONL_FILE}" ]]; then
+  echo "[ERROR] 找不到 session '${SESSION_ID}' 的 cruise log JSONL 檔案" >&2
+  echo "        搜尋目錄：${CRUISE_LOG_DIR}" >&2
+  echo "        請確認 session-id 正確，或設定 CRUISE_LOG_DIR 環境變數" >&2
+  exit 1
+fi
+
+# ── 擷取 [TRACE] 條目 ─────────────────────────────────────────────────────
+
+# 從 JSONL 中篩選含 [TRACE] 的行，提取 JSON 部分
+TRACE_LINES="$(grep '^\[TRACE\]' "${JSONL_FILE}" || true)"
+
+if [[ -z "${TRACE_LINES}" ]]; then
+  echo "=== Trace Analyzer — Session: ${SESSION_ID} ==="
+  echo ""
+  echo "[INFO] 此 session 的 cruise log 無 [TRACE] 條目"
+  echo "       檔案：${JSONL_FILE}"
+  exit 0
+fi
+
+# ── 解析並分組 ────────────────────────────────────────────────────────────
+
+# 取得所有出現的 story ID（去重排序）
+# [TRACE] {"type":"...","story":782,...}  =>  抽出 "story":N 的 N
+STORY_IDS="$(echo "${TRACE_LINES}" | grep -oE '"story":[0-9]+' | grep -oE '[0-9]+' | sort -un)"
+
+# ── 輸出 ─────────────────────────────────────────────────────────────────
+
+echo "=== Trace Analyzer — Session: ${SESSION_ID} ==="
+echo "    來源檔案：$(basename "${JSONL_FILE}")"
+echo ""
+
+for STORY_NUM in ${STORY_IDS}; do
+  # 篩選本 Story 的所有 TRACE 條目
+  STORY_TRACES="$(echo "${TRACE_LINES}" | grep "\"story\":${STORY_NUM}[^0-9]")"
+
+  # 統計各動作類型數量（grep -c 回傳 0 時 exit code 為 1，用 || true 避免 pipefail）
+  TOTAL=$(echo "${STORY_TRACES}" | wc -l | tr -d ' ')
+  FILE_WRITE=$(echo "${STORY_TRACES}" | grep -c '"action":"file-write"' || true)
+  FILE_READ=$(echo "${STORY_TRACES}" | grep -c '"action":"file-read"' || true)
+  TEST_RUN=$(echo "${STORY_TRACES}" | grep -c '"action":"test-run"' || true)
+  REVIEW_START=$(echo "${STORY_TRACES}" | grep -c '"action":"review-start"' || true)
+  REVIEW_COMPLETE=$(echo "${STORY_TRACES}" | grep -c '"action":"review-complete"' || true)
+  DECISION=$(echo "${STORY_TRACES}" | grep -c '"action":"decision"' || true)
+  ERROR_COUNT=$(echo "${STORY_TRACES}" | grep -c '"action":"error"' || true)
+
+  echo "┌─ Story ${STORY_NUM} ─────────────────────────────────────────"
+  echo "│  total actions：${TOTAL}"
+  echo "│  file-write：${FILE_WRITE}   file-read：${FILE_READ}"
+  echo "│  test-run：${TEST_RUN}   review-start：${REVIEW_START}   review-complete：${REVIEW_COMPLETE}"
+  echo "│  decision：${DECISION}   error：${ERROR_COUNT}"
+  echo "│"
+  echo "│  Action Timeline："
+
+  # 輸出每筆 TRACE 條目（timestamp + actor + action + target）
+  while IFS= read -r LINE; do
+    JSON_PART="${LINE#\[TRACE\] }"
+
+    # 擷取各欄位（使用 grep，不依賴 jq）
+    TS="$(echo "${JSON_PART}" | grep -oE '"timestamp":"[^"]*"' | head -1 | sed 's/"timestamp":"//;s/"//')"
+    ACTOR="$(echo "${JSON_PART}" | grep -oE '"actor":"[^"]*"' | head -1 | sed 's/"actor":"//;s/"//')"
+    ACTION="$(echo "${JSON_PART}" | grep -oE '"action":"[^"]*"' | head -1 | sed 's/"action":"//;s/"//')"
+    TARGET="$(echo "${JSON_PART}" | grep -oE '"target":"[^"]*"' | head -1 | sed 's/"target":"//;s/"//')"
+
+    printf "│    [%s] %s (%s) => %s\n" \
+      "${TS:-unknown}" \
+      "${ACTION:-unknown}" \
+      "${ACTOR:-unknown}" \
+      "${TARGET:-unknown}"
+  done <<< "${STORY_TRACES}"
+
+  echo "└──────────────────────────────────────────────────────────"
+  echo ""
+done
+
+echo "=== 分析完成 ==="

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -292,6 +292,57 @@ mkdir -p logs/live
 
 ---
 
+### §8.0 [TRACE] stdout 格式（#782 Sprint 162 — Cruise Log 追蹤）
+
+<!-- #782 Structured Trace Log — JSONL TRACE 格式 -->
+
+在每個重要 action 執行時，輸出 `[TRACE]` 行至 stdout。Cruise log 基礎設施會自動捕獲此 stdout 輸出，不需另建 log 檔案（NFR1：不引入新 log 基礎設施）。
+
+**格式定義**：
+
+```
+[TRACE] {"type":"action-type","story":<N>,"actor":"<role>","action":"<verb>","target":"<path>","timestamp":"<ISO8601>"}
+```
+
+**欄位說明**：
+
+| 欄位 | 說明 | 範例 |
+|------|------|------|
+| `type` | 固定值 `"action-type"` | `"action-type"` |
+| `story` | Story 編號（整數）| `782` |
+| `actor` | 執行動作的角色 | `"developer"` |
+| `action` | 動作動詞 | 見下方 Action 類型清單 |
+| `target` | 目標路徑或識別碼 | `"scripts/trace-analyzer.sh"` |
+| `timestamp` | ISO 8601 帶時區（由 `date` 指令取得）| `"2026-03-25T10:00:00+0800"` |
+
+**Action 類型清單**（`action` 欄位允許值）：
+
+| action | 說明 |
+|--------|------|
+| `file-write` | 寫入或建立檔案 |
+| `file-read` | 讀取檔案 |
+| `test-run` | 執行測試 |
+| `review-start` | 開始自審（Spec / Code Quality / Security）|
+| `review-complete` | 完成自審 |
+| `decision` | 重要技術決策 |
+| `error` | 遇到錯誤或異常 |
+
+**使用範例**：
+
+```bash
+# 寫入檔案時
+echo "[TRACE] {\"type\":\"action-type\",\"story\":${STORY_NUM},\"actor\":\"developer\",\"action\":\"file-write\",\"target\":\"${FILE_PATH}\",\"timestamp\":\"$(date '+%Y-%m-%dT%H:%M:%S%z')\"}"
+
+# 執行測試時
+echo "[TRACE] {\"type\":\"action-type\",\"story\":${STORY_NUM},\"actor\":\"developer\",\"action\":\"test-run\",\"target\":\"${TEST_FILE}\",\"timestamp\":\"$(date '+%Y-%m-%dT%H:%M:%S%z')\"}"
+```
+
+**隱私保護**：`[TRACE]` 格式僅記錄 action metadata（actor、action 名稱、target 路徑、timestamp），不記錄使用者輸入內容或任何 PII。
+
+**與 ADR-033 trace-log 的關係**：本 `[TRACE]` stdout 格式為輕量版追蹤，藉由 cruise log 基礎設施捕獲。ADR-033 的 `docs/trace-logs/` JSONL（含 traceId/spanId/parentSpanId）為深度跨 Agent 追蹤，兩者互補不衝突。
+
+---
+
 ## §3 TDD 開發流程（強制，doc_only=false 時）
 
 <HARD-GATE>

--- a/tests/test-trace-analyzer.sh
+++ b/tests/test-trace-analyzer.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# test-trace-analyzer.sh
+# #782 驗收測試：Structured Trace Log — trace-analyzer.sh 分析工具
+# TDD Red phase — 先寫測試，再實作
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TRACE_ANALYZER="${REPO_ROOT}/scripts/trace-analyzer.sh"
+LIFECYCLE_PROMPT="${REPO_ROOT}/skills/sprint-execution/story-lifecycle-prompt.md"
+
+pass() {
+  echo "[PASS] $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== #782 Structured Trace Log — trace-analyzer 驗收測試 ==="
+echo ""
+
+# ── AC2: scripts/trace-analyzer.sh 存在且可執行 ────────────────────────────
+
+echo "--- AC2: trace-analyzer.sh 存在與執行能力 ---"
+
+if [[ -f "${TRACE_ANALYZER}" ]]; then
+  pass "AC2-1: scripts/trace-analyzer.sh 檔案存在"
+else
+  fail "AC2-1: scripts/trace-analyzer.sh 不存在"
+fi
+
+if [[ -x "${TRACE_ANALYZER}" ]]; then
+  pass "AC2-2: scripts/trace-analyzer.sh 有執行權限"
+else
+  fail "AC2-2: scripts/trace-analyzer.sh 無執行權限"
+fi
+
+# ── AC2: trace-analyzer 接受 session-id 參數 ───────────────────────────────
+
+echo ""
+echo "--- AC2: session-id 參數處理 ---"
+
+if [[ -f "${TRACE_ANALYZER}" ]]; then
+  # 無參數應顯示用法說明
+  OUTPUT="$("${TRACE_ANALYZER}" 2>&1 || true)"
+  if echo "${OUTPUT}" | grep -qi "usage\|session\|用法\|參數"; then
+    pass "AC2-3: 無參數時顯示使用說明"
+  else
+    fail "AC2-3: 無參數時未顯示使用說明（output: ${OUTPUT}）"
+  fi
+else
+  fail "AC2-3: trace-analyzer.sh 不存在，跳過"
+fi
+
+# ── AC4: 使用 seeded JSONL 測試正確輸出 ───────────────────────────────────
+
+echo ""
+echo "--- AC4: seeded JSONL 測試 ---"
+
+# 建立臨時測試環境
+TMPDIR_BASE="$(mktemp -d)"
+FAKE_CRUISE_DIR="${TMPDIR_BASE}/cruise-logs"
+mkdir -p "${FAKE_CRUISE_DIR}"
+
+SESSION_ID="test-782-session"
+
+# 建立 seeded JSONL 測試資料（模擬 cruise log 格式，含 [TRACE] 條目）
+SEED_JSONL="${FAKE_CRUISE_DIR}/2026-03-25-session-${SESSION_ID}.jsonl"
+
+cat > "${SEED_JSONL}" << 'JSONL_EOF'
+{"event":"session_start","timestamp":"2026-03-25T10:00:00+0800","sessionId":"test-782-session"}
+[TRACE] {"type":"action-type","story":782,"actor":"developer","action":"file-write","target":"scripts/trace-analyzer.sh","timestamp":"2026-03-25T10:01:00+0800"}
+{"event":"cruise_cycle","timestamp":"2026-03-25T10:01:30+0800"}
+[TRACE] {"type":"action-type","story":782,"actor":"developer","action":"file-write","target":"tests/test-trace-analyzer.sh","timestamp":"2026-03-25T10:02:00+0800"}
+[TRACE] {"type":"action-type","story":782,"actor":"developer","action":"test-run","target":"tests/test-trace-analyzer.sh","timestamp":"2026-03-25T10:03:00+0800"}
+[TRACE] {"type":"action-type","story":782,"actor":"developer","action":"decision","target":"use-jq-for-parsing","timestamp":"2026-03-25T10:04:00+0800"}
+[TRACE] {"type":"action-type","story":782,"actor":"developer","action":"error","target":"missing-dependency","timestamp":"2026-03-25T10:05:00+0800"}
+[TRACE] {"type":"action-type","story":783,"actor":"developer","action":"file-write","target":"other-file.sh","timestamp":"2026-03-25T10:06:00+0800"}
+[TRACE] {"type":"action-type","story":783,"actor":"developer","action":"file-read","target":"SKILL.md","timestamp":"2026-03-25T10:07:00+0800"}
+JSONL_EOF
+
+if [[ -f "${TRACE_ANALYZER}" ]]; then
+  # 執行 analyzer 對測試 JSONL
+  ANALYZER_OUTPUT="$(CRUISE_LOG_DIR="${FAKE_CRUISE_DIR}" "${TRACE_ANALYZER}" "${SESSION_ID}" 2>&1)"
+
+  # AC2: 應包含 Story 分組的 timeline
+  if echo "${ANALYZER_OUTPUT}" | grep -q "782\|Story 782\|story:782"; then
+    pass "AC4-1: 輸出含 Story 782 的 timeline"
+  else
+    fail "AC4-1: 輸出未含 Story 782（output: ${ANALYZER_OUTPUT}）"
+  fi
+
+  if echo "${ANALYZER_OUTPUT}" | grep -q "783\|Story 783\|story:783"; then
+    pass "AC4-2: 輸出含 Story 783 的 timeline"
+  else
+    fail "AC4-2: 輸出未含 Story 783（output: ${ANALYZER_OUTPUT}）"
+  fi
+
+  # AC3: 每個 Story 應輸出 total actions
+  if echo "${ANALYZER_OUTPUT}" | grep -qi "total\|total.*action\|action.*count\|共"; then
+    pass "AC4-3: 輸出含 total actions 統計"
+  else
+    fail "AC4-3: 輸出未含 total actions 統計（output: ${ANALYZER_OUTPUT}）"
+  fi
+
+  # AC3: 應輸出 file-write count
+  if echo "${ANALYZER_OUTPUT}" | grep -qi "file-write\|file_write\|寫入"; then
+    pass "AC4-4: 輸出含 file-write 計數"
+  else
+    fail "AC4-4: 輸出未含 file-write 計數（output: ${ANALYZER_OUTPUT}）"
+  fi
+
+  # AC3: 應輸出 decision count
+  if echo "${ANALYZER_OUTPUT}" | grep -qi "decision\|決策"; then
+    pass "AC4-5: 輸出含 decision 計數"
+  else
+    fail "AC4-5: 輸出未含 decision 計數（output: ${ANALYZER_OUTPUT}）"
+  fi
+
+  # AC3: 應輸出 error count
+  if echo "${ANALYZER_OUTPUT}" | grep -qi "error\|錯誤"; then
+    pass "AC4-6: 輸出含 error 計數"
+  else
+    fail "AC4-6: 輸出未含 error 計數（output: ${ANALYZER_OUTPUT}）"
+  fi
+
+  # AC2: Story 782 應有 5 個 TRACE 條目（file-write x2, test-run x1, decision x1, error x1）
+  STORY_782_COUNT=$(echo "${ANALYZER_OUTPUT}" | grep -c "782" || echo "0")
+  if [[ "${STORY_782_COUNT}" -ge 1 ]]; then
+    pass "AC4-7: Story 782 被識別並輸出（至少 1 行含 782）"
+  else
+    fail "AC4-7: Story 782 未被識別（count: ${STORY_782_COUNT}）"
+  fi
+
+  # AC3: 驗證 Story 782 的 file-write count = 2
+  if echo "${ANALYZER_OUTPUT}" | grep -A20 "782" | grep -qi "file.write.*2\|2.*file.write"; then
+    pass "AC4-8: Story 782 的 file-write 計數正確（= 2）"
+  else
+    # 接受 "file-write: 2" 或類似格式
+    if echo "${ANALYZER_OUTPUT}" | grep -A20 "782" | grep -qE "file.write[^0-9]*[2-9]|[2-9][^0-9]*file.write"; then
+      pass "AC4-8: Story 782 的 file-write 計數 >= 2"
+    else
+      fail "AC4-8: Story 782 的 file-write 計數不正確（output: ${ANALYZER_OUTPUT}）"
+    fi
+  fi
+
+else
+  fail "AC4-1: trace-analyzer.sh 不存在，跳過 seeded JSONL 測試"
+  fail "AC4-2: trace-analyzer.sh 不存在，跳過"
+  fail "AC4-3: trace-analyzer.sh 不存在，跳過"
+  fail "AC4-4: trace-analyzer.sh 不存在，跳過"
+  fail "AC4-5: trace-analyzer.sh 不存在，跳過"
+  fail "AC4-6: trace-analyzer.sh 不存在，跳過"
+  fail "AC4-7: trace-analyzer.sh 不存在，跳過"
+  fail "AC4-8: trace-analyzer.sh 不存在，跳過"
+fi
+
+# ── AC1: story-lifecycle-prompt.md 含 [TRACE] 格式定義 ────────────────────
+
+echo ""
+echo "--- AC1: story-lifecycle-prompt.md TRACE 格式 ---"
+
+if [[ -f "${LIFECYCLE_PROMPT}" ]]; then
+  # AC1: 應含 [TRACE] 前綴格式
+  if grep -q "\[TRACE\]" "${LIFECYCLE_PROMPT}"; then
+    pass "AC1-1: story-lifecycle-prompt.md 含 [TRACE] 格式標記"
+  else
+    fail "AC1-1: story-lifecycle-prompt.md 缺少 [TRACE] 格式標記"
+  fi
+
+  # AC1: 格式中應包含 type 欄位
+  if grep -q '"type"' "${LIFECYCLE_PROMPT}"; then
+    pass "AC1-2: [TRACE] 格式含 type 欄位"
+  else
+    fail "AC1-2: [TRACE] 格式缺少 type 欄位"
+  fi
+
+  # AC1: 格式中應包含 story 欄位（story number）
+  if grep -q '"story"' "${LIFECYCLE_PROMPT}"; then
+    pass "AC1-3: [TRACE] 格式含 story 欄位"
+  else
+    fail "AC1-3: [TRACE] 格式缺少 story 欄位"
+  fi
+
+  # AC1: 格式中應包含 actor 欄位
+  if grep -q '"actor"' "${LIFECYCLE_PROMPT}"; then
+    pass "AC1-4: [TRACE] 格式含 actor 欄位"
+  else
+    fail "AC1-4: [TRACE] 格式缺少 actor 欄位"
+  fi
+
+  # AC1: 格式中應包含 action 欄位
+  if grep -q '"action"' "${LIFECYCLE_PROMPT}"; then
+    pass "AC1-5: [TRACE] 格式含 action 欄位"
+  else
+    fail "AC1-5: [TRACE] 格式缺少 action 欄位"
+  fi
+
+  # AC1: 格式中應包含 target 欄位
+  if grep -q '"target"' "${LIFECYCLE_PROMPT}"; then
+    pass "AC1-6: [TRACE] 格式含 target 欄位"
+  else
+    fail "AC1-6: [TRACE] 格式缺少 target 欄位"
+  fi
+
+  # AC1: 格式中應包含 timestamp 欄位
+  if grep -q '"timestamp"' "${LIFECYCLE_PROMPT}"; then
+    pass "AC1-7: [TRACE] 格式含 timestamp 欄位"
+  else
+    fail "AC1-7: [TRACE] 格式缺少 timestamp 欄位"
+  fi
+
+  # AC1: 應定義主要 action 類型（file-write, file-read, test-run, review-start, decision, error 等）
+  if grep -q "file-write\|file-read\|test-run\|decision\|review-start" "${LIFECYCLE_PROMPT}"; then
+    pass "AC1-8: story-lifecycle-prompt.md 定義主要 action 類型"
+  else
+    fail "AC1-8: story-lifecycle-prompt.md 缺少主要 action 類型定義"
+  fi
+else
+  fail "AC1-1: story-lifecycle-prompt.md 不存在"
+  fail "AC1-2: story-lifecycle-prompt.md 不存在，跳過"
+  fail "AC1-3: story-lifecycle-prompt.md 不存在，跳過"
+  fail "AC1-4: story-lifecycle-prompt.md 不存在，跳過"
+  fail "AC1-5: story-lifecycle-prompt.md 不存在，跳過"
+  fail "AC1-6: story-lifecycle-prompt.md 不存在，跳過"
+  fail "AC1-7: story-lifecycle-prompt.md 不存在，跳過"
+  fail "AC1-8: story-lifecycle-prompt.md 不存在，跳過"
+fi
+
+# ── NFR1: 不引入新的 log 基礎設施 ─────────────────────────────────────────
+
+echo ""
+echo "--- NFR1: TRACE 使用現有 cruise log 基礎設施 ---"
+
+if [[ -f "${LIFECYCLE_PROMPT}" ]] && grep -q "cruise.log\|cruise-log\|stdout\|\[TRACE\]" "${LIFECYCLE_PROMPT}"; then
+  pass "NFR1-1: TRACE 格式使用 stdout（cruise log 基礎設施）"
+else
+  fail "NFR1-1: 未確認 TRACE 使用 cruise log / stdout 基礎設施"
+fi
+
+# ── NFR2: trace-analyzer 為 post-hoc 分析工具 ─────────────────────────────
+
+echo ""
+echo "--- NFR2: trace-analyzer 為 post-hoc 分析（非阻塞）---"
+
+if [[ -f "${TRACE_ANALYZER}" ]] && grep -q "post.hoc\|analysis\|分析\|offline\|non.blocking\|非阻塞" "${TRACE_ANALYZER}"; then
+  pass "NFR2-1: trace-analyzer 有 post-hoc 說明"
+else
+  # 放寬：只要 trace-analyzer 是獨立腳本（非在 Sprint 中載入）即可
+  if [[ -f "${TRACE_ANALYZER}" ]]; then
+    pass "NFR2-1: trace-analyzer 為獨立後分析工具（非 Sprint 中執行）"
+  else
+    fail "NFR2-1: trace-analyzer.sh 不存在"
+  fi
+fi
+
+# ── 清理臨時目錄 ─────────────────────────────────────────────────────────
+
+rm -rf "${TMPDIR_BASE}"
+
+# ── 最終結果 ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "============================================"
+echo "結果：PASS=${PASS}  FAIL=${FAIL}"
+echo "============================================"
+
+if [[ "${FAIL}" -eq 0 ]]; then
+  echo "[FINAL] ALL PASS"
+  exit 0
+else
+  echo "[FINAL] FAIL（${FAIL} 項未通過）"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **AC1**: 在 `skills/sprint-execution/story-lifecycle-prompt.md` 新增 §8.0 `[TRACE]` stdout 格式定義，包含完整欄位說明（type/story/actor/action/target/timestamp）及 7 種 action 類型清單
- **AC2-AC3**: 新增 `scripts/trace-analyzer.sh`，接受 session-id 參數，讀取 cruise log JSONL，篩選 `[TRACE]` 條目，按 Story 分組輸出 timeline 與統計摘要（total/file-write/file-read/decision/error）
- **AC4**: 新增 `tests/test-trace-analyzer.sh`，使用 seeded JSONL 驗證完整 timeline 輸出，21 tests PASS

## 設計說明

本 Story 的 `[TRACE]` stdout 格式（AC1）與 ADR-033 的 `docs/trace-logs/` JSONL 格式互補：

| 格式 | 用途 | 儲存 |
|------|------|------|
| `[TRACE]` stdout（#782）| 輕量版 action 追蹤，藉由 cruise log 捕獲 | cruise-logs JSONL |
| ADR-033 trace-log | 深度跨 Agent 追蹤（traceId/spanId/parentSpanId）| trace-logs JSONL |

NFR1 確保：`[TRACE]` 不引入新 log 基礎設施，使用現有 cruise log stdout 捕獲機制。

## Test plan

- [x] `bash tests/test-trace-analyzer.sh` — 21/21 PASS
- [x] `bash tests/test-392-structured-trace-log.sh` — 26/26 PASS（無回歸）
- [x] `bash scripts/validate-skills.sh` — 31 Skills 全過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
