### PR TITLE
feat(#923): Hook 執行超時與隔離機制

### DIFF
--- a/hooks/hook-runner.sh
+++ b/hooks/hook-runner.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# hooks/hook-runner.sh
+# Story #923: Hook 執行超時與隔離機制
+#
+# 用途：帶 timeout + 隔離層的 Hook 執行包裝器
+#       所有 Hook 可透過此包裝器執行以獲得：
+#       1. Timeout 控制（預設 30s，可透過 HOOK_TIMEOUT 環境變數配置）
+#       2. 執行隔離（trap + subshell，單一 Hook 失敗不波及整體流程）
+#       3. 執行結果 metric 記錄（寫入 .claude/hooks/execution-metrics.jsonl）
+#
+# 用法：
+#   bash hooks/hook-runner.sh <hook-script> [args...]
+#   HOOK_TIMEOUT=60 bash hooks/hook-runner.sh hooks/my-hook.sh arg1
+#   HOOK_TIMEOUT=0  bash hooks/hook-runner.sh hooks/my-hook.sh  # 0 = 無限制
+
+set -uo pipefail
+
+# ── 設定區 ──────────────────────────────────────────────────────────────────
+
+# Hook timeout 秒數（NFR1：可配置，預設 30s）
+HOOK_TIMEOUT="${HOOK_TIMEOUT:-30}"
+
+# Metrics 寫入路徑（可透過環境變數覆蓋，用於測試隔離）
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+METRICS_FILE="${METRICS_FILE:-${REPO_ROOT}/.claude/hooks/execution-metrics.jsonl}"
+
+# ── 工具函式 ────────────────────────────────────────────────────────────────
+
+_now_ms() {
+  # 取得毫秒級時間戳（bash + date 相容實作）
+  if date +%s%3N >/dev/null 2>&1; then
+    date +%s%3N
+  else
+    # macOS fallback: python3
+    python3 -c "import time; print(int(time.time()*1000))" 2>/dev/null || \
+      echo $(($(date +%s) * 1000))
+  fi
+}
+
+_iso_timestamp() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+_write_metric() {
+  local hook_name="$1"
+  local status="$2"   # success | failure | timeout
+  local duration_ms="$3"
+  local exit_code="${4:-0}"
+
+  # 確保 metrics 目錄存在
+  local metrics_dir
+  metrics_dir="$(dirname "$METRICS_FILE")"
+  mkdir -p "$metrics_dir" 2>/dev/null || true
+
+  # 建構 JSONL 條目（NFR2：所有狀態均記錄）
+  local entry
+  entry=$(printf '{"timestamp":"%s","hook":"%s","status":"%s","duration_ms":%s,"exit_code":%s}' \
+    "$(_iso_timestamp)" \
+    "$hook_name" \
+    "$status" \
+    "$duration_ms" \
+    "$exit_code")
+
+  # 寫入（append），失敗靜默忽略（不阻塞主流程）
+  echo "$entry" >> "$METRICS_FILE" 2>/dev/null || true
+}
+
+# ── 主流程 ──────────────────────────────────────────────────────────────────
+
+# 驗證輸入
+if [[ $# -lt 1 ]]; then
+  echo "[HOOK-RUNNER] ERROR: 必須提供 hook script 路徑" >&2
+  exit 1
+fi
+
+HOOK_SCRIPT="$1"
+shift
+HOOK_ARGS=("$@")
+HOOK_NAME="$(basename "$HOOK_SCRIPT")"
+
+# 記錄開始時間
+START_MS=$(_now_ms)
+
+# ── AC2: Hook 執行隔離層 ─────────────────────────────────────────────────────
+# 使用 subshell + trap 確保 Hook 失敗不影響外層流程
+
+HOOK_EXIT=0
+HOOK_STATUS="success"
+
+if [[ "$HOOK_TIMEOUT" -eq 0 ]]; then
+  # 無限制模式：直接在 subshell 中執行
+  (
+    set +e
+    bash "$HOOK_SCRIPT" "${HOOK_ARGS[@]+"${HOOK_ARGS[@]}"}"
+  )
+  HOOK_EXIT=$?
+else
+  # ── AC1: Timeout 機制 ───────────────────────────────────────────────────
+  # 使用 timeout 指令包裝執行（POSIX 相容）
+  # timeout 返回碼：124 = timed out，其他 = hook 自身返回碼
+  if command -v timeout >/dev/null 2>&1; then
+    (
+      set +e
+      timeout "$HOOK_TIMEOUT" bash "$HOOK_SCRIPT" "${HOOK_ARGS[@]+"${HOOK_ARGS[@]}"}"
+    )
+    HOOK_EXIT=$?
+  else
+    # fallback: background + wait（macOS 無 timeout 指令時）
+    (
+      set +e
+      bash "$HOOK_SCRIPT" "${HOOK_ARGS[@]+"${HOOK_ARGS[@]}"}" &
+    ) &
+    BG_PID=$!
+    # 等待最多 HOOK_TIMEOUT 秒
+    WAIT_COUNT=0
+    while kill -0 "$BG_PID" 2>/dev/null && [[ $WAIT_COUNT -lt $HOOK_TIMEOUT ]]; do
+      sleep 1
+      WAIT_COUNT=$((WAIT_COUNT + 1))
+    done
+    if kill -0 "$BG_PID" 2>/dev/null; then
+      # 仍在執行 → 超時，kill
+      kill -TERM "$BG_PID" 2>/dev/null || true
+      sleep 1
+      kill -KILL "$BG_PID" 2>/dev/null || true
+      HOOK_EXIT=124  # 與 timeout 指令一致
+    else
+      wait "$BG_PID" 2>/dev/null
+      HOOK_EXIT=$?
+    fi
+  fi
+fi
+
+# 計算執行時間
+END_MS=$(_now_ms)
+DURATION_MS=$((END_MS - START_MS))
+
+# ── 狀態判定 ────────────────────────────────────────────────────────────────
+
+if [[ $HOOK_EXIT -eq 124 ]]; then
+  HOOK_STATUS="timeout"
+  # AC1: 超時記錄到 live-log（NFR2: observability）
+  echo "[HOOK-RUNNER] TIMEOUT: ${HOOK_NAME} exceeded ${HOOK_TIMEOUT}s limit, killed" >&2
+elif [[ $HOOK_EXIT -ne 0 ]]; then
+  HOOK_STATUS="failure"
+fi
+
+# ── AC3: Metric 記錄 ────────────────────────────────────────────────────────
+_write_metric "$HOOK_NAME" "$HOOK_STATUS" "$DURATION_MS" "$HOOK_EXIT"
+
+# ── 返回 Hook 的原始 exit code（AC2: 隔離層透明傳遞，不吞掉錯誤資訊）──────
+exit "$HOOK_EXIT"

--- a/tests/test-hook-timeout-isolation.sh
+++ b/tests/test-hook-timeout-isolation.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# tests/test-hook-timeout-isolation.sh
+# Story #923: Hook 執行超時與隔離機制 — 單元測試
+# AC4: >= 3 個測試（timeout, isolation, metric recording）
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK_RUNNER="${REPO_ROOT}/hooks/hook-runner.sh"
+METRICS_FILE="${REPO_ROOT}/.claude/hooks/execution-metrics.jsonl"
+PASS=0
+FAIL=0
+
+# Test helper
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  [PASS] $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  [FAIL] $desc — expected='$expected' actual='$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    echo "  [PASS] $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  [FAIL] $desc — expected '$needle' in output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_file_exists() {
+  local desc="$1" file="$2"
+  if [[ -f "$file" ]]; then
+    echo "  [PASS] $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  [FAIL] $desc — file not found: $file"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Test: Hook 執行超時與隔離機制 (Story #923) ==="
+
+# Setup: create temp dir for test hooks
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Create a fast-completing hook
+cat > "$TMPDIR/fast-hook.sh" << 'HOOK'
+#!/usr/bin/env bash
+echo "fast hook completed"
+exit 0
+HOOK
+chmod +x "$TMPDIR/fast-hook.sh"
+
+# Create a hook that sleeps longer than timeout
+cat > "$TMPDIR/slow-hook.sh" << 'HOOK'
+#!/usr/bin/env bash
+sleep 60
+echo "should not reach here"
+exit 0
+HOOK
+chmod +x "$TMPDIR/slow-hook.sh"
+
+# Create a hook that exits with error
+cat > "$TMPDIR/fail-hook.sh" << 'HOOK'
+#!/usr/bin/env bash
+echo "hook failure output" >&2
+exit 1
+HOOK
+chmod +x "$TMPDIR/fail-hook.sh"
+
+# Create a hook that exits successfully
+cat > "$TMPDIR/success-hook.sh" << 'HOOK'
+#!/usr/bin/env bash
+echo "hook success"
+exit 0
+HOOK
+chmod +x "$TMPDIR/success-hook.sh"
+
+# Remove old metrics file to start clean
+rm -f "$METRICS_FILE"
+
+echo ""
+echo "--- TC-1: Timeout 機制 ---"
+
+# TC-1.1: Fast hook completes within timeout → exit 0
+RESULT=$(HOOK_TIMEOUT=5 METRICS_FILE="$METRICS_FILE" bash "$HOOK_RUNNER" "$TMPDIR/fast-hook.sh" 2>/dev/null; echo "exit:$?")
+assert_contains "TC-1.1 fast hook completes successfully" "exit:0" "$RESULT"
+
+# TC-1.2: Slow hook is killed by timeout → exit non-zero or timeout recorded
+START=$(date +%s)
+HOOK_TIMEOUT=2 METRICS_FILE="$METRICS_FILE" bash "$HOOK_RUNNER" "$TMPDIR/slow-hook.sh" 2>/dev/null || true
+END=$(date +%s)
+ELAPSED=$((END - START))
+if [[ $ELAPSED -lt 5 ]]; then
+  echo "  [PASS] TC-1.2 slow hook killed within timeout window (${ELAPSED}s < 5s)"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] TC-1.2 slow hook took too long (${ELAPSED}s, timeout should be 2s)"
+  FAIL=$((FAIL + 1))
+fi
+
+# TC-1.3: Default timeout (HOOK_TIMEOUT not set) → uses 30s default (just verify it runs)
+OUTPUT=$(METRICS_FILE="$METRICS_FILE" bash "$HOOK_RUNNER" "$TMPDIR/fast-hook.sh" 2>/dev/null)
+assert_contains "TC-1.3 default timeout config runs successfully" "fast hook completed" "$OUTPUT"
+
+echo ""
+echo "--- TC-2: Isolation 機制 ---"
+
+# TC-2.1: Failed hook does not propagate failure to runner (isolation) → runner exits 0
+ISOLATION_EXIT=0
+HOOK_TIMEOUT=5 METRICS_FILE="$METRICS_FILE" bash "$HOOK_RUNNER" "$TMPDIR/fail-hook.sh" 2>/dev/null || ISOLATION_EXIT=$?
+# Runner should handle failure gracefully (record it) without crashing
+# exit code may be non-zero but process should complete cleanly
+if [[ $ISOLATION_EXIT -le 1 ]]; then
+  echo "  [PASS] TC-2.1 failed hook handled gracefully (exit=$ISOLATION_EXIT)"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] TC-2.1 unexpected exit code: $ISOLATION_EXIT"
+  FAIL=$((FAIL + 1))
+fi
+
+# TC-2.2: After a failed hook, subsequent hooks can still run
+OUTPUT2=$(HOOK_TIMEOUT=5 METRICS_FILE="$METRICS_FILE" bash "$HOOK_RUNNER" "$TMPDIR/success-hook.sh" 2>/dev/null)
+assert_contains "TC-2.2 subsequent hook runs after previous failure" "hook success" "$OUTPUT2"
+
+echo ""
+echo "--- TC-3: Metric 記錄 ---"
+
+# TC-3.1: Metrics file created after hook execution
+assert_file_exists "TC-3.1 metrics file exists after run" "$METRICS_FILE"
+
+# TC-3.2: Metrics file contains JSONL entries
+if [[ -f "$METRICS_FILE" ]]; then
+  ENTRY_COUNT=$(wc -l < "$METRICS_FILE")
+  if [[ $ENTRY_COUNT -gt 0 ]]; then
+    echo "  [PASS] TC-3.2 metrics file has $ENTRY_COUNT entries"
+    PASS=$((PASS + 1))
+  else
+    echo "  [FAIL] TC-3.2 metrics file is empty"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
+# TC-3.3: Metrics entries have required fields (hook, status, duration_ms, timestamp)
+if [[ -f "$METRICS_FILE" ]]; then
+  FIRST_ENTRY=$(head -1 "$METRICS_FILE")
+  assert_contains "TC-3.3 metrics entry has 'hook' field" '"hook"' "$FIRST_ENTRY"
+  assert_contains "TC-3.4 metrics entry has 'status' field" '"status"' "$FIRST_ENTRY"
+  assert_contains "TC-3.5 metrics entry has 'timestamp' field" '"timestamp"' "$FIRST_ENTRY"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS | FAIL: $FAIL"
+if [[ $FAIL -eq 0 ]]; then
+  echo "[TEST-SUITE-PASS] All tests passed"
+  exit 0
+else
+  echo "[TEST-SUITE-FAIL] $FAIL test(s) failed"
+  exit 1
+fi


### PR DESCRIPTION
## Story #923: Hook 執行超時與隔離機制

### 交付物
- `hooks/hook-runner.sh`: Hook 執行包裝器（timeout + 隔離 + metrics）
- `tests/test-hook-timeout-isolation.sh`: 10 個單元測試（全 PASS）
- `.claude/hooks/.gitkeep`: 確保 metrics 目錄存在

### AC 達成
- AC1: HOOK_TIMEOUT 可配置（預設 30s），timeout 事件記錄至 stderr（live-log）
- AC2: subshell 隔離層，單一 Hook 失敗不影響後續 Hook
- AC3: 執行結果 JSONL 寫入 .claude/hooks/execution-metrics.jsonl
- AC4: 10 個測試通過（timeout × 3、isolation × 2、metrics × 5）

### NFR
- NFR1（reliability）: HOOK_TIMEOUT 可配置，預設 30s，0 = 無限制
- NFR2（observability）: 所有執行狀態（success/failure/timeout）均記錄

Closes #923
