### PR TITLE
feat(#827): Sprint Retrospective 自動模板生成 — 預填 Sprint 指標

### DIFF
--- a/scripts/generate-retro-template.sh
+++ b/scripts/generate-retro-template.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# scripts/generate-retro-template.sh — #827 Sprint Retrospective 自動模板生成
+# 接收 sprint_N.md 路徑，輸出預填 Retrospective Markdown 模板
+#
+# Usage: bash scripts/generate-retro-template.sh <sprint_N.md>
+# Output: 預填 Retrospective Markdown（Sprint Goal、velocity、完成率、DONE Stories 清單）
+# NFR1: 腳本無需網路連線（純本地文件解析）
+# NFR2: 當 sprint_N.md 格式不符預期時，輸出 [RETRO-TEMPLATE-WARN] 而非 crash
+
+set -u
+
+SPRINT_FILE="${1:-}"
+
+if [[ -z "$SPRINT_FILE" ]]; then
+  echo "[RETRO-TEMPLATE-WARN] Usage: $0 <sprint_N.md>" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SPRINT_FILE" ]]; then
+  echo "[RETRO-TEMPLATE-WARN] Sprint file not found: $SPRINT_FILE" >&2
+  exit 1
+fi
+
+# Extract Sprint number from filename
+SPRINT_NUM=$(basename "$SPRINT_FILE" .md | grep -oE '[0-9]+$' || echo "N")
+
+# Parse Sprint Goal
+SPRINT_GOAL=$(grep -E "\*\*Sprint Goal\*\*" "$SPRINT_FILE" 2>/dev/null | head -1 \
+  | sed 's/.*\*\*Sprint Goal\*\*[：:]\s*//' | sed 's/^> *//' || echo "")
+
+if [[ -z "$SPRINT_GOAL" ]]; then
+  echo "[RETRO-TEMPLATE-WARN] Could not parse Sprint Goal from: $SPRINT_FILE" >&2
+  SPRINT_GOAL="（未能解析 Sprint Goal）"
+fi
+
+# Parse Total points (velocity)
+VELOCITY=$(grep -oE '\*\*Total: [0-9]+ pts\*\*' "$SPRINT_FILE" 2>/dev/null | head -1 \
+  | grep -oE '[0-9]+' || echo "")
+
+if [[ -z "$VELOCITY" ]]; then
+  echo "[RETRO-TEMPLATE-WARN] Could not parse velocity from: $SPRINT_FILE" >&2
+  VELOCITY="N/A"
+fi
+
+# Parse capacity
+CAPACITY=$(grep -E "\*\*容量\*\*" "$SPRINT_FILE" 2>/dev/null | head -1 \
+  | grep -oE '[0-9]+' | head -1 || echo "$VELOCITY")
+
+# Parse DONE stories
+DONE_STORIES=()
+while IFS= read -r line; do
+  DONE_STORIES+=("$line")
+done < <(grep "| DONE" "$SPRINT_FILE" 2>/dev/null \
+  | sed 's/^| [0-9]* | //' \
+  | sed 's/ | [^ ]* | [0-9]* | DONE.*//' \
+  | sed 's/ *$$//')
+
+DONE_COUNT=${#DONE_STORIES[@]}
+
+# Parse FAIL stories
+FAIL_STORIES=()
+while IFS= read -r line; do
+  FAIL_STORIES+=("$line")
+done < <(grep "| FAIL" "$SPRINT_FILE" 2>/dev/null \
+  | sed 's/^| [0-9]* | //' \
+  | sed 's/ | [^ ]* | [0-9]* | FAIL.*//' \
+  | sed 's/ *$$//')
+
+FAIL_COUNT=${#FAIL_STORIES[@]}
+TOTAL_STORIES=$((DONE_COUNT + FAIL_COUNT))
+
+if [[ $TOTAL_STORIES -gt 0 ]]; then
+  COMPLETION_RATE=$(python3 -c "print(f'{$DONE_COUNT/$TOTAL_STORIES*100:.0f}%')" 2>/dev/null || echo "${DONE_COUNT}/${TOTAL_STORIES}")
+else
+  COMPLETION_RATE="N/A"
+fi
+
+# Get current date
+TODAY=$(date '+%Y-%m-%d')
+
+# Output Retrospective Template
+cat << EOF
+# Sprint ${SPRINT_NUM} Retrospective
+
+**日期**：${TODAY}
+**Sprint**：${SPRINT_NUM}
+
+---
+
+## Sprint Summary（自動預填）
+
+| 指標 | 數值 |
+|------|------|
+| Sprint Goal | ${SPRINT_GOAL} |
+| Velocity | ${VELOCITY} pts |
+| 容量 | ${CAPACITY} pts |
+| 完成率 | ${COMPLETION_RATE} |
+| DONE Stories | ${DONE_COUNT} |
+| FAIL Stories | ${FAIL_COUNT} |
+
+## DONE Stories
+
+EOF
+
+if [[ ${#DONE_STORIES[@]} -gt 0 ]]; then
+  for STORY in "${DONE_STORIES[@]}"; do
+    echo "- ${STORY}"
+  done
+else
+  echo "_（無 DONE Stories）_"
+fi
+
+cat << 'EOF'
+
+---
+
+## Retrospective
+
+### What went well（做得好的）
+
+-
+
+### What could be improved（可以改善的）
+
+-
+
+### Problems（問題點）
+
+-
+
+### Action Items（下一 Sprint 改善行動）
+
+| # | Action | Owner | Priority |
+|---|--------|-------|---------|
+| 1 |  |  | must |
+
+---
+
+> _此模板由 generate-retro-template.sh 自動生成，請補充各欄位。_
+EOF
+
+exit 0

--- a/tests/test-generate-retro-template.sh
+++ b/tests/test-generate-retro-template.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# tests/test-generate-retro-template.sh — AC3: Story #827
+# 驗證 scripts/generate-retro-template.sh 解析 sprint_162.md 輸出正確欄位
+
+set -u
+
+PASS=0
+FAIL=0
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/generate-retro-template.sh"
+SPRINT_162="$REPO_ROOT/docs/sprints/sprint_162.md"
+
+pass() { echo "[PASS] $1"; PASS=$((PASS+1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+# Test 1: Script exists
+if [[ -f "$SCRIPT" ]]; then
+  pass "Script exists: scripts/generate-retro-template.sh"
+else
+  fail "Script missing: scripts/generate-retro-template.sh"
+  echo "=== Results: $PASS passed, $FAIL failed ==="
+  exit 1
+fi
+
+# Test 2: Fixture sprint_162.md exists
+if [[ -f "$SPRINT_162" ]]; then
+  pass "Fixture exists: docs/sprints/sprint_162.md"
+else
+  fail "Fixture missing: docs/sprints/sprint_162.md"
+fi
+
+# Test 3: AC3 — parse sprint_162.md and output correct fields
+if [[ -f "$SPRINT_162" ]]; then
+  OUTPUT=$(bash "$SCRIPT" "$SPRINT_162" 2>&1)
+  EC=$?
+
+  if [[ $EC -eq 0 ]]; then
+    pass "AC3: Script exits 0 parsing sprint_162.md"
+  else
+    fail "AC3: Script exited with error $EC on sprint_162.md"
+  fi
+
+  # Check for Sprint Goal
+  if echo "$OUTPUT" | grep -qiE "(Sprint Goal|Sprint.*Goal)"; then
+    pass "AC3: Output contains Sprint Goal section"
+  else
+    fail "AC3: Output missing Sprint Goal"
+  fi
+
+  # Check for velocity (pts)
+  if echo "$OUTPUT" | grep -qE "[0-9]+ pts"; then
+    pass "AC3: Output contains velocity/points data"
+  else
+    fail "AC3: Output missing velocity/points"
+  fi
+
+  # Check for DONE stories or completion rate
+  if echo "$OUTPUT" | grep -qiE "(DONE|完成|completed|velocity)"; then
+    pass "AC3: Output contains DONE/completion info"
+  else
+    fail "AC3: Output missing DONE/completion section"
+  fi
+fi
+
+# Test 4: AC1 — output contains Retrospective template sections
+if [[ -f "$SPRINT_162" ]]; then
+  OUTPUT=$(bash "$SCRIPT" "$SPRINT_162" 2>&1)
+
+  # Check for went-well / improvement sections (standard retro template)
+  if echo "$OUTPUT" | grep -qiE "(Well|好|改善|Improvement|問題|Problem|Action)"; then
+    pass "AC1: Output contains retrospective template sections"
+  else
+    fail "AC1: Output missing retrospective template sections"
+  fi
+fi
+
+# Test 5: AC2 — output format aligns with existing sprint review format
+if [[ -f "$SPRINT_162" ]]; then
+  OUTPUT=$(bash "$SCRIPT" "$SPRINT_162" 2>&1)
+  # Should contain markdown header
+  if echo "$OUTPUT" | grep -qE "^#"; then
+    pass "AC2: Output contains markdown headers (format aligned)"
+  else
+    fail "AC2: Output missing markdown headers"
+  fi
+fi
+
+# Test 6: NFR2 — Bad format input outputs [RETRO-TEMPLATE-WARN] not crash
+TMPFILE=$(mktemp --suffix=.md)
+echo "This is not a valid sprint file format" > "$TMPFILE"
+OUTPUT=$(bash "$SCRIPT" "$TMPFILE" 2>&1)
+EC=$?
+rm -f "$TMPFILE"
+
+if [[ $EC -le 1 ]]; then
+  pass "NFR2: Graceful handling of bad format (exit $EC)"
+else
+  fail "NFR2: Script crashed on bad format (exit $EC)"
+fi
+
+if echo "$OUTPUT" | grep -q "\[RETRO-TEMPLATE-WARN\]"; then
+  pass "NFR2: [RETRO-TEMPLATE-WARN] output for bad format"
+else
+  fail "NFR2: [RETRO-TEMPLATE-WARN] not found for bad format"
+fi
+
+# Test 7: Missing file handling
+OUTPUT=$(bash "$SCRIPT" /nonexistent/sprint.md 2>&1)
+EC=$?
+if [[ $EC -le 1 ]]; then
+  pass "Edge: Handles missing file without crash (exit $EC)"
+else
+  fail "Edge: Crashed on missing file (exit $EC)"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
feat(#827): Sprint Retrospective 自動模板生成

新增 scripts/generate-retro-template.sh 與 tests/test-generate-retro-template.sh

- AC1: 接收 sprint_N.md，輸出預填 Retro 模板（Goal、velocity、完成率、DONE）
- AC2: 格式對齊現有 sprint_N.md §Retrospective 段落
- AC3: 驗證 sprint_162.md 解析（11/11 PASS）
- NFR1: 純本地解析；NFR2: [RETRO-TEMPLATE-WARN] graceful
