### PR TITLE
feat(#882): Backlog Health 自動告警 — sprint-candidate 低水位通知

### DIFF
--- a/docs/guides/script-testability-guide.md
+++ b/docs/guides/script-testability-guide.md
@@ -54,6 +54,39 @@ REPO_ROOT="/tmp/fixture-dir" bash scripts/my-script.sh
 
 ---
 
+## grep 搭配 set -e 的陷阱
+
+### 問題說明
+
+當腳本使用 `set -euo pipefail` 時，`grep` 未找到匹配內容會返回 exit code 1，導致腳本非預期退出。這是 grep 的設計特性（0 = 有匹配，1 = 無匹配，2+ = 錯誤），與 `set -e` 的「任何非零退出碼即停止」衝突。
+
+### 錯誤模式
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 如果 file.log 中找不到 "ERROR"，grep 返回 1，腳本非預期終止
+ERROR_COUNT=$(grep -c "ERROR" file.log)
+echo "錯誤數：$ERROR_COUNT"
+```
+
+### 正確模式
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+
+# 方法 1：搭配 || true（推薦）
+ERROR_COUNT=$(grep -c "ERROR" file.log || true)
+echo "錯誤數：${ERROR_COUNT:-0}"
+
+# 方法 2：移除 set -e（若允許其他命令失敗未偵測）
+# ⚠️   僅在確實不需監控其他失敗時使用
+```
+
+---
+
 ## 測試隔離技術
 
 ### 1. Fixture 目錄（推薦）


### PR DESCRIPTION
## Summary

- **Story #882**: Backlog Health 自動告警 — sprint-candidate 低水位 GitHub Issue 通知
- `scripts/backlog-health-report.sh` 新增 `--alert` 模式：當 sprint-candidate < MIN_CANDIDATES（預設 10）時 exit 1
- 新增 `.github/workflows/backlog-health-alert.yml`：低水位時自動建立 GitHub Issue
- 告警去重（NFR1）：透過 `gh issue list --label backlog-alert` 防止重複建立
- Issue body 使用 `--body-file` 模式（Rule #13）
- CI Actions 全部使用 `@v4`（Rule #10）

## AC 達成狀態

- [x] AC1: `--alert` 模式存在，低水位 exit 1（MIN_CANDIDATES 預設 10）
- [x] AC2: GitHub Actions workflow 已建立（workflow_dispatch + schedule）
- [x] AC3: 告警 Issue 標題含「sprint-candidate 僅剩 N 個」
- [x] AC4: MIN_CANDIDATES 可透過 workflow env var 覆蓋
- [x] AC5: `tests/test-backlog-health-alert.sh` — 12 個測試全過
- [x] NFR1: 去重保護（open issue 檢查）
- [x] NFR2: `--body-file` 模式

## Test plan

- [x] `bash tests/test-backlog-health-alert.sh` — PASS 12/12
- [x] `bash tests/test-backlog-health-report.sh` — PASS 6/6（既有測試無回歸）
- [x] `bash scripts/validate-json.sh` — PASS
- [x] `bash scripts/validate-ci-versions.sh` — PASS

Generated with Claude Code (claude-sonnet-4-6)
