### PR TITLE
feat(sprint-166): 強化流程紀律 — PR 強制化、haiku 路由規則自動化、Backlog 健康觸發、xrefs 測試

### DIFF
--- a/docs/adr/ADR-039-token-cost-routing.md
+++ b/docs/adr/ADR-039-token-cost-routing.md
@@ -89,6 +89,50 @@ model-route sprint-163-metrics tier=1 score=4 model=haiku reason=metrics-calcula
 
 ---
 
+### 決策 2.6：Score 4-5 TEST/DOC/LOG 強制 haiku 規則（#854，Sprint 166）
+
+<!-- #854 retro: haiku 路由比例偏低（18%）— ADR-039 Score 4-5 TEST/DOC 強制 haiku 規則 — Sprint 166 -->
+
+**背景**：Sprint 165 Retro 顯示 haiku 路由比例僅 18%（目標 >= 30%），Planning 階段 Risk Scoring 偏保守，Score 4-5 的低風險任務仍被路由至 sonnet。
+
+**新增強制規則**：
+
+<HARD-RULE id="haiku-force-route-456">
+**Score 4-5 且 Story Type ∈ {TEST, DOC, LOG} 時，一律路由至 haiku（Tier 1），不依賴 agent 主觀判斷。**
+
+此規則優先於 agent 評分結果。Planning 時若 Story 符合條件但被評為 Tier 2+，PO 必須降級至 haiku 並說明理由。
+</HARD-RULE>
+
+**識別規則**：
+
+| 條件 | Story Type 判斷標準 |
+|------|------------------|
+| `TEST` | 標題含「test:」前綴、或 AC 主要內容為新建/修改 tests/ 腳本 |
+| `DOC` | 標題含「doc:」「retro:」前綴、或 AC 主要為修改 .md 文件 |
+| `LOG` | Story 主要輸出為 log 記錄、metrics 計算或報告生成 |
+
+**防 over-correction 規則**（AC4 — QA 建議補充）：
+
+此強制規則不影響 Score >= 7 的 Story 路由。Score >= 7 的 Story 仍依動態評分路由至 sonnet 或 opus，不被此規則強制降至 haiku。
+
+**RICE Score 與路由 Tier 交叉審查（Sprint Planning PO Round 新增步驟）**：
+
+Sprint Planning PO Round 完成 Story 選取後，計算本 Sprint haiku 比例預估值：
+```
+haiku_ratio = haiku_stories / total_stories
+```
+若 `haiku_ratio < 20%`，PO 必須逐一說明 Tier 2+ 選用理由，確認無可降級的 TEST/DOC/LOG Stories 被誤評。
+
+**路由記錄範例（新增規則）**：
+```
+model-route #853 tier=1 score=5 model=haiku reason=score-4-5+story-type=DOC(retro:)
+model-route #840 tier=1 score=6 model=haiku reason=score-4-6+story-type=TEST(tests/)
+```
+
+**預期效果**：haiku 比例從 18% 提升至 >= 30%（Sprint 166 起生效）。
+
+---
+
 ### 決策 3：路由決策的可觀測性
 
 **路由記錄位置**：`docs/km/Metrics_Log.md` 每個 Sprint 的 token 消耗紀錄中，新增 `model_routing` 欄位：

--- a/skills/cruise/references/po-patrol.md
+++ b/skills/cruise/references/po-patrol.md
@@ -772,3 +772,49 @@ bash "${REPO_PATH}/scripts/backlog-health-report.sh" \
 | `TRIGGER` | sprint-candidate 計數 < 閾值，建議補充 Backlog |
 
 支援 `--last-n <N>` 指定查看天數（預設 7）。使用 jq 解析 JSONL，不依賴 Python（NFR1）。
+
+## Backlog 健康度每日巡查 Warning（#855 AC2，Sprint 166）
+
+<!-- #855 retro: Backlog 候選不足 — 自動補充觸發機制 — Sprint 166 -->
+
+每個 PO Cruise patrol cycle 中，backlog-health-report.sh 輸出後自動判斷是否需輸出警告：
+
+```bash
+CURRENT_COUNT=$(gh issue list -R ${OWNER_REPO} --label sprint-candidate --state open --json number 2>/dev/null | jq 'length' || echo "UNKNOWN")
+WARN_THRESHOLD="${BACKLOG_WARN_THRESHOLD:-8}"  # 讀取 .claude/shikigami.local.md，預設 8
+
+if [ "$CURRENT_COUNT" != "UNKNOWN" ] && [ "$CURRENT_COUNT" -lt "$WARN_THRESHOLD" ]; then
+  echo "[BACKLOG-DAILY-WARN] sprint-candidate=$CURRENT_COUNT < 每日警戒閾值=$WARN_THRESHOLD，建議補充 Backlog"
+  log action: "backlog-daily-warn (sprint_candidate=${CURRENT_COUNT}, threshold=${WARN_THRESHOLD})"
+fi
+```
+
+**冪等性（AC4 — QA 建議補充）**：同一 cycle 內 [BACKLOG-DAILY-WARN] 僅輸出一次，不重複觸發 Discovery（Discovery 觸發依賴 [BACKLOG-REPLENISH-TRIGGER] 信號機制，由 Sprint Review §2.7 控制）。
+
+## Sprint Planning 前 48h Backlog 健康度提醒（#855 AC3，Sprint 166）
+
+<!-- #855 AC3：Sprint Planning 前 48h 若候選 < 容量上限，自動提醒 PO 補充 -->
+
+當 PO patrol 偵測到「距上次 Sprint Review 時間 >= 6 天」（即 Sprint 週期近末），且 sprint-candidate 數量 < Sprint 容量上限（預設 6 pts，可從 calculate-sprint-capacity.sh 取得）時，自動在最新 sprint-candidate Issue 留言提醒：
+
+```bash
+# 計算距上次 Sprint Review 的天數（從 docs/sprints/sprint-checkpoint.json 讀取）
+LAST_REVIEW_DATE=$(jq -r '.updated_at // empty' docs/sprints/sprint-checkpoint.json 2>/dev/null | cut -c1-10)
+DAYS_SINCE_REVIEW=$(( ( $(date +%s) - $(date -d "${LAST_REVIEW_DATE}" +%s 2>/dev/null || echo 0) ) / 86400 ))
+
+# 取得 Sprint 容量上限
+CAPACITY_UPPER=$(bash scripts/calculate-sprint-capacity.sh 2>/dev/null | grep -oP '(?<=range: \d-)\d+' || echo "6")
+
+if [ "$DAYS_SINCE_REVIEW" -ge 6 ] && [ "$CURRENT_COUNT" -lt "$CAPACITY_UPPER" ]; then
+  FIRST_CANDIDATE=$(gh issue list -R ${OWNER_REPO} --label sprint-candidate --state open --json number --jq '.[0].number' 2>/dev/null)
+  if [ -n "$FIRST_CANDIDATE" ]; then
+    printf '%s\n' "## [Backlog 健康度提醒]" "" \
+      "Sprint 週期接近尾聲（距上次 Review ${DAYS_SINCE_REVIEW} 天），sprint-candidate 數量 ${CURRENT_COUNT} < Sprint 容量上限 ${CAPACITY_UPPER}。" "" \
+      "建議 PO 在下次 Sprint Planning 前補充候選項目，確保有足夠 Backlog 支撐 Sprint 容量。" > /tmp/backlog-remind-body.txt
+    gh issue comment "${FIRST_CANDIDATE}" -R ${OWNER_REPO} --body-file /tmp/backlog-remind-body.txt 2>/dev/null || true
+    log action: "backlog-48h-remind (sprint_candidate=${CURRENT_COUNT}, capacity_upper=${CAPACITY_UPPER}, days=${DAYS_SINCE_REVIEW})"
+  fi
+fi
+```
+
+**非阻塞**：gh API 失敗時靜默跳過，不中斷 patrol cycle。使用 `--body-file` 模式避免特殊字符 YAML parse error（CLAUDE.md 紅線 13）。

--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -453,6 +453,12 @@ DESIGN Story 優先執行，依賴其 Contract 的 FEATURE Story 須等 Contract
 例外：標注為 [SPIKE] 的探索性任務可豁免，但進入正式開發時必須補測試。
 </HARD-GATE>
 
+<HARD-GATE>
+**所有 Story（含 test-only Story）交付必須透過 Pull Request，不得直推 main。**
+Sprint Review 時將逐一確認每個 Story 是否有對應 PR；若無，標記 `[PROCESS-VIOLATION]`。
+此規則自 Sprint 166 起強制生效（Sprint 165 Retro Action #853）。
+</HARD-GATE>
+
 Story Type 對 TDD 豁免與 Review 策略的影響（FEATURE 必須 TDD；DESIGN 豁免；INFRA 條件性；SECURITY 強制；INTEGRATION 必須；RESEARCH 豁免）。doc-only Story 優先判定 TDD 豁免，但雙階段 Review 維持必要。
 
 > 詳見 `references/hard-gates-tdd.md`（L-size 審查增強、§8.1 安全審查觸發條件）

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -690,6 +690,7 @@ Security Self-Review — {story_id}
 | 設定 | 無硬編碼金鑰，配置透過環境變數管理 | [ ] |
 | 反回歸 | 既有測試全部仍然通過（0 regression） | [ ] |
 | 技術債 | 取捷徑情況已用 `[TECH-DEBT]` 標記，並更新 Registry（若無則 N/A） | [ ] |
+| **PR 流程** | **所有 Story（含 test-only）交付必須透過 PR，不得直推 main**（Sprint 165 Retro #853） | [ ] |
 
 ---
 

--- a/skills/sprint-planning/SKILL.md
+++ b/skills/sprint-planning/SKILL.md
@@ -41,6 +41,7 @@ Sprint Planning 是每個 Sprint 週期的起點儀式。由 **PO** 主持，**A
 - [ ] 角色權重調整檢查（詳見 §7）*(慢想)*
 - [ ] **PO** 掃描 GitHub open issues，對未分類 issues 執行 Triage（<!-- Claude Code -->invoke shikigami:issue-management Triage<!-- /Claude Code --><!-- OpenCode -->使用 issue-management skill<!-- /OpenCode -->）
 - [ ] **Pre-flight Backlog 健康度檢查**：執行 `gh issue list --label "sprint-candidate" --state open --json number | jq length` 取得 `BACKLOG_COUNT`；若 `BACKLOG_COUNT < 5`，輸出 `[BACKLOG-WARN] sprint-candidate 不足 (N < 5)，建議先執行 backlog-management` 並自動觸發 `/backlog-management` skill 補充；若 `BACKLOG_COUNT >= 5`，輸出 `[BACKLOG-OK] sprint-candidate: N 個，健康度正常` 並繼續
+- [ ] **Pre-flight Model Routing 健康度掃描**（ADR-039 決策 2.6，#854，Sprint 166）：執行 `bash scripts/routing-stats.sh 2>/dev/null | grep -q "\[OVER-ROUTING-WARN\]"` 判斷是否存在 routing 警告；若存在 `[OVER-ROUTING-WARN]`，輸出提示 `[ROUTING-SCAN-TRIGGER] 檢測到 haiku 比例偏低，本次 Planning 啟動 haiku 適用場景擴充掃描`，PO 在 Story 選取後額外執行 RICE Score 與 Routing Tier 交叉審查（詳見 po-prompt.md §haiku 交叉審查）；若無警告或腳本不存在，靜默略過（非阻塞）
 - [ ] 記錄 Sprint Planning 開始時間：`START_TIME=$(date '+%Y-%m-%dT%H:%M+08:00')`
 - [ ] **PO** 執行 Backlog 排序與 Story 選取（詳見 [po-prompt.md](./references/po-prompt.md) Round 1）
 - [ ] **PO Round 1 ADR 自動納入**（#456）：PO 選取 Story 後，掃描 Architect 技術評估的 ADR 欄位；若有標注「已補建 #N（RESEARCH）」的 ADR Story，自動將該 ADR RESEARCH Story 一併選入同一 Sprint（AC2）

--- a/skills/sprint-planning/references/po-prompt.md
+++ b/skills/sprint-planning/references/po-prompt.md
@@ -94,6 +94,28 @@ PO 在 Sprint Planning Round 1 掃描 Backlog 時，**必須**確認每個候選
 
 逐一列出每個 Story 預計修改的主要檔案，判斷哪些 Story 修改不同檔案（可平行執行），哪些 Story 修改相同檔案（有衝突，需順序執行）。
 
+### RICE Score 與路由 Tier 交叉審查（ADR-039 決策 2.6，#854，Sprint 166）
+
+<!-- #854 retro: haiku 路由比例偏低 — ADR-039 Score 4-5 TEST/DOC 強制 haiku 規則 — Sprint 166 -->
+
+PO 完成 Story 選取後，必須執行 haiku 比例交叉審查：
+
+1. 對每個選入 Story，評估 Story Type（TEST / DOC / LOG / FEATURE / INFRA...）與風險分數
+2. Score 4-5 且 Story Type ∈ {TEST, DOC, LOG} → 強制路由至 haiku（Tier 1），不可依賴 agent 主觀判斷
+3. 計算 haiku 預估比例：`haiku_ratio = haiku_stories / total_stories`
+4. 若 `haiku_ratio < 20%`，PO 必須逐一說明 Tier 2+ 選用理由，確認無可降級 Stories
+
+**AC2 交叉審查輸出格式**（加入 Round 1 回傳表格）：
+
+```markdown
+| Story ID | 標題 | 估點 | AC 確認結果 | 獨立性評估 | Story Type | Risk Score | Routing Tier |
+|----------|------|------|------------|-----------|-----------|-----------|-------------|
+| US-#N    | ...  | S    | PASS       | 獨立      | TEST      | 5         | haiku（強制） |
+| US-#M    | ...  | M    | PASS       | 獨立      | FEATURE   | 8         | sonnet       |
+```
+
+若 `haiku_ratio < 20%`：輸出 `[HAIKU-RATIO-WARN] haiku 比例 X% < 20%，請確認是否有可降級 Stories`
+
 ### Round 1 回傳格式
 
 ```markdown

--- a/skills/sprint-review/SKILL.md
+++ b/skills/sprint-review/SKILL.md
@@ -97,6 +97,24 @@ Read: contracts/numerical-consistency-contract.md（若本 Sprint 有數值修�
 **§2.6 完成後**：Review subagent 立即寫入同步 signal（`docs/sprints/.review-signal-<SESSION_ID>`）。
 
 
+## 2.64 PR 流程合規檢查（Sprint 165 Retro #853）
+
+在 §2.6 Issue 狀態回寫後，對本 Sprint 每個 Story 確認是否有對應 PR：
+
+```bash
+for story_id in ${SPRINT_STORY_IDS}; do
+  PR_COUNT=$(gh pr list -R ${OWNER_REPO} --state merged --search "#${story_id}" --json number | jq length 2>/dev/null || echo "0")
+  if [ "$PR_COUNT" -eq 0 ]; then
+    echo "[PROCESS-VIOLATION] Story #${story_id} 未透過 PR 交付（直推 main），違反 Sprint 165 Retro #853 規範"
+    # 記錄至 Sprint Review 會議紀錄 process_violations 欄位
+  else
+    echo "[PR-COMPLIANCE-OK] Story #${story_id} 有對應 PR"
+  fi
+done
+```
+
+**非阻塞**：`[PROCESS-VIOLATION]` 僅記錄，不阻擋 Sprint Review 完成。但違規次數需列入下次 Retro 討論。
+
 ## 2.65 CRITICAL 決策記錄（#779 AC2）
 
 <!-- #779 quality-gate 決策記錄機制 — Sprint 159 -->

--- a/tests/test-validate-xrefs.sh
+++ b/tests/test-validate-xrefs.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# tests/test-validate-xrefs.sh
+# Story #840：validate-xrefs.sh 自動化測試
+#
+# 驗證 scripts/validate-xrefs.sh 的行為符合 AC1-AC4：
+# - AC1：掃描所有 .md 的 shikigami:[a-z-]+ 引用
+# - AC2：測試涵蓋有效引用（PASS）和無效引用（FAIL）場景
+# - AC3：使用 fixture 目錄模擬 skills/agents 結構
+# - AC4：測試 PASS 且 exit 0
+# NFR1：測試執行時間 < 3 秒（透過 fixture 隔離避免全 repo 掃描）
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATE_SCRIPT="${REPO_ROOT}/scripts/validate-xrefs.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "[PASS] $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_exit_code() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label (期望 exit=$expected，實際 exit=$actual)"
+  fi
+}
+
+assert_output_contains() {
+  local needle="$1"
+  local haystack="$2"
+  local label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    pass "$label"
+  else
+    fail "$label (輸出中找不到「$needle」)"
+  fi
+}
+
+assert_output_not_contains() {
+  local needle="$1"
+  local haystack="$2"
+  local label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    fail "$label (輸出中不應出現「$needle」)"
+  else
+    pass "$label"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 前置檢查：validate-xrefs.sh 必須存在
+# ---------------------------------------------------------------------------
+if [[ ! -f "$VALIDATE_SCRIPT" ]]; then
+  echo "[FATAL] scripts/validate-xrefs.sh 不存在，無法執行測試"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture 目錄建立（AC3）
+# 建立最小 repo 結構，讓腳本在 fixture 內執行以控制測試時間（NFR1）
+# ---------------------------------------------------------------------------
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+# 建立 fixture 目錄結構（模擬真實 repo）
+mkdir -p "$FIXTURE_DIR/scripts/lib"
+mkdir -p "$FIXTURE_DIR/skills/sprint-planning"
+mkdir -p "$FIXTURE_DIR/skills/sprint-execution"
+mkdir -p "$FIXTURE_DIR/agents"
+mkdir -p "$FIXTURE_DIR/commands"
+
+# 複製腳本與 lib（讓腳本在 fixture 內可執行）
+cp "$VALIDATE_SCRIPT" "$FIXTURE_DIR/scripts/validate-xrefs.sh"
+cp "$REPO_ROOT/scripts/lib/validate-helpers.sh" "$FIXTURE_DIR/scripts/lib/validate-helpers.sh"
+
+# 建立 SKILL.md 供有效引用使用（fixture 內）
+touch "$FIXTURE_DIR/skills/sprint-planning/SKILL.md"
+touch "$FIXTURE_DIR/skills/sprint-execution/SKILL.md"
+
+# ---------------------------------------------------------------------------
+# TEST 1：腳本在 skills/ 目錄存在時能正常執行（AC1 基礎可執行性）
+# 在 fixture clean env 中執行（僅含有效引用），驗證 exit 0
+# ---------------------------------------------------------------------------
+cat > "$FIXTURE_DIR/valid-doc.md" << 'EOF'
+invoke shikigami:sprint-planning and shikigami:sprint-execution
+EOF
+OUTPUT=$(cd "$FIXTURE_DIR" && bash scripts/validate-xrefs.sh 2>&1)
+EXIT_CODE_ACTUAL=$?
+assert_exit_code 0 "$EXIT_CODE_ACTUAL" "TC1: fixture 環境中無 broken reference，exit 0"
+
+# ---------------------------------------------------------------------------
+# TEST 2：有效引用通過（AC2 PASS 場景）
+# ---------------------------------------------------------------------------
+assert_output_not_contains "broken reference 'shikigami:sprint-planning'" "$OUTPUT" "TC2: sprint-planning 引用為有效引用，不應出現 broken reference"
+assert_output_not_contains "broken reference 'shikigami:sprint-execution'" "$OUTPUT" "TC2: sprint-execution 引用為有效引用，不應出現 broken reference"
+
+# ---------------------------------------------------------------------------
+# TEST 3：輸出摘要包含掃描統計（AC1 輸出格式）
+# ---------------------------------------------------------------------------
+assert_output_contains "掃描" "$OUTPUT" "TC3: 輸出包含掃描統計摘要"
+
+# ---------------------------------------------------------------------------
+# TEST 4：exit code 語意正確（AC4）
+# exit 0 = 無 broken reference（fixture clean）
+# ---------------------------------------------------------------------------
+assert_exit_code 0 "$EXIT_CODE_ACTUAL" "TC4: fixture clean 環境 exit 0（無 broken reference）"
+
+# ---------------------------------------------------------------------------
+# TEST 5：broken reference 偵測（AC2 FAIL 場景）
+# 在 fixture 中加入引用不存在 skill 的 .md
+# ---------------------------------------------------------------------------
+cat > "$FIXTURE_DIR/broken-doc.md" << 'EOF'
+shikigami:nonexistent-skill-zzzzzz
+EOF
+BROKEN_OUTPUT=$(cd "$FIXTURE_DIR" && bash scripts/validate-xrefs.sh 2>&1)
+BROKEN_EXIT=$?
+
+assert_output_contains "broken reference 'shikigami:nonexistent-skill-zzzzzz'" "$BROKEN_OUTPUT" "TC5: broken reference 被正確偵測並輸出錯誤訊息"
+assert_exit_code 1 "$BROKEN_EXIT" "TC5: broken reference 存在時 exit 1"
+
+# 清除 broken-doc 讓後續測試乾淨
+rm -f "$FIXTURE_DIR/broken-doc.md"
+
+# ---------------------------------------------------------------------------
+# TEST 6：placeholder 引用 shikigami:xxx 被跳過（邊界條件）
+# ---------------------------------------------------------------------------
+cat > "$FIXTURE_DIR/placeholder-doc.md" << 'EOF'
+invoke shikigami:xxx as placeholder
+EOF
+PLACEHOLDER_OUTPUT=$(cd "$FIXTURE_DIR" && bash scripts/validate-xrefs.sh 2>&1)
+PLACEHOLDER_EXIT=$?
+rm -f "$FIXTURE_DIR/placeholder-doc.md"
+
+assert_output_not_contains "broken reference 'shikigami:xxx'" "$PLACEHOLDER_OUTPUT" "TC6: placeholder shikigami:xxx 被正確跳過，不報錯"
+assert_exit_code 0 "$PLACEHOLDER_EXIT" "TC6: placeholder 不觸發 broken reference，exit 0"
+
+# ---------------------------------------------------------------------------
+# 測試結果摘要
+# ---------------------------------------------------------------------------
+echo ""
+echo "=============================="
+echo "tests/test-validate-xrefs.sh"
+echo "PASS: $PASS  FAIL: $FAIL"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Sprint 166 Stories

本 PR 涵蓋 Sprint 166 全部 4 個 Stories（6 pts）：

### #853 retro: 測試腳本 Story 必須走 PR 流程（1pt）

- `skills/sprint-execution/SKILL.md`：新增 HARD-GATE，所有 Story（含 test-only）交付必須透過 PR，不得直推 main，Sprint 166 起強制生效
- `skills/sprint-execution/story-lifecycle-prompt.md`：DoD 表格新增 PR 流程欄位
- `skills/sprint-review/SKILL.md`：新增 §2.64 PR 流程合規檢查，無 PR 標記 [PROCESS-VIOLATION]

### #854 retro: haiku 路由比例偏低 — ADR-039 Score 4-5 TEST/DOC 強制 haiku 規則（2pts）

- `docs/adr/ADR-039-token-cost-routing.md`：新增決策 2.6，Score 4-5 且 Story Type ∈ {TEST, DOC, LOG} 強制路由 haiku，含防 over-correction 規則（Score >= 7 不受影響）
- `skills/sprint-planning/references/po-prompt.md`：新增 RICE Score 與路由 Tier 交叉審查步驟，haiku_ratio < 20% 時輸出 [HAIKU-RATIO-WARN]
- `skills/sprint-planning/SKILL.md`：Pre-flight 加入 Model Routing 健康度掃描，[OVER-ROUTING-WARN] 時自動觸發交叉審查

### #855 retro: Backlog 候選不足 — 自動補充觸發機制（2pts）

- `skills/cruise/references/po-patrol.md`：新增每日 Backlog 健康度 warning（< 8 時輸出 [BACKLOG-DAILY-WARN]）和 Sprint Planning 前 48h 留言提醒機制

### #840 feat: validate-xrefs.sh 自動化測試（1pt）

- `tests/test-validate-xrefs.sh`：新建，6 個 TC，9 PASS，0 FAIL
- 使用 fixture 隔離（NFR1：0.098s << 3s）
- 涵蓋有效引用 PASS、broken reference FAIL、placeholder 跳過、exit code 語意等場景

## 驗證

- validate-skills.sh：31 Skills PASS
- validate-agents.sh：8 Agents PASS
- validate-json.sh：PASS
- validate-version.sh：PASS
- test-validate-xrefs.sh：9/9 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)