### PR TITLE
feat(#899): 為 #894 #895 #886 補充非功能性需求欄位

### DIFF
--- a/docs/sprints/.story-899-done
+++ b/docs/sprints/.story-899-done
@@ -1,0 +1,5 @@
+story_id: 899
+sprint: 171
+status: DONE
+completed_at: 2026-03-26T17:10+08:00
+deliverable: GitHub Issue body edits (#894, #895, #886)


### PR DESCRIPTION
feat(#899): 為 #894 #895 #886 補充非功能性需求欄位

## Summary

- #894 validate-a2a-schema.sh 型別文件：新增 `## 非功能性需求` 段落（NFR1 freshness + NFR2 performance）
- #895 routing-history schema 規格：新增 `## 非功能性需求` 段落（NFR1 completeness + NFR2 reliability）
- #886 驗證腳本整合測試補齊：新增 NFR1-3（reliability/performance/completeness）+ RICE Score 3.2

三個 Issues 在 Sprint 170 Planning 因缺少非功能性需求欄位被退回，本 Story 補齊後可在 Sprint 172 Planning 正常進入評估。

## AC Checklist

- [x] AC1: #894 已補充 NFR 段落
- [x] AC2: #895 已補充 NFR 段落
- [x] AC3: #886 已補充 NFR + RICE Score
- [x] AC4: 三個 Issues 可在下一 Sprint Planning 正常進入評估

Closes #899
