### PR TITLE
feat(#872): Retro Action Items 歷史分析工具

### DIFF
--- a/scripts/retro-action-analysis.sh
+++ b/scripts/retro-action-analysis.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# scripts/retro-action-analysis.sh
+# Story #872: Retro Action Items 歷史分析工具 — 完成率與重複主題趨勢
+#
+# Usage:
+#   bash scripts/retro-action-analysis.sh [--repo OWNER/REPO] [--last N]
+#
+# 功能：
+#   1. 掃描 retro-action label 的所有 Issues，計算完成率（closed/total）
+#   2. 識別標題關鍵字重複出現（>= 2 次）的主題，輸出 [SYSTEMIC-ISSUE] 標記
+#   3. 輸出近 5 Sprint 的 Retro Action 完成率趨勢
+#
+# 環境變數：
+#   OWNER_REPO — 預設 kctw-dev/shikigami（可由 --repo 覆寫）
+
+set -uo pipefail
+
+# ── 常數與預設值 ──────────────────────────────────────────────────────────────
+
+OWNER_REPO="${OWNER_REPO:-kctw-dev/shikigami}"
+LAST_N=5
+SYSTEMIC_THRESHOLD=2  # 關鍵字重複次數閾值
+
+# 常見停用詞（不參與關鍵字計數）
+STOPWORDS="的 了 在 是 和 或 但 有 與 我 你 他 她 我們 他們
+           a an the and or but in on at to for of with is are was
+           改善 加強 補充 處理 解決 優化 更新 修正 增加 移除 清理
+           issue issues story stories 問題 事項 工作"
+
+# ── 參數解析 ─────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)  OWNER_REPO="${2:-$OWNER_REPO}"; shift 2 ;;
+    --last)  LAST_N="${2:-5}"; shift 2 ;;
+    *)       shift ;;
+  esac
+done
+
+# ── gh API 呼叫（含降級處理） ─────────────────────────────────────────────────
+
+RAW_JSON=""
+GH_OK=true
+
+if ! RAW_JSON=$(gh issue list \
+    -R "$OWNER_REPO" \
+    --label retro-action \
+    --state all \
+    --limit 200 \
+    --json number,title,state,labels \
+    2>&1); then
+  echo "[WARN] gh issue list 失敗（$OWNER_REPO），以空資料繼續"
+  echo "[WARN] 錯誤訊息：$RAW_JSON"
+  RAW_JSON="[]"
+  GH_OK=false
+fi
+
+# 驗證 JSON 非空陣列字串
+if ! echo "$RAW_JSON" | grep -q '^\['; then
+  echo "[WARN] gh 回傳非 JSON 格式，以空資料繼續"
+  echo "[WARN] 回傳內容：${RAW_JSON:0:200}"
+  RAW_JSON="[]"
+  GH_OK=false
+fi
+
+# ── 解析 Issues ──────────────────────────────────────────────────────────────
+
+# 使用 jq 解析（若不可用則降級）
+if ! command -v jq &>/dev/null; then
+  echo "[WARN] jq 不可用，無法解析完整資料"
+  RAW_JSON="[]"
+fi
+
+# 提取欄位：number, title, state, sprint_label
+# Sprint label 格式：Sprint NNN
+declare -a ALL_TITLES=()
+declare -a ALL_STATES=()
+declare -a ALL_SPRINTS=()
+declare -i TOTAL=0
+declare -i CLOSED=0
+
+if [[ "$RAW_JSON" != "[]" && -n "$RAW_JSON" ]]; then
+  # 用 jq 解析每個 issue
+  while IFS='|' read -r num title state sprint; do
+    [[ -z "$title" ]] && continue
+    TOTAL=$(( TOTAL + 1 ))
+    ALL_TITLES+=("$title")
+    ALL_STATES+=("$state")
+    ALL_SPRINTS+=("$sprint")
+    if [[ "$state" == "CLOSED" ]]; then
+      CLOSED=$(( CLOSED + 1 ))
+    fi
+  done < <(echo "$RAW_JSON" | jq -r '.[] |
+    .number as $n |
+    .title as $t |
+    .state as $s |
+    ([ .labels[].name | select(test("^Sprint [0-9]+$")) ] | first // "Unknown") as $sprint |
+    "\($n)|\($t)|\($s)|\($sprint)"
+  ' 2>/dev/null || true)
+fi
+
+# ── 區塊 1: 整體完成率 ────────────────────────────────────────────────────────
+
+echo "=== Retro Action Items 分析報告 ==="
+echo "Repository: $OWNER_REPO"
+echo ""
+echo "── 整體完成率 ─────────────────────────────────────────────────────────────"
+
+if [[ $TOTAL -eq 0 ]]; then
+  echo "（無 retro-action Issues 資料）"
+else
+  # 計算百分比（整數）
+  RATE=$(( CLOSED * 100 / TOTAL ))
+  echo "總計：${CLOSED}/${TOTAL} 已完成（${RATE}%）"
+
+  # 完成率評估
+  if [[ $RATE -ge 80 ]]; then
+    echo "[STATUS] HEALTHY — 完成率 >= 80%"
+  elif [[ $RATE -ge 50 ]]; then
+    echo "[STATUS] WARNING — 完成率 50-79%"
+  else
+    echo "[STATUS] CRITICAL — 完成率 < 50%"
+  fi
+fi
+
+echo ""
+
+# ── 區塊 2: 關鍵字重複分析 — [SYSTEMIC-ISSUE] ────────────────────────────────
+
+echo "── 重複主題分析 ────────────────────────────────────────────────────────────"
+
+if [[ $TOTAL -eq 0 ]]; then
+  echo "（無資料）"
+else
+  # 建立關鍵字計數 map
+  declare -A KEYWORD_COUNT=()
+
+  for title in "${ALL_TITLES[@]:-}"; do
+    [[ -z "$title" ]] && continue
+    # 分詞：以空格、標點拆分，轉小寫
+    IFS=' 　，、。！？：；「」『』【】〔〕（）…—─' read -ra WORDS <<< "$title"
+    for word in "${WORDS[@]:-}"; do
+      # 清理特殊字元
+      word=$(echo "$word" | tr -d '[:punct:]' | tr '[:upper:]' '[:lower:]')
+      [[ -z "$word" ]] && continue
+      # 跳過停用詞（長度 <= 1 的也跳過）
+      [[ "${#word}" -le 1 ]] && continue
+      # 跳過純數字
+      [[ "$word" =~ ^[0-9]+$ ]] && continue
+      # 跳過停用詞列表
+      if echo "$STOPWORDS" | grep -qwF "$word" 2>/dev/null; then
+        continue
+      fi
+      KEYWORD_COUNT["$word"]=$(( ${KEYWORD_COUNT["$word"]:-0} + 1 ))
+    done
+  done
+
+  # 找出重複 >= SYSTEMIC_THRESHOLD 的關鍵字
+  SYSTEMIC_FOUND=false
+  declare -a SYSTEMIC_KEYWORDS=()
+
+  for kw in "${!KEYWORD_COUNT[@]}"; do
+    cnt="${KEYWORD_COUNT[$kw]}"
+    if [[ $cnt -ge $SYSTEMIC_THRESHOLD ]]; then
+      SYSTEMIC_KEYWORDS+=("${cnt}:${kw}")
+      SYSTEMIC_FOUND=true
+    fi
+  done
+
+  if [[ "$SYSTEMIC_FOUND" == "true" ]]; then
+    # 按出現次數排序
+    IFS=$'\n' SORTED_KW=($(printf '%s\n' "${SYSTEMIC_KEYWORDS[@]}" | sort -rn))
+    unset IFS
+    echo "[SYSTEMIC-ISSUE] 以下關鍵字重複出現 >= ${SYSTEMIC_THRESHOLD} 次，可能為系統性問題："
+    for entry in "${SORTED_KW[@]}"; do
+      cnt="${entry%%:*}"
+      kw="${entry#*:}"
+      printf "  %-20s (%d 次)\n" "$kw" "$cnt"
+    done
+  else
+    echo "（未偵測到重複主題 — 無系統性問題信號）"
+  fi
+fi
+
+echo ""
+
+# ── 區塊 3: 近 N Sprint 完成率趨勢 ───────────────────────────────────────────
+
+echo "── 近 ${LAST_N} Sprint 趨勢 ─────────────────────────────────────────────────"
+
+if [[ $TOTAL -eq 0 ]]; then
+  echo "（無資料）"
+else
+  # 按 Sprint 分組
+  declare -A SPRINT_TOTAL=()
+  declare -A SPRINT_CLOSED=()
+  declare -a SPRINT_NUMS=()
+
+  for i in "${!ALL_SPRINTS[@]}"; do
+    sprint="${ALL_SPRINTS[$i]:-Unknown}"
+    state="${ALL_STATES[$i]:-}"
+
+    # 提取 Sprint 號碼（用於排序）
+    sprint_num=$(echo "$sprint" | grep -oE '[0-9]+$' || echo "0")
+    sprint_key="Sprint $sprint_num"
+
+    if [[ -z "${SPRINT_TOTAL[$sprint_key]+_}" ]]; then
+      SPRINT_NUMS+=("$sprint_num")
+      SPRINT_TOTAL["$sprint_key"]=0
+      SPRINT_CLOSED["$sprint_key"]=0
+    fi
+
+    SPRINT_TOTAL["$sprint_key"]=$(( SPRINT_TOTAL["$sprint_key"] + 1 ))
+    if [[ "$state" == "CLOSED" ]]; then
+      SPRINT_CLOSED["$sprint_key"]=$(( SPRINT_CLOSED["$sprint_key"] + 1 ))
+    fi
+  done
+
+  # 排序 Sprint 號碼（去重）
+  if [[ "${#SPRINT_NUMS[@]}" -gt 0 ]]; then
+    IFS=$'\n' SORTED_SPRINT_NUMS=($(printf '%s\n' "${SPRINT_NUMS[@]}" | sort -nu))
+    unset IFS
+
+    # 取最近 LAST_N 個
+    TOTAL_SPRINTS="${#SORTED_SPRINT_NUMS[@]}"
+    if [[ "$TOTAL_SPRINTS" -gt "$LAST_N" ]]; then
+      START=$(( TOTAL_SPRINTS - LAST_N ))
+      SORTED_SPRINT_NUMS=("${SORTED_SPRINT_NUMS[@]:$START}")
+    fi
+
+    # 輸出趨勢表
+    printf "%-12s %-10s %s\n" "Sprint" "完成率" "Closed/Total"
+    printf "%-12s %-10s %s\n" "------" "------" "------------"
+
+    PREV_RATE=""
+    for num in "${SORTED_SPRINT_NUMS[@]}"; do
+      [[ -z "$num" || "$num" == "0" ]] && continue
+      sprint_key="Sprint $num"
+      s_total="${SPRINT_TOTAL[$sprint_key]:-0}"
+      s_closed="${SPRINT_CLOSED[$sprint_key]:-0}"
+
+      if [[ $s_total -eq 0 ]]; then
+        rate_pct="N/A"
+        trend_mark=""
+      else
+        rate_pct=$(( s_closed * 100 / s_total ))
+
+        # 計算趨勢
+        trend_mark=""
+        if [[ -n "$PREV_RATE" ]] && [[ "$rate_pct" =~ ^[0-9]+$ ]] && [[ "$PREV_RATE" =~ ^[0-9]+$ ]]; then
+          if (( rate_pct > PREV_RATE )); then
+            trend_mark="[TREND-UP]"
+          elif (( rate_pct < PREV_RATE )); then
+            trend_mark="[TREND-DOWN]"
+          else
+            trend_mark="[TREND-STABLE]"
+          fi
+        fi
+        rate_pct="${rate_pct}%"
+        PREV_RATE="${rate_pct//%/}"
+      fi
+
+      printf "| %-10s | %-8s | %s/%s %s\n" \
+        "$sprint_key" "$rate_pct" "$s_closed" "$s_total" "$trend_mark"
+    done
+  else
+    echo "（無 Sprint 標籤資料）"
+  fi
+fi
+
+echo ""
+echo "（顯示近 ${LAST_N} Sprint 趨勢；--last N 可調整）"
+[[ "$GH_OK" == "false" ]] && echo "" && echo "[WARN] 部分資料因 gh API 失敗而缺失，以上為降級輸出"
+
+exit 0

--- a/tests/test-retro-action-analysis.sh
+++ b/tests/test-retro-action-analysis.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# tests/test-retro-action-analysis.sh
+# Story #872: Retro Action Items 歷史分析工具 — 完成率與重複主題趨勢
+# TDD: 測試先於實作，使用 fixture 隔離（模擬 gh API 輸出）
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/retro-action-analysis.sh"
+PASS=0
+FAIL=0
+
+ok()   { echo "[PASS] $1"; PASS=$((PASS+1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+echo "=== test-retro-action-analysis.sh ==="
+
+# ── T1: 腳本存在且可執行 ──────────────────────────────────────────────────────
+if [[ -x "$SCRIPT" ]]; then
+  ok "T1: script exists and is executable"
+else
+  fail "T1: script not found or not executable: $SCRIPT"
+fi
+
+# ── T2: 完成率計算正確 ────────────────────────────────────────────────────────
+# fixture: 10 issues total, 7 closed, 3 open
+GH_STUB=$(mktemp -d)
+cat > "$GH_STUB/gh" << 'GHEOF'
+#!/usr/bin/env bash
+# gh stub: 10 issues (7 closed, 3 open), mixed Sprint labels
+# Supports: gh issue list --label retro-action --state all
+echo '[
+  {"number":101,"title":"改善 CI pipeline 速度","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 170"}]},
+  {"number":102,"title":"補充文件說明","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 170"}]},
+  {"number":103,"title":"改善 CI pipeline 穩定性","state":"OPEN","labels":[{"name":"retro-action"},{"name":"Sprint 170"}]},
+  {"number":104,"title":"改善溝通流程","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 171"}]},
+  {"number":105,"title":"補充測試覆蓋","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 171"}]},
+  {"number":106,"title":"改善 review 品質","state":"OPEN","labels":[{"name":"retro-action"},{"name":"Sprint 171"}]},
+  {"number":107,"title":"改善部署流程","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 172"}]},
+  {"number":108,"title":"加強 code review 機制","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 172"}]},
+  {"number":109,"title":"改善文件完整性","state":"OPEN","labels":[{"name":"retro-action"},{"name":"Sprint 172"}]},
+  {"number":110,"title":"改善 CI pipeline 覆蓋率","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 173"}]}
+]'
+GHEOF
+chmod +x "$GH_STUB/gh"
+
+OUTPUT=$(PATH="$GH_STUB:$PATH" bash "$SCRIPT" 2>&1)
+EC=$?
+rm -rf "$GH_STUB"
+
+if [[ $EC -eq 0 ]]; then
+  ok "T2a: script exits 0 with valid fixture"
+else
+  fail "T2a: script exited non-zero ($EC)"
+fi
+
+# 完成率 = 7/10 = 70%
+if echo "$OUTPUT" | grep -qE "70%|7/10"; then
+  ok "T2b: completion rate 70% (7/10) displayed"
+else
+  fail "T2b: completion rate 70% not found in output"
+fi
+
+# ── T3: total=0 邊界條件不崩潰 ───────────────────────────────────────────────
+GH_STUB=$(mktemp -d)
+cat > "$GH_STUB/gh" << 'GHEOF'
+#!/usr/bin/env bash
+echo '[]'
+GHEOF
+chmod +x "$GH_STUB/gh"
+
+EXIT_CODE=0
+EMPTY_OUT=$(PATH="$GH_STUB:$PATH" bash "$SCRIPT" 2>&1) || EXIT_CODE=$?
+rm -rf "$GH_STUB"
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  ok "T3: total=0 exits gracefully"
+else
+  fail "T3: total=0 caused crash (exit $EXIT_CODE)"
+fi
+
+# ── T4: 關鍵字重複偵測 — [SYSTEMIC-ISSUE] 標記 ───────────────────────────────
+# "CI pipeline" 出現 3 次，"改善" 出現多次，應標記 [SYSTEMIC-ISSUE]
+GH_STUB=$(mktemp -d)
+cat > "$GH_STUB/gh" << 'GHEOF'
+#!/usr/bin/env bash
+echo '[
+  {"number":201,"title":"CI pipeline 速度問題","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 168"}]},
+  {"number":202,"title":"CI pipeline 穩定性問題","state":"OPEN","labels":[{"name":"retro-action"},{"name":"Sprint 169"}]},
+  {"number":203,"title":"CI pipeline 覆蓋不足","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 170"}]},
+  {"number":204,"title":"文件缺失","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 171"}]},
+  {"number":205,"title":"溝通流程待改善","state":"OPEN","labels":[{"name":"retro-action"},{"name":"Sprint 172"}]}
+]'
+GHEOF
+chmod +x "$GH_STUB/gh"
+
+SYSTEMIC_OUT=$(PATH="$GH_STUB:$PATH" bash "$SCRIPT" 2>&1)
+rm -rf "$GH_STUB"
+
+if echo "$SYSTEMIC_OUT" | grep -q "\[SYSTEMIC-ISSUE\]"; then
+  ok "T4a: [SYSTEMIC-ISSUE] detected for repeated keyword (CI pipeline)"
+else
+  fail "T4a: [SYSTEMIC-ISSUE] not found for repeated keyword 'CI pipeline'"
+fi
+
+# ── T5: 無重複關鍵字時不出現 [SYSTEMIC-ISSUE] ────────────────────────────────
+GH_STUB=$(mktemp -d)
+cat > "$GH_STUB/gh" << 'GHEOF'
+#!/usr/bin/env bash
+echo '[
+  {"number":301,"title":"alpha unique issue","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 170"}]},
+  {"number":302,"title":"beta separate concern","state":"OPEN","labels":[{"name":"retro-action"},{"name":"Sprint 171"}]},
+  {"number":303,"title":"gamma distinct topic","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 172"}]}
+]'
+GHEOF
+chmod +x "$GH_STUB/gh"
+
+NO_SYSTEMIC_OUT=$(PATH="$GH_STUB:$PATH" bash "$SCRIPT" 2>&1)
+rm -rf "$GH_STUB"
+
+if ! echo "$NO_SYSTEMIC_OUT" | grep -q "\[SYSTEMIC-ISSUE\]"; then
+  ok "T5: no [SYSTEMIC-ISSUE] when no repeated keywords"
+else
+  fail "T5: false [SYSTEMIC-ISSUE] triggered for unique keywords"
+fi
+
+# ── T6: 近 5 Sprint 趨勢輸出格式 ─────────────────────────────────────────────
+GH_STUB=$(mktemp -d)
+cat > "$GH_STUB/gh" << 'GHEOF'
+#!/usr/bin/env bash
+echo '[
+  {"number":401,"title":"issue alpha","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 168"}]},
+  {"number":402,"title":"issue beta","state":"OPEN","labels":[{"name":"retro-action"},{"name":"Sprint 169"}]},
+  {"number":403,"title":"issue gamma","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 170"}]},
+  {"number":404,"title":"issue delta","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 171"}]},
+  {"number":405,"title":"issue epsilon","state":"OPEN","labels":[{"name":"retro-action"},{"name":"Sprint 172"}]},
+  {"number":406,"title":"issue zeta","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 173"}]}
+]'
+GHEOF
+chmod +x "$GH_STUB/gh"
+
+TREND_OUT=$(PATH="$GH_STUB:$PATH" bash "$SCRIPT" 2>&1)
+rm -rf "$GH_STUB"
+
+# 應輸出 Sprint 趨勢區塊，顯示近 5 Sprint（168-173 中最近 5 個）
+SPRINT_TREND_COUNT=$(echo "$TREND_OUT" | grep -cE "Sprint [0-9]+" || true)
+if [[ "$SPRINT_TREND_COUNT" -ge 1 && "$SPRINT_TREND_COUNT" -le 5 ]]; then
+  ok "T6a: trend output shows 1-5 sprint entries (got $SPRINT_TREND_COUNT)"
+else
+  fail "T6a: trend output unexpected sprint count: $SPRINT_TREND_COUNT (expected 1-5)"
+fi
+
+# 應有完成率格式（百分比或分數）
+if echo "$TREND_OUT" | grep -qE "[0-9]+%|[0-9]+/[0-9]+"; then
+  ok "T6b: trend output contains completion rate format"
+else
+  fail "T6b: trend output missing completion rate format"
+fi
+
+# ── T7: gh API 失敗時優雅降級 — 輸出 [WARN] ─────────────────────────────────
+GH_STUB=$(mktemp -d)
+cat > "$GH_STUB/gh" << 'GHEOF'
+#!/usr/bin/env bash
+echo "error: authentication required" >&2
+exit 1
+GHEOF
+chmod +x "$GH_STUB/gh"
+
+WARN_EXIT=0
+WARN_OUT=$(PATH="$GH_STUB:$PATH" bash "$SCRIPT" 2>&1) || WARN_EXIT=$?
+rm -rf "$GH_STUB"
+
+# 腳本不應 crash（exit 0 或非嚴重錯誤），且應輸出 [WARN]
+if [[ $WARN_EXIT -eq 0 ]]; then
+  ok "T7a: gh API failure — script exits 0 (graceful degradation)"
+else
+  fail "T7a: gh API failure — script exited non-zero ($WARN_EXIT)"
+fi
+
+if echo "$WARN_OUT" | grep -q "\[WARN\]"; then
+  ok "T7b: gh API failure — [WARN] marker present in output"
+else
+  fail "T7b: gh API failure — [WARN] marker missing from output"
+fi
+
+# ── T8: 執行時間 < 10s (NFR) ─────────────────────────────────────────────────
+GH_STUB=$(mktemp -d)
+cat > "$GH_STUB/gh" << 'GHEOF'
+#!/usr/bin/env bash
+echo '[{"number":501,"title":"perf test issue","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 173"}]}]'
+GHEOF
+chmod +x "$GH_STUB/gh"
+
+START_NS=$(date +%s%N 2>/dev/null || echo 0)
+PATH="$GH_STUB:$PATH" bash "$SCRIPT" >/dev/null 2>&1 || true
+END_NS=$(date +%s%N 2>/dev/null || echo 10000000000)
+ELAPSED_MS=$(( (END_NS - START_NS) / 1000000 ))
+rm -rf "$GH_STUB"
+
+if [[ "$ELAPSED_MS" -lt 10000 ]]; then
+  ok "T8: execution time ${ELAPSED_MS}ms < 10000ms (NFR)"
+else
+  fail "T8: execution time ${ELAPSED_MS}ms >= 10000ms (NFR violated)"
+fi
+
+# ── T9: 整體輸出結構完整性 ───────────────────────────────────────────────────
+# 使用 T2 的標準 fixture，驗證輸出包含預期區塊
+GH_STUB=$(mktemp -d)
+cat > "$GH_STUB/gh" << 'GHEOF'
+#!/usr/bin/env bash
+echo '[
+  {"number":601,"title":"改善 CI pipeline 速度","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 170"}]},
+  {"number":602,"title":"補充文件說明","state":"CLOSED","labels":[{"name":"retro-action"},{"name":"Sprint 170"}]},
+  {"number":603,"title":"改善溝通效率","state":"OPEN","labels":[{"name":"retro-action"},{"name":"Sprint 171"}]}
+]'
+GHEOF
+chmod +x "$GH_STUB/gh"
+
+FULL_OUT=$(PATH="$GH_STUB:$PATH" bash "$SCRIPT" 2>&1)
+rm -rf "$GH_STUB"
+
+# 輸出應包含「完成率」相關詞彙
+if echo "$FULL_OUT" | grep -qiE "完成率|completion|closed|total"; then
+  ok "T9a: output contains completion rate section"
+else
+  fail "T9a: output missing completion rate section"
+fi
+
+# 輸出應包含「趨勢」或「trend」相關詞彙
+if echo "$FULL_OUT" | grep -qiE "趨勢|trend|Sprint [0-9]+"; then
+  ok "T9b: output contains trend section"
+else
+  fail "T9b: output missing trend section"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- 新建 `scripts/retro-action-analysis.sh`：掃描 retro-action label Issues，計算完成率（closed/total）
- 識別標題關鍵字重複 >= 2 次的系統性問題，輸出 `[SYSTEMIC-ISSUE]` 標記
- 輸出近 5 Sprint Retro Action 完成率趨勢，含 `[TREND-UP/DOWN/STABLE]` 信號
- 新建 `tests/test-retro-action-analysis.sh`（13 個測試，全 fixture 隔離，13/13 PASS）
- gh API 失敗時優雅降級：輸出 `[WARN]` 並以空資料繼續

## AC 覆蓋

| AC | 狀態 |
|----|------|
| AC1: 新建 scripts/retro-action-analysis.sh | DONE |
| AC2: 掃描 retro-action Issues，計算完成率 | DONE |
| AC3: 關鍵字重複 >= 2 次輸出 [SYSTEMIC-ISSUE] | DONE |
| AC4: 近 5 Sprint 完成率趨勢 | DONE |
| AC5: tests/test-retro-action-analysis.sh（fixture 隔離）| DONE |
| NFR: gh 失敗 [WARN] 降級 | DONE |
| NFR: 執行時間 < 10s | DONE (~75ms) |

## Test plan

- [x] T1: 腳本存在且可執行
- [x] T2: 完成率計算正確（7/10 = 70%）
- [x] T3: total=0 邊界條件不崩潰
- [x] T4: [SYSTEMIC-ISSUE] 偵測關鍵字重複
- [x] T5: 無重複關鍵字時不誤觸 [SYSTEMIC-ISSUE]
- [x] T6: 近 5 Sprint 趨勢格式正確
- [x] T7: gh API 失敗 — exit 0 + [WARN] 輸出
- [x] T8: 執行時間 < 10000ms
- [x] T9: 整體輸出結構完整（完成率 + 趨勢區塊）

Closes #872

---
Generated with [Claude Code](https://claude.ai/claude-code)
