### PR TITLE
chore(#934): sprint-candidate 水位監控 — 補充 Discovery 至 10 個

### DIFF
--- a/docs/cruise-logs/2026-03-26-session-20260326-194854.jsonl
+++ b/docs/cruise-logs/2026-03-26-session-20260326-194854.jsonl
@@ -1,0 +1,1 @@
+{"timestamp":"2026-03-26T11:48:54Z","type":"memory-aware-dispatch","available_mb":3807,"dynamic_max":2,"static_max":2,"detection_method":"proc","warning_triggered":false,"memory_per_agent_mb":512}

--- a/docs/cruise-logs/2026-03-26-session-cron-20260326-194002.jsonl
+++ b/docs/cruise-logs/2026-03-26-session-cron-20260326-194002.jsonl
@@ -1,0 +1,1 @@
+{"type":"cruise-init","cycle":1,"mode":"once","patrol":"po","project_level":"low","strict":false,"repos":["kctw-dev/shikigami"],"session_id":"cron-20260326-194002","timestamp":"2026-03-26T11:41:35Z"}

--- a/docs/cruise-logs/backlog-water-20260326.jsonl
+++ b/docs/cruise-logs/backlog-water-20260326.jsonl
@@ -1,0 +1,1 @@
+{"type":"backlog-water-check","sprint":175,"story":"#934","timestamp":"2026-03-26T20:01:50Z","sprint_candidate_before":6,"sprint_candidate_after":10,"threshold":10,"action":"discovery-triggered","new_issues":["#939","#940","#941","#942"],"result":"OK"}


### PR DESCRIPTION
## Story #934: sprint-candidate 水位持續監控與補充機制

### 交付物
- Backlog Discovery 執行：建立 4 個新 sprint-candidate Issues (#939, #940, #941, #942)
- `docs/cruise-logs/backlog-water-20260326.jsonl`：水位監控可追溯記錄

### AC 達成
- AC1: Sprint 175 Planning 前水位 10（達標 >= 10 ✓）
- AC2: Sprint 175 執行後水位 6 → 觸發 Backlog Discovery → 補充至 10
  - #939: 高風險 Hook 遷移至 hook-runner.sh (S, should)
  - #940: Skill 依賴宣告一致性驗證 (S, could)
  - #941: Hook 執行指標查詢工具 (S, could)
  - #942: docs/guides/ 統一索引 (S, could)

### NFR
- NFR1（observability）: 結果寫入 cruise log，可追溯 ✓

Closes #934
