### PR TITLE
feat(#848): complexity-trend.sh — measure-complexity 歷史記錄與增速預警

### DIFF
--- a/scripts/complexity-trend.sh
+++ b/scripts/complexity-trend.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# scripts/complexity-trend.sh — #848 複雜度趨勢追蹤
+# 將每次 measure-complexity.sh 量測結果 append 至 docs/km/complexity-trend.csv
+#
+# Usage:
+#   bash scripts/complexity-trend.sh              # 量測並 append，輸出趨勢
+#   bash scripts/complexity-trend.sh --no-trend   # 只 append，不輸出趨勢
+#   bash scripts/complexity-trend.sh --trend-only # 只顯示趨勢（不量測）
+#
+# 環境變數覆蓋：
+#   COMPLEXITY_TREND_CSV  — 覆蓋 CSV 路徑（測試用）
+#   REPO_ROOT             — 覆蓋 repo 根目錄（測試用）
+#
+# NFR1: CSV 可被 Sprint Review 直接引用
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+CSV_PATH="${COMPLEXITY_TREND_CSV:-$REPO_ROOT/docs/km/complexity-trend.csv}"
+MEASURE_SCRIPT="$REPO_ROOT/scripts/measure-complexity.sh"
+
+NO_TREND=false
+TREND_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-trend)   NO_TREND=true;   shift ;;
+    --trend-only) TREND_ONLY=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+# ── 建立 CSV（若不存在）──────────────────────────────────────────────
+ensure_csv_header() {
+  mkdir -p "$(dirname "$CSV_PATH")" 2>/dev/null || true
+  # 建立或修復：若檔案不存在、或為空、或 header 不正確則寫入 header
+  if [[ ! -f "$CSV_PATH" ]] || ! grep -q "^date,SKILL_COUNT" "$CSV_PATH" 2>/dev/null; then
+    echo "date,SKILL_COUNT,AGENT_COUNT,HOOK_COUNT,TOTAL_LINES" > "$CSV_PATH"
+  fi
+}
+
+# ── 量測當前值 ────────────────────────────────────────────────────────
+measure_current() {
+  if [[ ! -f "$MEASURE_SCRIPT" ]]; then
+    echo "WARN: measure-complexity.sh not found, using fallback" >&2
+    SKILL_COUNT=$(find "$REPO_ROOT/skills" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+    AGENT_COUNT=$(find "$REPO_ROOT/agents" -maxdepth 1 -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+    HOOK_COUNT=$(find "$REPO_ROOT/hooks" -name "*.sh" 2>/dev/null | wc -l | tr -d ' ')
+    TOTAL_LINES=$(find "$REPO_ROOT" -name "*.md" -o -name "*.sh" -o -name "*.json" -o -name "*.yaml" 2>/dev/null \
+      | grep -v ".claude/worktrees" | xargs wc -l 2>/dev/null | tail -1 | awk '{print $1}' || echo "0")
+  else
+    OUTPUT=$(bash "$MEASURE_SCRIPT" 2>/dev/null || true)
+    SKILL_COUNT=$(echo "$OUTPUT" | grep -oP 'SKILL_COUNT\s+\K\d+' | head -1 || echo "0")
+    AGENT_COUNT=$(echo "$OUTPUT" | grep -oP 'AGENT_COUNT\s+\K\d+' | head -1 || echo "0")
+    HOOK_COUNT=$(echo "$OUTPUT"  | grep -oP 'HOOK_COUNT\s+\K\d+' | head -1 || echo "0")
+    TOTAL_LINES=$(echo "$OUTPUT" | grep -oP 'TOTAL_LINES\s+\K\d+' | head -1 || echo "0")
+  fi
+  TODAY=$(date '+%Y-%m-%d')
+}
+
+# ── Append（冪等：同日期只寫一次）───────────────────────────────────
+append_snapshot() {
+  ensure_csv_header
+  measure_current
+  # 冪等檢查：若今日資料已存在，跳過
+  if grep -q "^${TODAY}," "$CSV_PATH" 2>/dev/null; then
+    echo "[COMPLEXITY-TREND] 今日快照已存在（${TODAY}），跳過追加"
+    return 0
+  fi
+  echo "${TODAY},${SKILL_COUNT},${AGENT_COUNT},${HOOK_COUNT},${TOTAL_LINES}" >> "$CSV_PATH"
+  echo "[COMPLEXITY-TREND] 追加快照：${TODAY} SKILL=${SKILL_COUNT} AGENT=${AGENT_COUNT} HOOK=${HOOK_COUNT} LINES=${TOTAL_LINES}"
+}
+
+# ── 趨勢計算（最近 5 次量測的增減百分比）─────────────────────────────
+show_trend() {
+  ensure_csv_header
+  # 讀取最近 5 筆（不含 header）
+  RECENT=$(tail -n +2 "$CSV_PATH" | tail -5)
+  LINE_COUNT=$(echo "$RECENT" | grep -c "^[0-9]" || true)
+  if [[ "$LINE_COUNT" -lt 2 ]]; then
+    echo "[COMPLEXITY-TREND] 歷史資料不足（需 >= 2 筆），無法計算趨勢（目前 ${LINE_COUNT} 筆）"
+    return 0
+  fi
+
+  echo ""
+  echo "=== Complexity Trend（最近 ${LINE_COUNT} 次量測）==="
+  echo ""
+
+  # 取第一筆與最後一筆做整體趨勢
+  FIRST=$(echo "$RECENT" | head -1)
+  LAST=$(echo "$RECENT" | tail -1)
+
+  F_DATE=$(echo "$FIRST" | cut -d',' -f1)
+  L_DATE=$(echo "$LAST" | cut -d',' -f1)
+
+  F_SKILL=$(echo "$FIRST" | cut -d',' -f2)
+  L_SKILL=$(echo "$LAST" | cut -d',' -f2)
+  F_AGENT=$(echo "$FIRST" | cut -d',' -f3)
+  L_AGENT=$(echo "$LAST" | cut -d',' -f3)
+  F_HOOK=$(echo "$FIRST" | cut -d',' -f4)
+  L_HOOK=$(echo "$LAST" | cut -d',' -f4)
+  F_LINES=$(echo "$FIRST" | cut -d',' -f5)
+  L_LINES=$(echo "$LAST" | cut -d',' -f5)
+
+  # 計算百分比變化（整數近似）
+  pct_change() {
+    local old="$1" new="$2"
+    if [[ "$old" -eq 0 ]]; then echo "N/A"; return; fi
+    local diff=$(( new - old ))
+    local pct=$(( (diff * 100) / old ))
+    if [[ "$diff" -gt 0 ]]; then
+      echo "+${pct}%"
+    elif [[ "$diff" -lt 0 ]]; then
+      echo "${pct}%"
+    else
+      echo "0%"
+    fi
+  }
+
+  echo "期間：${F_DATE} → ${L_DATE}"
+  echo ""
+  printf "%-15s %8s %8s %8s\n" "指標" "起始值" "最新值" "變化%"
+  printf "%-15s %8s %8s %8s\n" "SKILL_COUNT" "$F_SKILL" "$L_SKILL" "$(pct_change "$F_SKILL" "$L_SKILL")"
+  printf "%-15s %8s %8s %8s\n" "AGENT_COUNT" "$F_AGENT" "$L_AGENT" "$(pct_change "$F_AGENT" "$L_AGENT")"
+  printf "%-15s %8s %8s %8s\n" "HOOK_COUNT"  "$F_HOOK"  "$L_HOOK"  "$(pct_change "$F_HOOK"  "$L_HOOK")"
+  printf "%-15s %8s %8s %8s\n" "TOTAL_LINES" "$F_LINES" "$L_LINES" "$(pct_change "$F_LINES" "$L_LINES")"
+
+  # 預警：TOTAL_LINES 增速 > 20%
+  if [[ "$F_LINES" -gt 0 ]]; then
+    LINES_PCT=$(( ((L_LINES - F_LINES) * 100) / F_LINES ))
+    if [[ "$LINES_PCT" -gt 20 ]]; then
+      echo ""
+      echo "[COMPLEXITY-WARN] TOTAL_LINES 增速 ${LINES_PCT}% 超過 20% 閾值，建議評估複雜度預算"
+    fi
+  fi
+  echo ""
+  echo "CSV: $CSV_PATH"
+}
+
+# ── 主流程 ────────────────────────────────────────────────────────────
+if [[ "$TREND_ONLY" == "true" ]]; then
+  show_trend
+else
+  append_snapshot
+  if [[ "$NO_TREND" != "true" ]]; then
+    show_trend
+  fi
+fi

--- a/tests/test-complexity-trend.sh
+++ b/tests/test-complexity-trend.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# test-complexity-trend.sh — #848 複雜度趨勢追蹤測試
+# AC1: scripts/complexity-trend.sh 存在，執行後 append 至 docs/km/complexity-trend.csv
+# AC2: CSV 含欄位：日期, SKILL_COUNT, AGENT_COUNT, HOOK_COUNT, TOTAL_LINES
+# AC3: 輸出簡易趨勢（最近 5 次量測的增減百分比）
+# AC4: 對應測試存在（本檔）
+# NFR1: CSV 可被 Sprint Review 直接引用
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [[ "$result" == "pass" ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== test-complexity-trend.sh ==="
+
+SCRIPT="$REPO_ROOT/scripts/complexity-trend.sh"
+CSV="$REPO_ROOT/docs/km/complexity-trend.csv"
+TMP_CSV=$(mktemp)
+
+cleanup() {
+  rm -f "$TMP_CSV"
+}
+trap cleanup EXIT
+
+# AC1: 腳本存在
+if [[ -f "$SCRIPT" ]]; then
+  check "AC1: scripts/complexity-trend.sh 存在" "pass"
+else
+  check "AC1: scripts/complexity-trend.sh 存在" "fail"
+fi
+
+# AC2: CSV 欄位驗證 — 執行腳本後 CSV 含正確 header
+OVERRIDE_CSV="$TMP_CSV"
+if COMPLEXITY_TREND_CSV="$OVERRIDE_CSV" bash "$SCRIPT" --no-trend 2>/dev/null; then
+  if [[ -f "$OVERRIDE_CSV" ]]; then
+    HEADER=$(head -1 "$OVERRIDE_CSV" 2>/dev/null || true)
+    if echo "$HEADER" | grep -q "date" && \
+       echo "$HEADER" | grep -q "SKILL_COUNT" && \
+       echo "$HEADER" | grep -q "AGENT_COUNT" && \
+       echo "$HEADER" | grep -q "HOOK_COUNT" && \
+       echo "$HEADER" | grep -q "TOTAL_LINES"; then
+      check "AC2: CSV header 包含所有必要欄位" "pass"
+    else
+      check "AC2: CSV header 包含所有必要欄位 (got: $HEADER)" "fail"
+    fi
+    # 驗證有一筆資料行
+    DATA_LINES=$(tail -n +2 "$OVERRIDE_CSV" | grep -c "^[0-9]" || true)
+    if [[ "$DATA_LINES" -ge 1 ]]; then
+      check "AC2: CSV 包含至少一筆資料行" "pass"
+    else
+      check "AC2: CSV 包含至少一筆資料行" "fail"
+    fi
+  else
+    check "AC2: CSV 檔案被建立" "fail"
+    check "AC2: CSV 包含至少一筆資料行" "fail"
+  fi
+else
+  check "AC2: 腳本執行成功" "fail"
+  check "AC2: CSV 包含至少一筆資料行" "fail"
+fi
+
+# AC3: 趨勢輸出 — 需要至少 2 筆資料才能計算趨勢，先 append 兩筆再呼叫
+TMP_TREND_CSV=$(mktemp)
+# 寫入 2 筆模擬歷史資料
+cat > "$TMP_TREND_CSV" << 'CSVEOF'
+date,SKILL_COUNT,AGENT_COUNT,HOOK_COUNT,TOTAL_LINES
+2026-03-25,30,8,29,9800
+2026-03-26,31,8,30,10049
+CSVEOF
+TREND_OUTPUT=$(COMPLEXITY_TREND_CSV="$TMP_TREND_CSV" bash "$SCRIPT" --trend-only 2>/dev/null || true)
+rm -f "$TMP_TREND_CSV"
+if echo "$TREND_OUTPUT" | grep -qiE "trend|%|increase|decrease|增|減|TOTAL_LINES" 2>/dev/null; then
+  check "AC3: 趨勢輸出包含變化資訊" "pass"
+else
+  check "AC3: 趨勢輸出包含變化資訊 (got: $(echo "$TREND_OUTPUT" | head -3))" "fail"
+fi
+
+# AC4: 測試自身存在
+if [[ -f "$REPO_ROOT/tests/test-complexity-trend.sh" ]]; then
+  check "AC4: tests/test-complexity-trend.sh 存在" "pass"
+else
+  check "AC4: tests/test-complexity-trend.sh 存在" "fail"
+fi
+
+# NFR1: CSV append 冪等性 — 同日期執行兩次，不重複追加
+TMP_IDEM_CSV=$(mktemp)
+cat > "$TMP_IDEM_CSV" << 'CSVEOF'
+date,SKILL_COUNT,AGENT_COUNT,HOOK_COUNT,TOTAL_LINES
+CSVEOF
+COMPLEXITY_TREND_CSV="$TMP_IDEM_CSV" bash "$SCRIPT" --no-trend 2>/dev/null || true
+LINES_AFTER_1=$(wc -l < "$TMP_IDEM_CSV")
+COMPLEXITY_TREND_CSV="$TMP_IDEM_CSV" bash "$SCRIPT" --no-trend 2>/dev/null || true
+LINES_AFTER_2=$(wc -l < "$TMP_IDEM_CSV")
+rm -f "$TMP_IDEM_CSV"
+if [[ "$LINES_AFTER_1" -eq "$LINES_AFTER_2" ]]; then
+  check "NFR1: 同日期重複執行不重複追加（冪等）" "pass"
+else
+  check "NFR1: 同日期重複執行不重複追加（冪等）" "fail"
+fi
+
+echo ""
+echo "Results: PASS=${PASS} FAIL=${FAIL}"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
新增 scripts/complexity-trend.sh，將每次量測快照 append 至 docs/km/complexity-trend.csv。

- AC1: complexity-trend.sh 腳本建立完成
- AC2: CSV 欄位 date, SKILL_COUNT, AGENT_COUNT, HOOK_COUNT, TOTAL_LINES
- AC3: 輸出最近 5 次趨勢與百分比，TOTAL_LINES >20% 觸發 [COMPLEXITY-WARN]
- AC4: tests/test-complexity-trend.sh 全部通過（PASS=6 FAIL=0）
- NFR1: 冪等，同日期不重複追加
