### PR TITLE
feat(#838): 驗證腳本測試覆蓋率提升

### DIFF
--- a/tests/test-validate-agents.sh
+++ b/tests/test-validate-agents.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# tests/test-validate-agents.sh
+# Story #838：Agent 定義驗證 — 測試套件
+#
+# 驗證 scripts/validate-agents.sh 的行為符合 AC1-AC5
+# - AC1：掃描 agents/ 下所有 .md 檔案
+# - AC2：驗證 frontmatter 含 name、description、model 欄位
+# - AC3：驗證 model 值在白名單中（sonnet、haiku、opus）
+# - AC4：驗證 description 欄位非空
+# - AC5：exit 0 通過，exit 1 失敗
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATE_SCRIPT="${REPO_ROOT}/scripts/validate-agents.sh"
+PASS=0
+FAIL=0
+
+# Helper functions
+pass() {
+  echo "[PASS] $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_exit_code() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label (期望 exit=$expected，實際 exit=$actual)"
+  fi
+}
+
+assert_output_contains() {
+  local needle="$1"
+  local haystack="$2"
+  local label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    pass "$label"
+  else
+    fail "$label (輸出中找不到「$needle」)"
+  fi
+}
+
+# Setup temporary test environment
+setup_test_env() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/agents"
+  echo "$tmpdir"
+}
+
+# Write a valid agent .md file
+write_valid_agent() {
+  local dir="$1"
+  local name="$2"
+  cat > "$dir/agents/${name}.md" <<EOF
+---
+name: $name
+description: A test agent for $name
+model: sonnet
+---
+
+# $name
+
+This is a test agent.
+EOF
+}
+
+# Write an invalid agent (empty description)
+write_invalid_agent_empty_desc() {
+  local dir="$1"
+  local name="$2"
+  cat > "$dir/agents/${name}.md" <<EOF
+---
+name: $name
+description:
+model: sonnet
+---
+
+# $name
+
+This agent has empty description.
+EOF
+}
+
+# Run validate script and return exit code
+run_validate_test() {
+  local tmpdir="$1"
+  local exit_code
+  cd "$tmpdir"
+  if bash "$VALIDATE_SCRIPT" > /tmp/validate_agents_output.txt 2>&1; then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
+  cd "$REPO_ROOT"
+  echo "$exit_code"
+}
+
+echo "=============================="
+echo " Story #838 - test-validate-agents.sh"
+echo "=============================="
+echo ""
+
+# ── Pre-check: validate-agents.sh 必須存在 ────────────────────────────────
+if [[ ! -f "$VALIDATE_SCRIPT" ]]; then
+  fail "scripts/validate-agents.sh 不存在"
+  echo "FAIL: $FAIL / PASS: $PASS"
+  exit 1
+fi
+pass "scripts/validate-agents.sh 存在"
+
+# ── TC-01: AC1 通過 — 掃描並列出所有 agent 檔案 ────────────────────────────
+tmpdir=$(setup_test_env)
+write_valid_agent "$tmpdir" "test-agent-1"
+write_valid_agent "$tmpdir" "test-agent-2"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-01 AC1：有效 agent 掃描 exit 0"
+assert_output_contains "test-agent-1.md" "$output" "TC-01 AC1：輸出列出 test-agent-1.md"
+assert_output_contains "test-agent-2.md" "$output" "TC-01 AC1：輸出列出 test-agent-2.md"
+assert_output_contains "2 個 Agent" "$output" "TC-01 AC1：輸出顯示正確數量"
+rm -rf "$tmpdir"
+
+# ── TC-02: AC2 FAIL — 缺少 name 欄位 ─────────────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/agents/no-name.md" <<'EOF'
+---
+description: Agent without name
+model: sonnet
+---
+
+# No Name
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-02 AC2 缺少 name：exit 1"
+assert_output_contains "缺少 name 欄位" "$output" "TC-02 AC2 缺少 name：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-03: AC2 FAIL — 缺少 description 欄位 ──────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/agents/no-desc.md" <<'EOF'
+---
+name: no-desc
+model: sonnet
+---
+
+# No Description
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-03 AC2 缺少 description：exit 1"
+assert_output_contains "缺少 description 欄位" "$output" "TC-03 AC2 缺少 description：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-04: AC2 FAIL — 缺少 model 欄位 ───────────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/agents/no-model.md" <<'EOF'
+---
+name: no-model
+description: Test agent
+---
+
+# No Model
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-04 AC2 缺少 model：exit 1"
+assert_output_contains "缺少 model 欄位" "$output" "TC-04 AC2 缺少 model：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-05: AC3 FAIL — model 值不在白名單中 ──────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/agents/bad-model.md" <<'EOF'
+---
+name: bad-model
+description: A test agent
+model: gpt-4
+---
+
+# Bad Model
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-05 AC3 無效 model：exit 1"
+assert_output_contains "不在白名單" "$output" "TC-05 AC3 無效 model：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-06: AC3 PASS — model 值有效（sonnet） ─────────────────────────────
+tmpdir=$(setup_test_env)
+write_valid_agent "$tmpdir" "sonnet-agent"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-06 AC3 sonnet model：exit 0"
+assert_output_contains "sonnet" "$output" "TC-06 AC3 sonnet model：輸出驗證通過"
+rm -rf "$tmpdir"
+
+# ── TC-07: AC3 PASS — model 值有效（haiku） ──────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/agents/haiku-agent.md" <<'EOF'
+---
+name: haiku-agent
+description: A haiku-based agent
+model: haiku
+---
+
+# Haiku Agent
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-07 AC3 haiku model：exit 0"
+assert_output_contains "haiku" "$output" "TC-07 AC3 haiku model：輸出驗證通過"
+rm -rf "$tmpdir"
+
+# ── TC-08: AC3 PASS — model 值有效（opus） ───────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/agents/opus-agent.md" <<'EOF'
+---
+name: opus-agent
+description: An opus-based agent
+model: opus
+---
+
+# Opus Agent
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-08 AC3 opus model：exit 0"
+assert_output_contains "opus" "$output" "TC-08 AC3 opus model：輸出驗證通過"
+rm -rf "$tmpdir"
+
+# ── TC-09: AC4 FAIL — description 為空 ─────────────────────────────────
+tmpdir=$(setup_test_env)
+write_invalid_agent_empty_desc "$tmpdir" "empty-desc"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-09 AC4 空 description：exit 1"
+assert_output_contains "為空字串或僅含空白字元" "$output" "TC-09 AC4 空 description：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-10: AC4 PASS — description 非空 ───────────────────────────────────
+tmpdir=$(setup_test_env)
+write_valid_agent "$tmpdir" "valid-agent"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_agents_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-10 AC4 非空 description：exit 0"
+assert_output_contains "description 欄位非空" "$output" "TC-10 AC4 非空 description：輸出驗證通過"
+rm -rf "$tmpdir"
+
+# ── NFR1: 執行時間 < 5 秒 ──────────────────────────────────────────────────
+tmpdir=$(setup_test_env)
+write_valid_agent "$tmpdir" "perf-test"
+start_time=$(date +%s)
+cd "$tmpdir"
+bash "$VALIDATE_SCRIPT" > /tmp/validate_agents_output.txt 2>&1 || true
+cd "$REPO_ROOT"
+end_time=$(date +%s)
+duration=$((end_time - start_time))
+
+if [ "$duration" -lt 5 ]; then
+  pass "NFR1：執行時間 $duration 秒 < 5 秒"
+else
+  fail "NFR1：執行時間 $duration 秒 >= 5 秒"
+fi
+rm -rf "$tmpdir"
+
+echo ""
+echo "=============================="
+echo " 結果：PASS=$PASS  FAIL=$FAIL"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test-validate-json.sh
+++ b/tests/test-validate-json.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# tests/test-validate-json.sh
+# Story #838：JSON Schema 驗證 — 測試套件
+#
+# 驗證 scripts/validate-json.sh 的行為符合 AC1-AC5
+# - AC1：驗證 plugin.json 必填欄位（name、version、description、author）
+# - AC2：驗證 marketplace.json 必填欄位（name、plugins）
+# - AC3：驗證 version 格式符合 semver（major.minor.patch）
+# - AC4：驗證 plugin.json 欄位白名單（白名單外欄位觸發 WARNING，非 ERROR）
+# - AC5：exit code 0 無 ERROR，非 0 有 ERROR
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATE_SCRIPT="${REPO_ROOT}/scripts/validate-json.sh"
+PASS=0
+FAIL=0
+
+# Helper functions
+pass() {
+  echo "[PASS] $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_exit_code() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label (期望 exit=$expected，實際 exit=$actual)"
+  fi
+}
+
+assert_output_contains() {
+  local needle="$1"
+  local haystack="$2"
+  local label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    pass "$label"
+  else
+    fail "$label (輸出中找不到「$needle」)"
+  fi
+}
+
+# Setup temporary test environment
+setup_test_env() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/.claude-plugin"
+  echo "$tmpdir"
+}
+
+# Write a valid plugin.json
+write_valid_plugin_json() {
+  local dir="$1"
+  local version="${2:-0.1.0}"
+  cat > "$dir/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "test-plugin",
+  "version": "$version",
+  "description": "A test plugin",
+  "author": "Test Author"
+}
+EOF
+}
+
+# Write a valid marketplace.json
+write_valid_marketplace_json() {
+  local dir="$1"
+  local version="${2:-0.1.0}"
+  cat > "$dir/.claude-plugin/marketplace.json" <<EOF
+{
+  "name": "test-plugin",
+  "plugins": [
+    {
+      "name": "test-plugin",
+      "version": "$version"
+    }
+  ]
+}
+EOF
+}
+
+# Run validate script and return exit code
+run_validate_test() {
+  local tmpdir="$1"
+  local exit_code
+  cd "$tmpdir"
+  if bash "$VALIDATE_SCRIPT" > /tmp/validate_json_output.txt 2>&1; then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
+  cd "$REPO_ROOT"
+  echo "$exit_code"
+}
+
+echo "=============================="
+echo " Story #838 - test-validate-json.sh"
+echo "=============================="
+echo ""
+
+# ── Pre-check: validate-json.sh 必須存在 ────────────────────────────────
+if [[ ! -f "$VALIDATE_SCRIPT" ]]; then
+  fail "scripts/validate-json.sh 不存在"
+  echo "FAIL: $FAIL / PASS: $PASS"
+  exit 1
+fi
+pass "scripts/validate-json.sh 存在"
+
+# ── TC-01: AC1 PASS — plugin.json 包含所有必填欄位 ──────────────────────────
+tmpdir=$(setup_test_env)
+write_valid_plugin_json "$tmpdir" "0.1.0"
+write_valid_marketplace_json "$tmpdir" "0.1.0"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-01 AC1 plugin.json 有效：exit 0"
+assert_output_contains "name" "$output" "TC-01 AC1：輸出驗證 name 欄位"
+assert_output_contains "version" "$output" "TC-01 AC1：輸出驗證 version 欄位"
+assert_output_contains "description" "$output" "TC-01 AC1：輸出驗證 description 欄位"
+assert_output_contains "author" "$output" "TC-01 AC1：輸出驗證 author 欄位"
+rm -rf "$tmpdir"
+
+# ── TC-02: AC1 FAIL — plugin.json 缺少 name ──────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/.claude-plugin/plugin.json" <<'EOF'
+{
+  "version": "0.1.0",
+  "description": "Missing name",
+  "author": "Test"
+}
+EOF
+write_valid_marketplace_json "$tmpdir" "0.1.0"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-02 AC1 缺少 name：exit 1"
+assert_output_contains "缺少必填欄位「name」" "$output" "TC-02 AC1 缺少 name：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-03: AC1 FAIL — plugin.json 缺少 version ──────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "test-plugin",
+  "description": "Missing version",
+  "author": "Test"
+}
+EOF
+write_valid_marketplace_json "$tmpdir" "0.1.0"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-03 AC1 缺少 version：exit 1"
+assert_output_contains "缺少必填欄位「version」" "$output" "TC-03 AC1 缺少 version：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-04: AC1 FAIL — plugin.json 缺少 description ───────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "test-plugin",
+  "version": "0.1.0",
+  "author": "Test"
+}
+EOF
+write_valid_marketplace_json "$tmpdir" "0.1.0"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-04 AC1 缺少 description：exit 1"
+assert_output_contains "缺少必填欄位「description」" "$output" "TC-04 AC1 缺少 description：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-05: AC1 FAIL — plugin.json 缺少 author ──────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "test-plugin",
+  "version": "0.1.0",
+  "description": "Missing author"
+}
+EOF
+write_valid_marketplace_json "$tmpdir" "0.1.0"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-05 AC1 缺少 author：exit 1"
+assert_output_contains "缺少必填欄位「author」" "$output" "TC-05 AC1 缺少 author：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-06: AC2 PASS — marketplace.json 包含所有必填欄位 ────────────────────
+tmpdir=$(setup_test_env)
+write_valid_plugin_json "$tmpdir" "0.1.0"
+write_valid_marketplace_json "$tmpdir" "0.1.0"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-06 AC2 marketplace.json 有效：exit 0"
+assert_output_contains "plugins" "$output" "TC-06 AC2：輸出驗證 plugins 欄位"
+rm -rf "$tmpdir"
+
+# ── TC-07: AC2 FAIL — marketplace.json 缺少 name ──────────────────────────
+tmpdir=$(setup_test_env)
+write_valid_plugin_json "$tmpdir" "0.1.0"
+cat > "$tmpdir/.claude-plugin/marketplace.json" <<'EOF'
+{
+  "plugins": [
+    {
+      "name": "test-plugin",
+      "version": "0.1.0"
+    }
+  ]
+}
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-07 AC2 缺少 name：exit 1"
+assert_output_contains "缺少必填欄位「name」" "$output" "TC-07 AC2 缺少 name：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-08: AC2 FAIL — marketplace.json 缺少 plugins ──────────────────────
+tmpdir=$(setup_test_env)
+write_valid_plugin_json "$tmpdir" "0.1.0"
+cat > "$tmpdir/.claude-plugin/marketplace.json" <<'EOF'
+{
+  "name": "test-plugin"
+}
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-08 AC2 缺少 plugins：exit 1"
+assert_output_contains "缺少必填欄位「plugins」" "$output" "TC-08 AC2 缺少 plugins：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-09: AC3 PASS — version 符合 semver ────────────────────────────────
+tmpdir=$(setup_test_env)
+write_valid_plugin_json "$tmpdir" "1.2.3"
+write_valid_marketplace_json "$tmpdir" "1.2.3"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-09 AC3 semver 有效：exit 0"
+assert_output_contains "semver" "$output" "TC-09 AC3 semver 有效：輸出驗證通過"
+rm -rf "$tmpdir"
+
+# ── TC-10: AC3 FAIL — version 不符合 semver（缺少 patch）────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "test-plugin",
+  "version": "1.2",
+  "description": "Invalid version",
+  "author": "Test"
+}
+EOF
+write_valid_marketplace_json "$tmpdir" "1.2"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-10 AC3 版本無效（缺 patch）：exit 1"
+assert_output_contains "不符合 semver" "$output" "TC-10 AC3 版本無效：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-11: AC3 FAIL — version 含非數字字符 ──────────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "test-plugin",
+  "version": "1.2.3-beta",
+  "description": "Invalid version",
+  "author": "Test"
+}
+EOF
+write_valid_marketplace_json "$tmpdir" "1.2.3-beta"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-11 AC3 版本含預發標籤：exit 1"
+assert_output_contains "不符合 semver" "$output" "TC-11 AC3 版本含預發標籤：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-12: AC4 PASS — plugin.json 中白名單欄位 ──────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "test-plugin",
+  "version": "0.1.0",
+  "description": "Test",
+  "author": "Author",
+  "homepage": "https://example.com",
+  "license": "MIT"
+}
+EOF
+write_valid_marketplace_json "$tmpdir" "0.1.0"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-12 AC4 白名單欄位有效：exit 0"
+assert_output_contains "homepage" "$output" "TC-12 AC4 白名單欄位：輸出驗證通過"
+rm -rf "$tmpdir"
+
+# ── TC-13: AC4 WARNING — plugin.json 中非白名單欄位 ────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "test-plugin",
+  "version": "0.1.0",
+  "description": "Test",
+  "author": "Author",
+  "unknownField": "value"
+}
+EOF
+write_valid_marketplace_json "$tmpdir" "0.1.0"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-13 AC4 非白名單欄位：exit 0（WARNING 不影響 exit code）"
+assert_output_contains "WARNING" "$output" "TC-13 AC4 非白名單欄位：輸出含 WARNING 標記"
+assert_output_contains "unknownField" "$output" "TC-13 AC4 非白名單欄位：輸出標明無效欄位"
+rm -rf "$tmpdir"
+
+# ── TC-14: 所有必填欄位缺失 ──────────────────────────────────────────────
+tmpdir=$(setup_test_env)
+cat > "$tmpdir/.claude-plugin/plugin.json" <<'EOF'
+{
+}
+EOF
+cat > "$tmpdir/.claude-plugin/marketplace.json" <<'EOF'
+{
+}
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_json_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-14 所有必填欄位缺失：exit 1"
+assert_output_contains "缺少必填欄位" "$output" "TC-14 所有必填欄位缺失：輸出含多個錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── NFR1: 執行時間 < 5 秒 ──────────────────────────────────────────────────
+tmpdir=$(setup_test_env)
+write_valid_plugin_json "$tmpdir" "0.1.0"
+write_valid_marketplace_json "$tmpdir" "0.1.0"
+start_time=$(date +%s)
+cd "$tmpdir"
+bash "$VALIDATE_SCRIPT" > /tmp/validate_json_output.txt 2>&1 || true
+cd "$REPO_ROOT"
+end_time=$(date +%s)
+duration=$((end_time - start_time))
+
+if [ "$duration" -lt 5 ]; then
+  pass "NFR1：執行時間 $duration 秒 < 5 秒"
+else
+  fail "NFR1：執行時間 $duration 秒 >= 5 秒"
+fi
+rm -rf "$tmpdir"
+
+echo ""
+echo "=============================="
+echo " 結果：PASS=$PASS  FAIL=$FAIL"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test-validate-skills.sh
+++ b/tests/test-validate-skills.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# tests/test-validate-skills.sh
+# Story #838：Skill 定義驗證 — 測試套件
+#
+# 驗證 scripts/validate-skills.sh 的行為符合 AC1-AC5
+# - AC1：掃描 skills/ 下所有子目錄
+# - AC2：驗證每個 Skill 目錄下有 SKILL.md 且含 name、description 欄位
+# - AC3：驗證 name 值與目錄名稱完全一致（大小寫敏感）
+# - AC4：空目錄或缺少 SKILL.md 報錯
+# - AC5：exit 0 通過，exit 1 失敗
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATE_SCRIPT="${REPO_ROOT}/scripts/validate-skills.sh"
+PASS=0
+FAIL=0
+
+# Helper functions
+pass() {
+  echo "[PASS] $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_exit_code() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label (期望 exit=$expected，實際 exit=$actual)"
+  fi
+}
+
+assert_output_contains() {
+  local needle="$1"
+  local haystack="$2"
+  local label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    pass "$label"
+  else
+    fail "$label (輸出中找不到「$needle」)"
+  fi
+}
+
+# Setup temporary test environment
+setup_test_env() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/skills"
+  echo "$tmpdir"
+}
+
+# Write a valid SKILL.md file
+write_valid_skill() {
+  local dir="$1"
+  local name="$2"
+  cat > "$dir/skills/${name}/SKILL.md" <<EOF
+---
+name: $name
+description: A test skill for $name
+---
+
+# $name
+
+This is a test skill.
+EOF
+}
+
+# Run validate script and return exit code
+run_validate_test() {
+  local tmpdir="$1"
+  local exit_code
+  cd "$tmpdir"
+  if bash "$VALIDATE_SCRIPT" > /tmp/validate_skills_output.txt 2>&1; then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
+  cd "$REPO_ROOT"
+  echo "$exit_code"
+}
+
+echo "=============================="
+echo " Story #838 - test-validate-skills.sh"
+echo "=============================="
+echo ""
+
+# ── Pre-check: validate-skills.sh 必須存在 ────────────────────────────────
+if [[ ! -f "$VALIDATE_SCRIPT" ]]; then
+  fail "scripts/validate-skills.sh 不存在"
+  echo "FAIL: $FAIL / PASS: $PASS"
+  exit 1
+fi
+pass "scripts/validate-skills.sh 存在"
+
+# ── TC-01: AC1 通過 — 掃描並列出所有 Skill 目錄 ───────────────────────────
+tmpdir=$(setup_test_env)
+mkdir -p "$tmpdir/skills/skill-one"
+mkdir -p "$tmpdir/skills/skill-two"
+write_valid_skill "$tmpdir" "skill-one"
+write_valid_skill "$tmpdir" "skill-two"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_skills_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-01 AC1：有效 Skill 掃描 exit 0"
+assert_output_contains "skill-one" "$output" "TC-01 AC1：輸出列出 skill-one 目錄"
+assert_output_contains "skill-two" "$output" "TC-01 AC1：輸出列出 skill-two 目錄"
+assert_output_contains "2 個 Skill" "$output" "TC-01 AC1：輸出顯示正確數量"
+rm -rf "$tmpdir"
+
+# ── TC-02: AC2 FAIL — 缺少 SKILL.md ──────────────────────────────────────
+tmpdir=$(setup_test_env)
+mkdir -p "$tmpdir/skills/empty-skill"
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_skills_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-02 AC4 缺少 SKILL.md：exit 1"
+assert_output_contains "找不到 SKILL.md" "$output" "TC-02 AC4 缺少 SKILL.md：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-03: AC2 FAIL — 缺少 name 欄位 ──────────────────────────────────────
+tmpdir=$(setup_test_env)
+mkdir -p "$tmpdir/skills/no-name-skill"
+cat > "$tmpdir/skills/no-name-skill/SKILL.md" <<'EOF'
+---
+description: A skill without name
+---
+
+# No Name Skill
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_skills_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-03 AC2 缺少 name：exit 1"
+assert_output_contains "缺少 name 欄位" "$output" "TC-03 AC2 缺少 name：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-04: AC2 FAIL — 缺少 description 欄位 ───────────────────────────────
+tmpdir=$(setup_test_env)
+mkdir -p "$tmpdir/skills/no-desc-skill"
+cat > "$tmpdir/skills/no-desc-skill/SKILL.md" <<'EOF'
+---
+name: no-desc-skill
+---
+
+# No Description Skill
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_skills_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-04 AC2 缺少 description：exit 1"
+assert_output_contains "缺少 description 欄位" "$output" "TC-04 AC2 缺少 description：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-05: AC3 FAIL — name 與目錄名稱不一致 ───────────────────────────────
+tmpdir=$(setup_test_env)
+mkdir -p "$tmpdir/skills/my-skill"
+cat > "$tmpdir/skills/my-skill/SKILL.md" <<'EOF'
+---
+name: different-name
+description: A skill with mismatched name
+---
+
+# Different Name
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_skills_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-05 AC3 name 不一致：exit 1"
+assert_output_contains "不一致" "$output" "TC-05 AC3 name 不一致：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-06: AC3 PASS — name 與目錄名稱一致 ──────────────────────────────────
+tmpdir=$(setup_test_env)
+mkdir -p "$tmpdir/skills/matching-skill"
+cat > "$tmpdir/skills/matching-skill/SKILL.md" <<'EOF'
+---
+name: matching-skill
+description: A skill with matching name
+---
+
+# Matching Skill
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_skills_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-06 AC3 name 一致：exit 0"
+assert_output_contains "name 值與目錄名稱一致" "$output" "TC-06 AC3 name 一致：輸出驗證通過"
+rm -rf "$tmpdir"
+
+# ── TC-07: AC3 FAIL — 大小寫不一致（敏感檢查） ──────────────────────────────
+tmpdir=$(setup_test_env)
+mkdir -p "$tmpdir/skills/CaseSensitive"
+cat > "$tmpdir/skills/CaseSensitive/SKILL.md" <<'EOF'
+---
+name: casesensitive
+description: A skill with case mismatch
+---
+
+# Case Mismatch
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_skills_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-07 AC3 大小寫不一致：exit 1"
+assert_output_contains "不一致" "$output" "TC-07 AC3 大小寫不一致：輸出含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── TC-08: 多個 Skill 有效 ──────────────────────────────────────────────────
+tmpdir=$(setup_test_env)
+for i in {1..3}; do
+  mkdir -p "$tmpdir/skills/skill-$i"
+  write_valid_skill "$tmpdir" "skill-$i"
+done
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_skills_output.txt)
+
+assert_exit_code 0 "$exit_code" "TC-08 多個有效 Skill：exit 0"
+assert_output_contains "3 個 Skill" "$output" "TC-08 多個有效 Skill：輸出正確數量"
+rm -rf "$tmpdir"
+
+# ── TC-09: 混合有效和無效 Skill ─────────────────────────────────────────────
+tmpdir=$(setup_test_env)
+mkdir -p "$tmpdir/skills/valid-skill"
+write_valid_skill "$tmpdir" "valid-skill"
+mkdir -p "$tmpdir/skills/invalid-skill"
+cat > "$tmpdir/skills/invalid-skill/SKILL.md" <<'EOF'
+---
+name: wrong-name
+description: Invalid skill
+---
+
+# Invalid
+EOF
+exit_code=$(run_validate_test "$tmpdir")
+output=$(cat /tmp/validate_skills_output.txt)
+
+assert_exit_code 1 "$exit_code" "TC-09 混合有效/無效：exit 1（因為有無效 Skill）"
+assert_output_contains "valid-skill" "$output" "TC-09 混合有效/無效：輸出包含有效 Skill"
+assert_output_contains "不一致" "$output" "TC-09 混合有效/無效：輸出包含錯誤訊息"
+rm -rf "$tmpdir"
+
+# ── NFR1: 執行時間 < 5 秒 ──────────────────────────────────────────────────
+tmpdir=$(setup_test_env)
+for i in {1..5}; do
+  mkdir -p "$tmpdir/skills/perf-skill-$i"
+  write_valid_skill "$tmpdir" "perf-skill-$i"
+done
+start_time=$(date +%s)
+cd "$tmpdir"
+bash "$VALIDATE_SCRIPT" > /tmp/validate_skills_output.txt 2>&1 || true
+cd "$REPO_ROOT"
+end_time=$(date +%s)
+duration=$((end_time - start_time))
+
+if [ "$duration" -lt 5 ]; then
+  pass "NFR1：執行時間 $duration 秒 < 5 秒"
+else
+  fail "NFR1：執行時間 $duration 秒 >= 5 秒"
+fi
+rm -rf "$tmpdir"
+
+echo ""
+echo "=============================="
+echo " 結果：PASS=$PASS  FAIL=$FAIL"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

新增三個驗證腳本的測試套件，提升測試覆蓋率：

- `tests/test-validate-agents.sh` — 24 個測試案例，驗證 Agent 定義格式檢查
- `tests/test-validate-skills.sh` — 23 個測試案例，驗證 Skill 結構完整性
- `tests/test-validate-json.sh` — 34 個測試案例，驗證 JSON 格式校驗

所有測試執行時間 < 5 秒，符合 NFR1 要求。

## Test Plan

- [x] AC1: tests/test-validate-agents.sh — 掃描並驗證 agent 檔案 PASS
- [x] AC2: tests/test-validate-skills.sh — 驗證 skill 目錄結構 PASS
- [x] AC3: tests/test-validate-json.sh — 驗證 JSON schema PASS
- [x] AC4: 所有新測試 exit 0 且 PASS
- [x] NFR1: 執行時間 < 5 秒

Generated with Claude Code