### PR TITLE
feat(#868): ADR 老化偵測 — adr-status-dashboard.sh --check-staleness

### DIFF
--- a/scripts/adr-status-dashboard.sh
+++ b/scripts/adr-status-dashboard.sh
@@ -7,15 +7,58 @@
 # AC3: Proposed/Draft 狀態以 [ADR-PENDING] 標記輸出
 # AC4: 對應測試 tests/test-adr-status-dashboard.sh
 # NFR1: 執行時間 < 2 秒
+#
+# Story #868: --check-staleness 旗標
+# AC1: 新增 --check-staleness 旗標
+# AC2: 超過 90 天未修改的 Accepted ADR 輸出 [ADR-STALE]
+# NFR1（Story #868）: 使用 git log --follow 取得最後修改日期，< 3s
 
 set -euo pipefail
 
-ADR_DIR="${1:-docs/adr}"
+CHECK_STALENESS=false
+ADR_DIR=""
+STALE_THRESHOLD_DAYS=90
+
+for arg in "$@"; do
+  case "$arg" in
+    --check-staleness) CHECK_STALENESS=true ;;
+    *) [[ -z "$ADR_DIR" ]] && ADR_DIR="$arg" || true ;;
+  esac
+done
+ADR_DIR="${ADR_DIR:-docs/adr}"
 
 if [[ ! -d "$ADR_DIR" ]]; then
   echo "[ERROR] ADR 目錄不存在: $ADR_DIR" >&2
   exit 1
 fi
+
+# ── 老化偵測輔助函數（Story #868）────────────────────────────────────────────
+
+get_last_modified_days() {
+  local file="$1"
+  local today_ts
+  today_ts=$(date +%s)
+
+  # 嘗試 git log --follow 取得最後 commit 日期
+  local last_commit_date
+  last_commit_date=$(git log --follow --format="%aI" -1 -- "$file" 2>/dev/null | head -1 || true)
+
+  local last_ts
+  if [[ -n "$last_commit_date" ]]; then
+    last_ts=$(date -d "$last_commit_date" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S" "${last_commit_date:0:19}" +%s 2>/dev/null || echo 0)
+  fi
+
+  # fallback: 使用檔案 mtime
+  if [[ -z "${last_ts:-}" ]] || [[ "$last_ts" -eq 0 ]]; then
+    last_ts=$(stat -c %Y "$file" 2>/dev/null || stat -f %m "$file" 2>/dev/null || echo 0)
+  fi
+
+  if [[ "$last_ts" -eq 0 ]]; then
+    echo 999  # unknown — treat as stale
+  else
+    echo $(( (today_ts - last_ts) / 86400 ))
+  fi
+}
 
 echo "# ADR 狀態儀表板"
 echo ""
@@ -48,6 +91,15 @@ for f in "$ADR_DIR"/ADR-*.md; do
     TODO="—"
   fi
 
+  # Story #868: 老化偵測 — Accepted ADR 超過 90 天
+  if [[ "$CHECK_STALENESS" == "true" ]] && echo "$STATUS" | grep -qiE "Accepted"; then
+    DAYS_OLD=$(get_last_modified_days "$f")
+    if [[ "$DAYS_OLD" -ge "$STALE_THRESHOLD_DAYS" ]]; then
+      STATUS_DISPLAY="[ADR-STALE] ${STATUS}（${DAYS_OLD}天未更新）"
+      TODO="建議重新評估"
+    fi
+  fi
+
   echo "| ${ADR_NUM} | ${TITLE} | ${STATUS_DISPLAY} | ${DATE} | ${TODO} |"
 done
 
@@ -57,4 +109,9 @@ echo "**統計**：共 ${TOTAL_COUNT} 個 ADR，其中 ${PENDING_COUNT} 個待�
 if [[ "$PENDING_COUNT" -gt 0 ]]; then
   echo ""
   echo "> [ADR-PENDING] 上述標記的 ADR 需要決策者關注並推進至 Accepted 或 Deprecated。"
+fi
+
+if [[ "$CHECK_STALENESS" == "true" ]]; then
+  echo ""
+  echo "> 老化偵測（--check-staleness）：Accepted ADR 超過 ${STALE_THRESHOLD_DAYS} 天未更新者已標記（Story #868）。"
 fi

--- a/tests/test-adr-status-dashboard.sh
+++ b/tests/test-adr-status-dashboard.sh
@@ -161,6 +161,100 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── Story #868: --check-staleness テスト ─────────────────────────────────────
+echo ""
+echo "=== Story #868: --check-staleness 老化偵測テスト ==="
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Fixture: Stale Accepted ADR（超過 90 天 — 使用 git log 會傳回空，降級用檔案 mtime）
+# 建立一個很舊的 ADR fixture（touch 設舊 mtime）
+STALE_FIXTURE_DIR=$(mktemp -d)
+trap "rm -rf ${STALE_FIXTURE_DIR}" EXIT
+
+cat > "${STALE_FIXTURE_DIR}/ADR-010-stale.md" << 'ADR_EOF'
+# ADR-010：老化測試 ADR
+
+**狀態**：Accepted
+**日期**：2025-01-01
+**決策者**：Architect
+ADR_EOF
+# 設定超過 90 天前的 mtime
+touch -t "202501010000" "${STALE_FIXTURE_DIR}/ADR-010-stale.md"
+
+cat > "${STALE_FIXTURE_DIR}/ADR-011-fresh.md" << 'ADR_EOF'
+# ADR-011：新鮮測試 ADR
+
+**狀態**：Accepted
+**日期**：2026-03-01
+**決策者**：Architect
+ADR_EOF
+# 設定 10 天前的 mtime (新鮮)
+touch -t "202603160000" "${STALE_FIXTURE_DIR}/ADR-011-fresh.md"
+
+# Test S1: --check-staleness 旗標執行不崩潰
+echo ""
+echo "--- S1: --check-staleness 旗標執行不崩潰 ---"
+EXIT_CODE=0
+bash "$REPO_ROOT/$SCRIPT" --check-staleness "$STALE_FIXTURE_DIR" > /dev/null 2>&1 || EXIT_CODE=$?
+if [[ "$EXIT_CODE" -le 1 ]]; then
+  echo "  PASS: --check-staleness 執行正常（exit $EXIT_CODE）"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: --check-staleness 崩潰（exit $EXIT_CODE）"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test S2: 老化 ADR 輸出 [ADR-STALE] 標記
+echo ""
+echo "--- S2: 老化 ADR 輸出 [ADR-STALE] ---"
+STALE_OUTPUT=$(bash "$REPO_ROOT/$SCRIPT" --check-staleness "$STALE_FIXTURE_DIR" 2>/dev/null || true)
+if echo "$STALE_OUTPUT" | grep -q "\[ADR-STALE\]"; then
+  echo "  PASS: [ADR-STALE] 標記出現在輸出"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: [ADR-STALE] 標記未出現（輸出：$(echo "$STALE_OUTPUT" | head -3)）"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test S3: 新鮮 ADR 不輸出 [ADR-STALE]
+echo ""
+echo "--- S3: 新鮮 ADR 不輸出 [ADR-STALE] ---"
+FRESH_ONLY_DIR=$(mktemp -d)
+trap "rm -rf ${FRESH_ONLY_DIR}" EXIT
+cat > "${FRESH_ONLY_DIR}/ADR-020-fresh.md" << 'ADR_EOF'
+# ADR-020：新鮮 ADR
+
+**狀態**：Accepted
+**日期**：2026-03-20
+**決策者**：Architect
+ADR_EOF
+touch -t "202603200000" "${FRESH_ONLY_DIR}/ADR-020-fresh.md"
+FRESH_OUTPUT=$(bash "$REPO_ROOT/$SCRIPT" --check-staleness "${FRESH_ONLY_DIR}" 2>/dev/null || true)
+STALE_COUNT=$(echo "$FRESH_OUTPUT" | grep -c "\[ADR-STALE\]" 2>/dev/null || true)
+if [[ "$STALE_COUNT" -eq 0 ]]; then
+  echo "  PASS: 新鮮 ADR 無 [ADR-STALE] 標記"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: 新鮮 ADR 出現 $STALE_COUNT 個 [ADR-STALE]（不應有）"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test S4: --check-staleness 執行時間 < 3s（NFR1）
+echo ""
+echo "--- S4: 執行時間 < 3s（NFR1）---"
+START_NS=$(date +%s%N 2>/dev/null || echo 0)
+bash "$REPO_ROOT/$SCRIPT" --check-staleness "$STALE_FIXTURE_DIR" > /dev/null 2>&1 || true
+END_NS=$(date +%s%N 2>/dev/null || echo 3000000000)
+ELAPSED_MS=$(( (END_NS - START_NS) / 1000000 ))
+if [[ "$ELAPSED_MS" -lt 3000 ]]; then
+  echo "  PASS: 執行時間 ${ELAPSED_MS}ms < 3000ms（NFR1）"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: 執行時間 ${ELAPSED_MS}ms >= 3000ms（NFR1 違反）"
+  FAIL=$((FAIL + 1))
+fi
+
 # Summary
 echo ""
 echo "=== 測試結果 ==="


### PR DESCRIPTION
feat(#868): ADR 老化偵測 — adr-status-dashboard.sh --check-staleness

## Summary

- 擴充 `scripts/adr-status-dashboard.sh`：新增 `--check-staleness` 旗標
- 超過 90 天未修改的 Accepted ADR 輸出 `[ADR-STALE]` 標記（建議重新評估）
- 使用 `git log --follow` 取得最後 commit 日期，fallback 至檔案 mtime
- 新增 4 個測試案例至 tests/test-adr-status-dashboard.sh（總計 13 個，全部 PASS）

## AC Checklist

- [x] AC1: 擴充 scripts/adr-status-dashboard.sh，新增 --check-staleness 旗標
- [x] AC2: 超過 90 天未修改的 Accepted ADR 輸出 [ADR-STALE] 標記
- [x] AC3: 執行 adr-status-dashboard.sh 時可選擇性包含老化報告（--check-staleness）
- [x] AC4: 新增對應測試案例至 tests/test-adr-status-dashboard.sh（4 個，全 PASS）

## Test Results

```
PASS: 13, FAIL: 0
ALL TESTS PASSED
```

## NFR

- NFR1: 執行時間 103ms < 3000ms
- 使用 git log --follow 取得最後修改日期（fallback 至 mtime）

Closes #868
