### PR TITLE
feat(#801): A2A Protocol 結構化通訊協議

### DIFF
--- a/docs/adr/ADR-044-a2a-protocol.md
+++ b/docs/adr/ADR-044-a2a-protocol.md
@@ -1,0 +1,235 @@
+# ADR-044: A2A Protocol — Agent-to-Agent 結構化通訊協議標準化
+
+**狀態**：Accepted
+**日期**：2026-03-25
+**決策者**：Architect Agent + Developer Agent
+**觸發 Story**：#801（feat: A2A Protocol — Agent-to-Agent 結構化通訊協議標準化）
+**Unblocks**：Sprint 162 自動化解析與 CI 驗證流程
+
+---
+
+## 背景與問題
+
+Sprint 162 之前，subagent 回傳結果為純文字 Markdown 格式（§9 輸出格式），主 session 透過人工讀取摘要的方式解析結果。此方式存在以下問題：
+
+1. **解析不可靠**：純文字結構依賴正則表達式，遇格式差異即失敗
+2. **自動化困難**：CI pipeline 無法直接驗證 subagent 結果品質
+3. **欄位未標準化**：不同 agent 角色（developer/architect/qa）回傳格式不一致
+4. **缺乏機器可讀性**：跨 session compaction 後結果復原依賴文字解析，風險高
+
+---
+
+## 決策內容
+
+### 選項 A：JSON Schema 標準化（選定）
+
+定義 A2A 通訊協議 JSON Schema，所有 subagent 在回傳前輸出一個 JSON block，作為機器可讀的結構化摘要。
+
+**優點**：
+- 機器可解析，CI 可驗證
+- 欄位明確，schema 可版本化演進
+- 向後相容：既有 Markdown 摘要保留，JSON block 為附加輸出
+
+**缺點**：
+- Subagent prompt 需更新（§9 輸出格式變更）
+
+### 選項 B：YAML 格式（未選）
+
+採用 YAML 格式取代 JSON。未選擇原因：JSON 有嚴格語法、現有工具鏈（python3 json 模組）直接支援，YAML 解析邊界問題較多。
+
+---
+
+## A2A Schema 定義
+
+版本：`1.0`
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "A2A Protocol Schema",
+  "description": "Shikigami Agent-to-Agent 結構化通訊協議 v1.0",
+  "type": "object",
+  "required": ["protocol_version", "story_id", "actor", "result", "summary", "timestamp"],
+  "properties": {
+    "protocol_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "A2A 協議版本號，當前固定為 1.0"
+    },
+    "story_id": {
+      "type": "integer",
+      "description": "對應的 GitHub Issue 編號（整數）"
+    },
+    "actor": {
+      "type": "string",
+      "enum": ["developer", "architect", "qa", "po", "security", "sm"],
+      "description": "執行本 Story 的 agent 角色"
+    },
+    "result": {
+      "type": "string",
+      "enum": ["PASS", "FAIL", "ESCALATE"],
+      "description": "Story 執行結果"
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "結果說明（≤200 字）"
+    },
+    "artifacts": {
+      "type": "array",
+      "description": "產出物清單（可選）",
+      "items": {
+        "type": "object",
+        "required": ["type", "path"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["file", "pr", "adr", "test", "doc"],
+            "description": "產出物類型"
+          },
+          "path": {
+            "type": "string",
+            "description": "檔案路徑或 URL"
+          },
+          "description": {
+            "type": "string",
+            "description": "產出物說明"
+          }
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "執行指標（可選）",
+      "properties": {
+        "tests_total": {
+          "type": "integer",
+          "description": "測試總數"
+        },
+        "tests_passed": {
+          "type": "integer",
+          "description": "通過測試數"
+        },
+        "files_created": {
+          "type": "integer",
+          "description": "新建檔案數"
+        },
+        "files_modified": {
+          "type": "integer",
+          "description": "修改檔案數"
+        }
+      }
+    },
+    "pr": {
+      "type": "object",
+      "description": "Pull Request 資訊（PASS 且有 PR 時填入）",
+      "properties": {
+        "number": {
+          "type": "integer",
+          "description": "PR 編號"
+        },
+        "url": {
+          "type": "string",
+          "description": "PR URL"
+        },
+        "merge_commit": {
+          "type": "string",
+          "description": "Merge commit SHA"
+        }
+      }
+    },
+    "escalation": {
+      "type": "object",
+      "description": "升級資訊（result=ESCALATE 時必填）",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "DESIGN_ISSUE",
+            "CONTEXT_OVERFLOW",
+            "REQUIREMENT_AMBIGUITY",
+            "DEPENDENCY_MISSING",
+            "SECURITY_CRITICAL",
+            "DEBATE_DESIGN_ISSUE"
+          ],
+          "description": "升級類型"
+        },
+        "reason": {
+          "type": "string",
+          "description": "升級原因說明"
+        }
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "回傳時間（ISO 8601 格式，含時區）"
+    }
+  }
+}
+```
+
+---
+
+## 使用規範
+
+### Subagent 輸出規則
+
+1. **必填欄位**：`protocol_version`、`story_id`、`actor`、`result`、`summary`、`timestamp`
+2. **條件必填**：`escalation` 在 `result=ESCALATE` 時必填
+3. **向後相容（NFR1）**：既有 Markdown 摘要格式（§9 PASS/FAIL/ESCALATE 模板）必須保留，JSON block 以 `<!-- A2A-RESULT -->` 標記附加於摘要末尾
+4. **時間格式**：`timestamp` 使用 `date -u +"%Y-%m-%dT%H:%M:%SZ"` 或帶時區 ISO 8601
+
+### 輸出範例
+
+```json
+{
+  "protocol_version": "1.0",
+  "story_id": 801,
+  "actor": "developer",
+  "result": "PASS",
+  "summary": "A2A Protocol 標準化完成，ADR-044 建立，§9 更新，驗證腳本就緒",
+  "artifacts": [
+    {"type": "adr", "path": "docs/adr/ADR-044-a2a-protocol.md", "description": "A2A Protocol 架構決策"},
+    {"type": "file", "path": "scripts/validate-a2a-schema.sh", "description": "Schema 驗證腳本"},
+    {"type": "test", "path": "tests/test-a2a-protocol.sh", "description": "驗收測試"}
+  ],
+  "metrics": {
+    "tests_total": 17,
+    "tests_passed": 17,
+    "files_created": 3,
+    "files_modified": 1
+  },
+  "pr": {
+    "number": 822,
+    "url": "https://github.com/kctw-dev/shikigami/pull/822",
+    "merge_commit": ""
+  },
+  "timestamp": "2026-03-25T22:00:00Z"
+}
+```
+
+---
+
+## 驗證
+
+- **驗證腳本**：`scripts/validate-a2a-schema.sh <file>`
+- **驗收測試**：`tests/test-a2a-protocol.sh`
+- **§9 引用**：`skills/sprint-execution/story-lifecycle-prompt.md` §9 及 `skills/sprint-execution/references/output-schema.md`
+
+---
+
+## 決策理由
+
+1. **機器可讀**：JSON 格式允許 CI pipeline 自動驗證 subagent 輸出品質
+2. **向後相容**：附加方式不破壞既有 Markdown 摘要消費者
+3. **版本化演進**：`protocol_version` 欄位允許未來擴展而不破壞舊 consumer
+4. **工具鏈簡單**：bash + python3 json 即可驗證，無需額外依賴
+
+---
+
+## 參照
+
+- **ADR-007**：`docs/adr/ADR-007-story-lifecycle-subagent.md`（Story Lifecycle 介面契約）
+- **ADR-033**：`docs/adr/ADR-033-structured-trace-log.md`（Structured Trace Log，同為結構化輸出）
+- **§9 Output Schema**：`skills/sprint-execution/references/output-schema.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,7 @@
 # ADR 目錄索引
 
 > 本文件由 `scripts/update-adr-index.sh` 自動產生，請勿手動修改。
-> 最後更新：2026-03-25 19:55:34
+> 最後更新：2026-03-25 22:33:45
 
 ## 架構決策紀錄（Architecture Decision Records）
 
@@ -50,3 +50,4 @@
 | ADR-041 | [ADR-041: Temporal-style Crash Recovery — Session 級別恢復設計](ADR-041-crash-recovery-design.md) | Accepted | 2026-03-24 |
 | ADR-042 | [ADR-042: Session Watchdog — 存活監控與自動重啟設計](ADR-042-session-watchdog-design.md) | Accepted | 2026-03-24 |
 | ADR-043 | [ADR-043: Backlog Replenishment Strategy — 提前預警機制與 2-Sprint 提前期設計](ADR-043-backlog-replenishment-strategy.md) | Accepted | 2026-03-25 |
+| ADR-044 | [ADR-044: A2A Protocol — Agent-to-Agent 結構化通訊協議標準化](ADR-044-a2a-protocol.md) | Accepted | 2026-03-25 |

--- a/scripts/validate-a2a-schema.sh
+++ b/scripts/validate-a2a-schema.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# scripts/validate-a2a-schema.sh
+# #801 A2A Protocol — Subagent result file schema 驗證
+#
+# 依據 ADR-044（A2A Protocol Schema v1.0）驗證 subagent 回傳的 JSON 結果檔案。
+#
+# 驗證項目：
+#   - 必要欄位存在：protocol_version, story_id, actor, result, summary, timestamp
+#   - protocol_version 值為 "1.0"
+#   - actor 合法值：developer | architect | qa | po | security | sm
+#   - result 合法值：PASS | FAIL | ESCALATE
+#   - timestamp 格式為 ISO 8601（含基本格式檢查）
+#   - escalation 在 result=ESCALATE 時必填
+#
+# 使用方式：
+#   bash scripts/validate-a2a-schema.sh <json-file>
+#
+# Exit code:
+#   0 = PASS（全部驗證通過）
+#   1 = FAIL（有驗證錯誤）
+#
+# 依賴：bash >= 4, python3（JSON 解析）
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# 常數
+# ---------------------------------------------------------------------------
+readonly REQUIRED_FIELDS=("protocol_version" "story_id" "actor" "result" "summary" "timestamp")
+readonly VALID_ACTORS=("developer" "architect" "qa" "po" "security" "sm")
+readonly VALID_RESULTS=("PASS" "FAIL" "ESCALATE")
+readonly VALID_ESCALATION_TYPES=("DESIGN_ISSUE" "CONTEXT_OVERFLOW" "REQUIREMENT_AMBIGUITY" "DEPENDENCY_MISSING" "SECURITY_CRITICAL" "DEBATE_DESIGN_ISSUE")
+
+# ---------------------------------------------------------------------------
+# 狀態追蹤
+# ---------------------------------------------------------------------------
+EXIT_CODE=0
+ERROR_COUNT=0
+PASS_COUNT=0
+
+# ---------------------------------------------------------------------------
+# 輸出函式
+# ---------------------------------------------------------------------------
+emit_pass() {
+  echo "[PASS] $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+emit_fail() {
+  echo "[FAIL] $1"
+  EXIT_CODE=1
+  ERROR_COUNT=$((ERROR_COUNT + 1))
+}
+
+# ---------------------------------------------------------------------------
+# 前置條件：確認 python3 存在
+# ---------------------------------------------------------------------------
+check_dependencies() {
+  if ! command -v python3 &>/dev/null; then
+    echo "[FAIL] 缺少依賴：python3 未安裝，無法進行 JSON 解析"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 主驗證邏輯（透過 python3 解析 JSON）
+# ---------------------------------------------------------------------------
+validate_file() {
+  local filepath="$1"
+
+  # 確認檔案存在
+  if [[ ! -f "${filepath}" ]]; then
+    emit_fail "找不到檔案：${filepath}"
+    return
+  fi
+
+  # 讀取檔案內容
+  local content
+  content=$(cat "${filepath}" 2>/dev/null || true)
+
+  if [[ -z "${content}" ]]; then
+    emit_fail "檔案為空：${filepath}"
+    return
+  fi
+
+  # 執行 Python 驗證邏輯
+  local validation_output
+  validation_output=$(python3 - "${filepath}" <<'PYEOF'
+import json
+import sys
+import re
+from pathlib import Path
+
+filepath = sys.argv[1]
+errors = []
+passes = []
+
+# 讀取並解析 JSON
+try:
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read().strip()
+    obj = json.loads(content)
+except json.JSONDecodeError as e:
+    print(f"FAIL:JSON 格式錯誤：{e}")
+    sys.exit(0)
+except Exception as e:
+    print(f"FAIL:讀取檔案失敗：{e}")
+    sys.exit(0)
+
+if not isinstance(obj, dict):
+    print("FAIL:JSON 頂層必須為物件（object）")
+    sys.exit(0)
+
+passes.append("JSON 格式合法")
+
+# 必要欄位檢查
+required = ["protocol_version", "story_id", "actor", "result", "summary", "timestamp"]
+for field in required:
+    if field not in obj:
+        errors.append(f"缺少必要欄位：{field}")
+    else:
+        passes.append(f"必要欄位存在：{field}")
+
+if errors:
+    for e in errors:
+        print(f"FAIL:{e}")
+    for p in passes:
+        print(f"PASS:{p}")
+    sys.exit(0)
+
+# protocol_version 驗證
+if obj["protocol_version"] != "1.0":
+    errors.append(f"protocol_version 值必須為 '1.0'，實際值：{obj['protocol_version']!r}")
+else:
+    passes.append("protocol_version = '1.0'")
+
+# actor 合法值驗證
+valid_actors = ["developer", "architect", "qa", "po", "security", "sm"]
+if obj["actor"] not in valid_actors:
+    errors.append(f"actor 值 {obj['actor']!r} 不合法，允許值：{valid_actors}")
+else:
+    passes.append(f"actor = {obj['actor']!r}（合法）")
+
+# result 合法值驗證
+valid_results = ["PASS", "FAIL", "ESCALATE"]
+if obj["result"] not in valid_results:
+    errors.append(f"result 值 {obj['result']!r} 不合法，允許值：{valid_results}")
+else:
+    passes.append(f"result = {obj['result']!r}（合法）")
+
+# story_id 型別驗證
+if not isinstance(obj["story_id"], int):
+    errors.append(f"story_id 必須為整數，實際類型：{type(obj['story_id']).__name__}")
+else:
+    passes.append(f"story_id = {obj['story_id']}（整數）")
+
+# timestamp 基本格式驗證（ISO 8601 簡略檢查）
+ts = obj["timestamp"]
+iso_pattern = re.compile(
+    r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2}|[+-]\d{4})$'
+)
+if not iso_pattern.match(str(ts)):
+    errors.append(f"timestamp 格式不符合 ISO 8601：{ts!r}")
+else:
+    passes.append(f"timestamp 格式合法：{ts!r}")
+
+# escalation 在 result=ESCALATE 時必填
+if obj["result"] == "ESCALATE":
+    if "escalation" not in obj or obj["escalation"] is None:
+        errors.append("result=ESCALATE 時，escalation 欄位必填")
+    else:
+        esc = obj["escalation"]
+        valid_types = ["DESIGN_ISSUE", "CONTEXT_OVERFLOW", "REQUIREMENT_AMBIGUITY",
+                       "DEPENDENCY_MISSING", "SECURITY_CRITICAL", "DEBATE_DESIGN_ISSUE"]
+        if "type" not in esc:
+            errors.append("escalation.type 欄位缺失")
+        elif esc["type"] not in valid_types:
+            errors.append(f"escalation.type 值 {esc['type']!r} 不合法")
+        else:
+            passes.append(f"escalation.type = {esc['type']!r}（合法）")
+        if "reason" not in esc or not esc["reason"]:
+            errors.append("escalation.reason 欄位缺失或為空")
+        else:
+            passes.append("escalation.reason 存在")
+
+# 輸出結果
+for e in errors:
+    print(f"FAIL:{e}")
+for p in passes:
+    print(f"PASS:{p}")
+PYEOF
+  2>&1 || true)
+
+  # 解析 Python 輸出
+  local has_fail=0
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    if [[ "${line}" == FAIL:* ]]; then
+      emit_fail "${line#FAIL:}"
+      has_fail=1
+    elif [[ "${line}" == PASS:* ]]; then
+      emit_pass "${line#PASS:}"
+    else
+      # 意外輸出視為錯誤
+      emit_fail "驗證異常：${line}"
+      has_fail=1
+    fi
+  done <<< "${validation_output}"
+}
+
+# ---------------------------------------------------------------------------
+# 主流程
+# ---------------------------------------------------------------------------
+main() {
+  echo "=== validate-a2a-schema.sh — A2A Protocol Schema 驗證（ADR-044）==="
+  echo ""
+
+  check_dependencies
+
+  # 確認有傳入檔案路徑
+  if [[ $# -lt 1 ]]; then
+    echo "[FAIL] 使用方式：bash scripts/validate-a2a-schema.sh <json-file>"
+    exit 1
+  fi
+
+  local filepath="$1"
+  echo "驗證目標：${filepath}"
+  echo ""
+
+  validate_file "${filepath}"
+
+  echo ""
+  echo "=============================="
+  if [[ "${EXIT_CODE}" -eq 0 ]]; then
+    echo " 結果：PASS（${PASS_COUNT} 項全部通過）"
+  else
+    echo " 結果：FAIL（${ERROR_COUNT} 個錯誤）"
+  fi
+  echo "=============================="
+
+  exit "${EXIT_CODE}"
+}
+
+main "${@}"

--- a/skills/sprint-execution/references/output-schema.md
+++ b/skills/sprint-execution/references/output-schema.md
@@ -128,3 +128,42 @@ team_debate:            # Team Debate 結果（§7.8，ADR-031，豁免時填 nu
 | DEPENDENCY_MISSING | 暫停 Sprint 執行，解決依賴後重試 |
 | SECURITY_CRITICAL | 暫停 Sprint 執行，觸發 security-review Skill |
 | DEBATE_DESIGN_ISSUE | 暫停 Sprint 執行，升級至 Architect 評估（Team Debate 未解決設計問題） |
+
+## §9.2 A2A Protocol JSON Block（ADR-044，#801 Sprint 162）
+
+<!-- #801 A2A Protocol 結構化輸出 — Sprint 162 -->
+
+在回傳 Markdown 摘要後，**必須附加** A2A JSON Block，供主 session 機器可讀解析（ADR-044 v1.0）。
+
+**完整格式**：
+
+```json
+<!-- A2A-RESULT -->
+{
+  "protocol_version": "1.0",
+  "story_id": <整數>,
+  "actor": "<developer|architect|qa|po|security|sm>",
+  "result": "<PASS|FAIL|ESCALATE>",
+  "summary": "<≤200 字結果說明>",
+  "artifacts": [
+    {"type": "<file|pr|adr|test|doc>", "path": "<路徑或URL>", "description": "<說明>"}
+  ],
+  "metrics": {
+    "tests_total": <整數>,
+    "tests_passed": <整數>,
+    "files_created": <整數>,
+    "files_modified": <整數>
+  },
+  "pr": {"number": <整數>, "url": "<PR URL>", "merge_commit": "<SHA>"},
+  "escalation": {"type": "<升級類型>", "reason": "<說明>"},
+  "timestamp": "<ISO 8601，如 2026-03-25T22:00:00Z>"
+}
+```
+
+**必填欄位**：`protocol_version`、`story_id`、`actor`、`result`、`summary`、`timestamp`
+
+**條件必填**：`escalation`（當 `result=ESCALATE` 時必填）
+
+**驗證**：`bash scripts/validate-a2a-schema.sh <result-file.json>`
+
+**Schema 定義**：`docs/adr/ADR-044-a2a-protocol.md`

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -879,13 +879,43 @@ fi
 ## §9 輸出格式（Output Schema）
 
 <!-- US-249 Subagent 結果暫存 — context compaction 後結果復原機制 — Sprint 92 -->
+<!-- #801 A2A Protocol 結構化輸出 — ADR-044 — Sprint 162 -->
 
 > **[REFERENCE]** 完整輸出格式（§9.0 Live Log、§9.1 暫存寫入、YAML 契約、PASS/ESCALATE Markdown 模板、升級決策規則）已移至 `skills/sprint-execution/references/output-schema.md`。
+
+> **[A2A Protocol]** 所有 subagent 回傳必須附加 A2A JSON Block（ADR-044），詳見 `docs/adr/ADR-044-a2a-protocol.md` 與 `references/output-schema.md` §9.2。
 
 **回傳前必執行**：
 1. 寫 live log `結果：PASS|FAIL|ESCALATE`；stdout `[SHIKIGAMI] event=story_end`；trace span `status=completed|failed`
 2. 寫暫存 `docs/sprints/subagent-results/{story_id}.md`（失敗時 `[CACHE-WRITE-FAIL]`，不阻塞）
 3. 依 Read 後的模板格式回傳標準化摘要給主 session
+4. **（A2A Protocol — ADR-044）** 在摘要末尾附加 A2A JSON Block：
+
+```json
+<!-- A2A-RESULT -->
+{
+  "protocol_version": "1.0",
+  "story_id": <整數>,
+  "actor": "<developer|architect|qa|po|security|sm>",
+  "result": "<PASS|FAIL|ESCALATE>",
+  "summary": "<≤200 字結果說明>",
+  "artifacts": [...],
+  "metrics": {"tests_total": N, "tests_passed": N, "files_created": N, "files_modified": N},
+  "pr": {"number": N, "url": "...", "merge_commit": "..."},
+  "timestamp": "<ISO 8601>"
+}
+```
+
+**A2A 欄位說明**：
+- `protocol_version`：固定 `"1.0"`（ADR-044 v1.0）
+- `story_id`：GitHub Issue 編號（整數，非字串）
+- `actor`：執行角色，合法值：`developer` / `architect` / `qa` / `po` / `security` / `sm`
+- `result`：`PASS` | `FAIL` | `ESCALATE`（與 §9 YAML status 一致）
+- `summary`：≤200 字說明（既有 §9 YAML summary 欄位的 JSON 版本）
+- `escalation`：`result=ESCALATE` 時必填，含 `type` 與 `reason`
+- `timestamp`：`$(date -u +"%Y-%m-%dT%H:%M:%SZ")` 取得
+
+**向後相容（NFR1）**：A2A JSON Block 為附加輸出，不替換既有 Markdown 摘要格式（PASS/FAIL/ESCALATE 模板）。現有 `output-schema.md` YAML 契約仍然有效。
 
 ---
 

--- a/tests/test-a2a-protocol.sh
+++ b/tests/test-a2a-protocol.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# tests/test-a2a-protocol.sh
+# #801 驗收測試：A2A Protocol — Agent-to-Agent 結構化通訊協議標準化
+# TDD Red phase — 先寫測試，再實作
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+ADR_FILE="${REPO_ROOT}/docs/adr/ADR-044-a2a-protocol.md"
+LIFECYCLE_PROMPT="${REPO_ROOT}/skills/sprint-execution/story-lifecycle-prompt.md"
+VALIDATE_SCRIPT="${REPO_ROOT}/scripts/validate-a2a-schema.sh"
+
+pass() {
+  echo "[PASS] $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== #801 A2A Protocol 驗收測試 ==="
+echo ""
+
+# ── AC1: ADR-044 存在且包含 Schema 定義 ──────────────────────────────────────
+
+echo "--- AC1: ADR-044 存在且含 Schema 定義 ---"
+
+if [[ -f "${ADR_FILE}" ]]; then
+  pass "AC1-1: ADR-044-a2a-protocol.md 存在"
+else
+  fail "AC1-1: ADR-044-a2a-protocol.md 不存在"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q "protocol_version" "${ADR_FILE}"; then
+  pass "AC1-2: ADR-044 包含 protocol_version 欄位定義"
+else
+  fail "AC1-2: ADR-044 缺少 protocol_version 欄位定義"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q "story_id" "${ADR_FILE}"; then
+  pass "AC1-3: ADR-044 包含 story_id 欄位定義"
+else
+  fail "AC1-3: ADR-044 缺少 story_id 欄位定義"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q '"actor"' "${ADR_FILE}"; then
+  pass "AC1-4: ADR-044 包含 actor 欄位定義"
+else
+  fail "AC1-4: ADR-044 缺少 actor 欄位定義"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q '"result"' "${ADR_FILE}"; then
+  pass "AC1-5: ADR-044 包含 result 欄位定義"
+else
+  fail "AC1-5: ADR-044 缺少 result 欄位定義"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q "PASS.*FAIL.*ESCALATE\|ESCALATE.*PASS.*FAIL" "${ADR_FILE}"; then
+  pass "AC1-6: ADR-044 定義 result 合法值（PASS|FAIL|ESCALATE）"
+else
+  fail "AC1-6: ADR-044 缺少 result 合法值定義（PASS|FAIL|ESCALATE）"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q '"summary"' "${ADR_FILE}"; then
+  pass "AC1-7: ADR-044 包含 summary 欄位定義"
+else
+  fail "AC1-7: ADR-044 缺少 summary 欄位定義"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q '"artifacts"' "${ADR_FILE}"; then
+  pass "AC1-8: ADR-044 包含 artifacts 欄位定義"
+else
+  fail "AC1-8: ADR-044 缺少 artifacts 欄位定義"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q '"metrics"' "${ADR_FILE}"; then
+  pass "AC1-9: ADR-044 包含 metrics 欄位定義"
+else
+  fail "AC1-9: ADR-044 缺少 metrics 欄位定義"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q '"timestamp"' "${ADR_FILE}"; then
+  pass "AC1-10: ADR-044 包含 timestamp 欄位定義"
+else
+  fail "AC1-10: ADR-044 缺少 timestamp 欄位定義"
+fi
+
+if [[ -f "${ADR_FILE}" ]] && grep -q "Accepted" "${ADR_FILE}"; then
+  pass "AC1-11: ADR-044 狀態為 Accepted"
+else
+  fail "AC1-11: ADR-044 狀態非 Accepted"
+fi
+
+echo ""
+
+# ── AC2: story-lifecycle-prompt.md §9 已更新為 A2A 格式 ─────────────────────
+
+echo "--- AC2: story-lifecycle-prompt.md §9 含 A2A 結構化輸出格式 ---"
+
+if [[ -f "${LIFECYCLE_PROMPT}" ]] && grep -q "A2A\|a2a-protocol\|ADR-044" "${LIFECYCLE_PROMPT}"; then
+  pass "AC2-1: story-lifecycle-prompt.md §9 包含 A2A 協議引用"
+else
+  fail "AC2-1: story-lifecycle-prompt.md §9 缺少 A2A 協議引用"
+fi
+
+if [[ -f "${LIFECYCLE_PROMPT}" ]] && grep -q "protocol_version" "${LIFECYCLE_PROMPT}"; then
+  pass "AC2-2: story-lifecycle-prompt.md 包含 protocol_version 欄位"
+else
+  fail "AC2-2: story-lifecycle-prompt.md 缺少 protocol_version 欄位"
+fi
+
+# NFR1: 確認既有欄位仍存在（向後相容）
+if [[ -f "${LIFECYCLE_PROMPT}" ]] && grep -q "PASS\|FAIL\|ESCALATE" "${LIFECYCLE_PROMPT}"; then
+  pass "AC2-3（NFR1）: story-lifecycle-prompt.md 保留既有 PASS/FAIL/ESCALATE 結果格式"
+else
+  fail "AC2-3（NFR1）: story-lifecycle-prompt.md 缺少既有 PASS/FAIL/ESCALATE 格式"
+fi
+
+if [[ -f "${LIFECYCLE_PROMPT}" ]] && grep -q "story_id\|Story ID" "${LIFECYCLE_PROMPT}"; then
+  pass "AC2-4（NFR1）: story-lifecycle-prompt.md 保留 story_id 欄位（向後相容）"
+else
+  fail "AC2-4（NFR1）: story-lifecycle-prompt.md 缺少 story_id 欄位"
+fi
+
+echo ""
+
+# ── AC3: validate-a2a-schema.sh 存在且可執行 ────────────────────────────────
+
+echo "--- AC3: validate-a2a-schema.sh 驗證腳本 ---"
+
+if [[ -f "${VALIDATE_SCRIPT}" ]]; then
+  pass "AC3-1: validate-a2a-schema.sh 存在"
+else
+  fail "AC3-1: validate-a2a-schema.sh 不存在"
+fi
+
+if [[ -f "${VALIDATE_SCRIPT}" ]] && [[ -x "${VALIDATE_SCRIPT}" ]]; then
+  pass "AC3-2: validate-a2a-schema.sh 可執行"
+else
+  fail "AC3-2: validate-a2a-schema.sh 不可執行"
+fi
+
+# 測試合法輸入（包含所有必要欄位）
+if [[ -f "${VALIDATE_SCRIPT}" ]]; then
+  VALID_JSON_FILE="$(mktemp /tmp/a2a-valid-XXXX.json)"
+  cat > "${VALID_JSON_FILE}" << 'EOF'
+{
+  "protocol_version": "1.0",
+  "story_id": 801,
+  "actor": "developer",
+  "result": "PASS",
+  "summary": "A2A Protocol 實作完成",
+  "artifacts": [],
+  "metrics": {
+    "tests_total": 10,
+    "tests_passed": 10,
+    "files_created": 3,
+    "files_modified": 1
+  },
+  "timestamp": "2026-03-25T22:00:00+08:00"
+}
+EOF
+
+  if bash "${VALIDATE_SCRIPT}" "${VALID_JSON_FILE}" 2>&1 | grep -q "PASS"; then
+    pass "AC3-3: validate-a2a-schema.sh 對合法 JSON 輸出 PASS"
+  else
+    fail "AC3-3: validate-a2a-schema.sh 對合法 JSON 未輸出 PASS"
+  fi
+  rm -f "${VALID_JSON_FILE}"
+fi
+
+# 測試非法輸入（缺少必要欄位）
+if [[ -f "${VALIDATE_SCRIPT}" ]]; then
+  INVALID_JSON_FILE="$(mktemp /tmp/a2a-invalid-XXXX.json)"
+  cat > "${INVALID_JSON_FILE}" << 'EOF'
+{
+  "story_id": 999,
+  "result": "PASS"
+}
+EOF
+
+  if bash "${VALIDATE_SCRIPT}" "${INVALID_JSON_FILE}" 2>&1 | grep -q "FAIL"; then
+    pass "AC3-4: validate-a2a-schema.sh 對缺少必要欄位的 JSON 輸出 FAIL"
+  else
+    fail "AC3-4: validate-a2a-schema.sh 對缺少必要欄位的 JSON 未輸出 FAIL"
+  fi
+  rm -f "${INVALID_JSON_FILE}"
+fi
+
+# 測試非法 result 值
+if [[ -f "${VALIDATE_SCRIPT}" ]]; then
+  INVALID_RESULT_FILE="$(mktemp /tmp/a2a-invalid-result-XXXX.json)"
+  cat > "${INVALID_RESULT_FILE}" << 'EOF'
+{
+  "protocol_version": "1.0",
+  "story_id": 999,
+  "actor": "developer",
+  "result": "UNKNOWN",
+  "summary": "test",
+  "timestamp": "2026-03-25T00:00:00Z"
+}
+EOF
+
+  if bash "${VALIDATE_SCRIPT}" "${INVALID_RESULT_FILE}" 2>&1 | grep -q "FAIL"; then
+    pass "AC3-5: validate-a2a-schema.sh 對非法 result 值輸出 FAIL"
+  else
+    fail "AC3-5: validate-a2a-schema.sh 對非法 result 值未輸出 FAIL"
+  fi
+  rm -f "${INVALID_RESULT_FILE}"
+fi
+
+# 測試非法 JSON
+if [[ -f "${VALIDATE_SCRIPT}" ]]; then
+  INVALID_FORMAT_FILE="$(mktemp /tmp/a2a-invalid-format-XXXX.json)"
+  printf '%s\n' "not valid json" > "${INVALID_FORMAT_FILE}"
+
+  if bash "${VALIDATE_SCRIPT}" "${INVALID_FORMAT_FILE}" 2>&1 | grep -q "FAIL"; then
+    pass "AC3-6: validate-a2a-schema.sh 對非法 JSON 格式輸出 FAIL"
+  else
+    fail "AC3-6: validate-a2a-schema.sh 對非法 JSON 格式未輸出 FAIL"
+  fi
+  rm -f "${INVALID_FORMAT_FILE}"
+fi
+
+echo ""
+
+# ── 總結 ──────────────────────────────────────────────────────────────────────
+
+TOTAL=$((PASS + FAIL))
+echo "=============================="
+echo " #801 A2A Protocol 測試總結"
+echo " 通過：${PASS}/${TOTAL}"
+echo " 失敗：${FAIL}/${TOTAL}"
+if [[ ${FAIL} -eq 0 ]]; then
+  echo " 結果：全部 PASS"
+else
+  echo " 結果：FAIL（${FAIL} 項未通過）"
+fi
+echo "=============================="
+
+exit ${FAIL}


### PR DESCRIPTION
## Summary

- **AC1**: 新增 `docs/adr/ADR-044-a2a-protocol.md`，定義 A2A Protocol JSON Schema v1.0（必填欄位、actor/result 合法值、escalation 條件必填規則）
- **AC2**: 更新 `skills/sprint-execution/story-lifecycle-prompt.md` §9 及 `references/output-schema.md` §9.2，加入 A2A JSON Block 輸出規範（向後相容 NFR1：既有 Markdown 摘要格式保留）
- **AC3**: 新增 `scripts/validate-a2a-schema.sh`，驗證 subagent 結果檔案符合 A2A Schema（必要欄位、合法值、ISO 8601 timestamp、ESCALATE 條件必填）
- **AC4**: 新增 `tests/test-a2a-protocol.sh`，21 項測試全部 PASS

## NFR1 向後相容確認

- §9 既有 YAML 契約（status/summary/modified_files/commit_sha 欄位）完整保留
- §9 既有 PASS/FAIL/ESCALATE Markdown 模板保留
- A2A JSON Block 為**附加輸出**（`<\!-- A2A-RESULT -->` 標記），不替換現有格式

## Test plan

- [x] `bash tests/test-a2a-protocol.sh` — 21/21 PASS
- [x] `bash tests/test-392-structured-trace-log.sh` — 26/26 PASS（無迴歸）
- [x] `bash scripts/validate-skills.sh` — 31 Skills 全部通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
