### PR TITLE
feat(#869): Sprint Metrics 歷史趨勢儀表板 — sprint-metrics-trend.sh

### DIFF
--- a/scripts/sprint-metrics-trend.sh
+++ b/scripts/sprint-metrics-trend.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scripts/sprint-metrics-trend.sh
+# Story #869: Sprint Metrics 歷史趨勢儀表板
+# 掃描 docs/km/metrics-log/*.md，輸出多 Sprint Velocity/Completion/SPACE 趨勢
+#
+# Usage:
+#   bash scripts/sprint-metrics-trend.sh [--last N]
+
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+METRICS_DIR="${METRICS_DIR:-$REPO_ROOT/docs/km/metrics-log}"
+LAST_N=5
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --last) LAST_N="${2:-5}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# ── 掃描 metrics-log 檔案 ────────────────────────────────────────────────────
+
+declare -a SPRINT_NUMS=()
+declare -A SPRINT_VEL=()
+declare -A SPRINT_COMP=()
+declare -A SPRINT_SPACE=()
+declare -A SEEN_SPRINTS=()
+
+shopt -s nullglob
+for file in "$METRICS_DIR"/*.md; do
+  [[ -f "$file" ]] || continue
+
+  sprint_num=$(grep -oE '(Sprint|sprint)[[:space:]]+([0-9]+)' "$file" 2>/dev/null | grep -oE '[0-9]+' | head -1 || true)
+  [[ -z "$sprint_num" ]] && continue
+  # Skip duplicates — keep first occurrence (oldest file)
+  [[ -n "${SEEN_SPRINTS[$sprint_num]:-}" ]] && continue
+  SEEN_SPRINTS["$sprint_num"]=1
+
+  velocity=$(grep -iE 'velocity[[:space:]]*\|[[:space:]]*[0-9]' "$file" 2>/dev/null | grep -oE '[0-9]+[[:space:]]*pts' | grep -oE '^[0-9]+' | head -1 || true)
+  [[ -z "$velocity" ]] && velocity=$(grep -iE 'velocity.*[0-9]+[[:space:]]*pts' "$file" 2>/dev/null | grep -oE '[0-9]+[[:space:]]*pts' | grep -oE '^[0-9]+' | head -1 || true)
+
+  completion=$(grep -iE '完成率|completion.rate' "$file" 2>/dev/null | grep -oE '[0-9]+%' | head -1 | tr -d '%' || true)
+
+  space=$(grep -iE 'overall[[:space:]]*\|[[:space:]]*[0-9]' "$file" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1 || true)
+  [[ -z "$space" ]] && space=$(grep -iE 'space' "$file" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1 || true)
+
+  SPRINT_NUMS+=("$sprint_num")
+  SPRINT_VEL["$sprint_num"]="${velocity:-}"
+  SPRINT_COMP["$sprint_num"]="${completion:-}"
+  SPRINT_SPACE["$sprint_num"]="${space:-}"
+done
+shopt -u nullglob
+
+# 排序
+if [[ "${#SPRINT_NUMS[@]}" -eq 0 ]]; then
+  echo "（無 metrics-log 資料）"
+  exit 0
+fi
+
+IFS=$'\n' SORTED_NUMS=($(printf '%s\n' "${SPRINT_NUMS[@]}" | sort -n))
+unset IFS
+
+# 限制最近 N 個
+TOTAL="${#SORTED_NUMS[@]}"
+if [[ "$TOTAL" -gt "$LAST_N" ]]; then
+  START=$(( TOTAL - LAST_N ))
+  SORTED_NUMS=("${SORTED_NUMS[@]:$START}")
+fi
+
+# ── 輸出趨勢表 ───────────────────────────────────────────────────────────────
+
+printf "%-10s %-10s %-12s %-8s %s\n" "Sprint" "Velocity" "Completion" "SPACE" "Trend"
+printf "%-10s %-10s %-12s %-8s %s\n" "------" "--------" "----------" "-----" "-----"
+
+PREV_VEL=""
+
+for num in "${SORTED_NUMS[@]}"; do
+  [[ -z "$num" ]] && continue
+  vel="${SPRINT_VEL[$num]:-}"
+  comp="${SPRINT_COMP[$num]:-}"
+  space="${SPRINT_SPACE[$num]:-}"
+
+  # 計算趨勢（僅在兩者都為數字時比較）
+  trend=""
+  if [[ -n "$vel" && -n "$PREV_VEL" ]] && \
+     [[ "$vel" =~ ^[0-9]+$ ]] && [[ "$PREV_VEL" =~ ^[0-9]+$ ]]; then
+    if (( vel > PREV_VEL )); then
+      trend="[TREND-UP]"
+    elif (( vel < PREV_VEL )); then
+      trend="[TREND-DOWN]"
+    else
+      trend="[TREND-STABLE]"
+    fi
+  fi
+
+  vel_display="${vel:+${vel}pts}"
+  comp_display="${comp:+${comp}%}"
+
+  printf "| %-8s | %-8s | %-10s | %-6s | %s\n" \
+    "Sprint $num" "${vel_display:---}" "${comp_display:---}" "${space:---}" "$trend"
+
+  [[ -n "$vel" ]] && PREV_VEL="$vel" || true
+done
+
+echo ""
+echo "（顯示最近 ${#SORTED_NUMS[@]} 個 Sprint；--last N 可調整）"

--- a/tests/test-sprint-metrics-trend.sh
+++ b/tests/test-sprint-metrics-trend.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# tests/test-sprint-metrics-trend.sh
+# Story #869: Sprint Metrics 歷史趨勢儀表板 — 單元測試
+# TDD: 測試先於實作
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT="$REPO_ROOT/scripts/sprint-metrics-trend.sh"
+FIXTURE_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$FIXTURE_DIR"; }
+trap cleanup EXIT
+
+ok()   { echo "[PASS] $1"; ((PASS++)) || true; }
+fail() { echo "[FAIL] $1"; ((FAIL++)) || true; }
+
+# ── Fixture 建立 ──────────────────────────────────────────────────────────────
+
+mk_metrics() {
+  local sprint="$1" velocity="$2" completion="$3" space="${4:-4.5}"
+  cat > "$FIXTURE_DIR/sprint-${sprint}-metrics.md" << EOF
+# Sprint ${sprint} Metrics Log
+
+**Sprint**：${sprint}
+**日期**：2026-01-01
+
+## Sprint Metrics
+
+| 指標 | 值 |
+|------|-----|
+| Velocity | ${velocity} pts |
+| 完成率 | ${completion}%（auto） |
+| Sprint Goal 達成 | YES |
+
+## SPACE Score
+
+| Dimension | Score |
+|-----------|-------|
+| Overall | ${space} |
+EOF
+}
+
+mk_metrics 160 6 100 4.5
+mk_metrics 161 7 100 4.8
+mk_metrics 162 5 83  4.2
+mk_metrics 163 6 100 4.6
+mk_metrics 164 8 100 5.0
+mk_metrics 165 6 100 4.7
+
+# ── Test 1: 腳本存在且可執行 ──────────────────────────────────────────────────
+if [[ -x "$SCRIPT" ]]; then
+  ok "T1: script exists and is executable"
+else
+  fail "T1: script not found or not executable: $SCRIPT"
+fi
+
+# ── Test 2: 基本輸出包含 Velocity 欄位 ───────────────────────────────────────
+OUTPUT=$(METRICS_DIR="$FIXTURE_DIR" bash "$SCRIPT" 2>/dev/null)
+if echo "$OUTPUT" | grep -qi "velocity\|Velocity\|速度"; then
+  ok "T2: output contains Velocity column"
+else
+  fail "T2: output missing Velocity column"
+fi
+
+# ── Test 3: --last N 限制輸出數量 ─────────────────────────────────────────────
+OUTPUT_L3=$(METRICS_DIR="$FIXTURE_DIR" bash "$SCRIPT" --last 3 2>/dev/null)
+SPRINT_LINES=$(echo "$OUTPUT_L3" | grep -cE "Sprint [0-9]+" 2>/dev/null || true)
+if [[ "$SPRINT_LINES" -le 3 ]]; then
+  ok "T3: --last 3 limits to <= 3 sprint rows"
+else
+  fail "T3: --last 3 returned $SPRINT_LINES sprint rows (expected <= 3)"
+fi
+
+# ── Test 4: TREND-UP 偵測（前段低後段高）────────────────────────────────────
+# Sprint 164=8 > Sprint 163=6，應觸發 TREND-UP
+if echo "$OUTPUT" | grep -q "TREND-UP"; then
+  ok "T4: [TREND-UP] detected when velocity increases"
+else
+  fail "T4: [TREND-UP] not found despite velocity increase"
+fi
+
+# ── Test 5: TREND-DOWN 偵測 ───────────────────────────────────────────────────
+# Sprint 162=5 < Sprint 161=7，應觸發 TREND-DOWN
+if echo "$OUTPUT" | grep -q "TREND-DOWN"; then
+  ok "T5: [TREND-DOWN] detected when velocity decreases"
+else
+  fail "T5: [TREND-DOWN] not found despite velocity decrease"
+fi
+
+# ── Test 6: 空目錄優雅降級 ────────────────────────────────────────────────────
+EMPTY_DIR=$(mktemp -d)
+EXIT_CODE=0
+METRICS_DIR="$EMPTY_DIR" bash "$SCRIPT" 2>/dev/null || EXIT_CODE=$?
+rmdir "$EMPTY_DIR"
+if [[ "$EXIT_CODE" -eq 0 ]]; then
+  ok "T6: empty metrics dir exits gracefully"
+else
+  fail "T6: empty metrics dir caused crash (exit $EXIT_CODE)"
+fi
+
+# ── Test 7: 執行時間 < 3s（NFR1） ────────────────────────────────────────────
+START_NS=$(date +%s%N 2>/dev/null || echo 0)
+METRICS_DIR="$FIXTURE_DIR" bash "$SCRIPT" >/dev/null 2>&1
+END_NS=$(date +%s%N 2>/dev/null || echo 3000000000)
+ELAPSED_MS=$(( (END_NS - START_NS) / 1000000 ))
+if [[ "$ELAPSED_MS" -lt 3000 ]]; then
+  ok "T7: execution time ${ELAPSED_MS}ms < 3000ms (NFR1)"
+else
+  fail "T7: execution time ${ELAPSED_MS}ms >= 3000ms (NFR1 violated)"
+fi
+
+# ── Test 8: Sprint 編號出現在輸出 ────────────────────────────────────────────
+if echo "$OUTPUT" | grep -qE "16[0-9]"; then
+  ok "T8: sprint numbers appear in output"
+else
+  fail "T8: no sprint numbers found in output"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
feat(#869): Sprint Metrics 歷史趨勢儀表板 — sprint-metrics-trend.sh

## Summary

- 新建 `scripts/sprint-metrics-trend.sh`：掃描 docs/km/metrics-log/*.md，輸出 Velocity/Completion/SPACE 多 Sprint 趨勢
- 支援 `--last N` 參數（預設 5），自動標注 [TREND-UP]/[TREND-DOWN]/[TREND-STABLE]
- 重複 Sprint 自動去重，空目錄優雅降級
- 新建 `tests/test-sprint-metrics-trend.sh`（8 個測試案例，全部 PASS）

## AC Checklist

- [x] AC1: 新建 scripts/sprint-metrics-trend.sh，掃描 docs/km/metrics-log/*.md
- [x] AC2: 輸出最近 N 個 Sprint 的 Velocity/Completion/SPACE 趨勢表
- [x] AC3: 識別趨勢方向，輸出 [TREND-UP]/[TREND-DOWN]/[TREND-STABLE]
- [x] AC4: 新建測試（fixture 隔離，8 個案例，全部 PASS）
- [x] AC5: NFR1 執行時間 151ms < 3000ms

Closes #869
