### PR TITLE
feat(#894): validate-a2a-schema.sh 補充 story_id integer 型別文件

### DIFF
--- a/scripts/validate-a2a-schema.sh
+++ b/scripts/validate-a2a-schema.sh
@@ -7,6 +7,7 @@
 # 驗證項目：
 #   - 必要欄位存在：protocol_version, story_id, actor, result, summary, timestamp
 #   - protocol_version 值為 "1.0"
+#   - story_id 為整數型別（integer），不可為字串
 #   - actor 合法值：developer | architect | qa | po | security | sm
 #   - result 合法值：PASS | FAIL | ESCALATE
 #   - timestamp 格式為 ISO 8601（含基本格式檢查）
@@ -150,7 +151,7 @@ else:
 
 # story_id 型別驗證
 if not isinstance(obj["story_id"], int):
-    errors.append(f"story_id 必須為整數，實際類型：{type(obj['story_id']).__name__}")
+    errors.append(f"story_id 必須為整數型別（integer），不可為字串。實際值：{obj['story_id']!r}（型別：{type(obj['story_id']).__name__}）")
 else:
     passes.append(f"story_id = {obj['story_id']}（整數）")
 

--- a/tests/test-validate-a2a-schema.sh
+++ b/tests/test-validate-a2a-schema.sh
@@ -199,6 +199,29 @@ EOF
 bash "$SCRIPT" "$ESCALATE_NO_DETAIL" > /dev/null 2>&1
 assert_exit_code 1 $? "AC4: ESCALATE 結果缺少 escalation 欄位 exit 1"
 
+# String story_id (type error) — #894 新增
+INVALID_STORY_ID_STRING="${FIXTURE_DIR}/invalid-story-id-string.json"
+cat > "$INVALID_STORY_ID_STRING" << 'EOF'
+{
+  "protocol_version": "1.0",
+  "story_id": "879",
+  "actor": "developer",
+  "result": "PASS",
+  "summary": "story_id as string",
+  "timestamp": "2026-03-26T14:00:00Z"
+}
+EOF
+
+STRING_OUT=$(bash "$SCRIPT" "$INVALID_STORY_ID_STRING" 2>/dev/null)
+if echo "$STRING_OUT" | grep -q "story_id.*整數\|story_id.*integer"; then
+    pass "AC4: story_id 字串型別錯誤訊息含型別提示"
+else
+    fail "AC4: story_id 字串型別錯誤訊息應含型別提示"
+fi
+
+bash "$SCRIPT" "$INVALID_STORY_ID_STRING" > /dev/null 2>&1
+assert_exit_code 1 $? "AC4: story_id 為字串型別 exit 1"
+
 # ─── AC5: /tmp fixture 使用與清理驗證 ──────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

補充 validate-a2a-schema.sh 對 story_id integer 型別的文件與測試案例。根據 Sprint 169 Retro 的 Action Item，解決開發者在使用字串值時難以發現驗證失敗的問題。

## Changes

1. **Header Comment 增強**：在 script 頂部驗證項目中標注 story_id 為整數型別（integer），不可為字串
2. **錯誤訊息改進**：更新 Python 驗證邏輯中的 story_id 型別錯誤訊息，明確提示「story_id 必須為整數型別（integer），不可為字串」並顯示實際值與型別
3. **測試覆蓋補充**：在 test-validate-a2a-schema.sh 中新增測試案例，涵蓋 story_id 為字串時的驗證場景

## Test Plan

- 執行完整測試：`bash tests/test-validate-a2a-schema.sh`
  - 結果：全部 17 個測試通過（含新增的 2 個 story_id 型別錯誤測試）
  - 執行時間：1s < NFR2 要求的 5s

## Acceptance Criteria Compliance

- AC1 ✓ Header comment 中標注 story_id 為 integer 型別
- AC2 ✓ 錯誤訊息明確提示整數型別（integer）與不可為字串
- AC3 ✓ 補充字串 story_id 的測試案例，驗證 exit 1 與錯誤訊息
- NFR1 ✓ Script header comment 準確反映當前驗證邏輯
- NFR2 ✓ 新增型別檢查不增加執行時間開銷

Generated with Claude Code
