### PR TITLE
feat(#944): 自動化 sprint-candidate 水位週期性監控機制

### DIFF
--- a/.github/workflows/backlog-health-monitor.yml
+++ b/.github/workflows/backlog-health-monitor.yml
@@ -1,0 +1,92 @@
+name: Backlog Health Monitor
+
+# Story #944: 自動化 sprint-candidate 水位週期性監控機制
+#
+# 觸發時機：
+#   - 每週一、三、五 UTC 09:00（週期性自動檢查）
+#   - 手動觸發（workflow_dispatch）
+#
+# 執行內容：
+#   - bash scripts/check-backlog-health.sh 檢查 sprint-candidate 水位
+#   - 水位不足時輸出 [BACKLOG-REPLENISH-TRIGGER]（可被 CI log 監控捕捉）
+#   - 每次執行結果寫入 JSONL 趨勢記錄（NFR2）
+#
+# NFR1: continue-on-error: true 確保本 workflow 失敗不阻擋其他 CI pipeline
+# 設計參考：complexity-trend.yml（AC3 要求）
+
+on:
+  schedule:
+    - cron: '0 9 * * 1,3,5'  # 週一、三、五 UTC 09:00
+  workflow_dispatch:
+    inputs:
+      threshold:
+        description: "sprint-candidate 水位閾值（預設 10）"
+        required: false
+        default: "10"
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  backlog-health-monitor:
+    name: "Backlog Health 水位監控"
+    runs-on: ubuntu-latest
+    continue-on-error: true  # NFR1: 失敗不阻擋其他 CI pipeline
+
+    permissions:
+      contents: write  # 寫入 JSONL 趨勢記錄並 commit
+      issues: read
+
+    env:
+      THRESHOLD: ${{ inputs.threshold || '10' }}
+      REPO: ${{ github.repository }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install jq
+        run: |
+          if ! command -v jq > /dev/null 2>&1; then
+            sudo apt-get install -y jq
+          fi
+
+      - name: Run backlog health check
+        id: health_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "[BACKLOG-MONITOR] 開始水位監控檢查..."
+          echo "[BACKLOG-MONITOR] threshold=${THRESHOLD}"
+
+          bash scripts/check-backlog-health.sh \
+            --threshold "${THRESHOLD}" \
+            --repo "${REPO}"
+
+          echo "[BACKLOG-MONITOR] 檢查完成"
+
+      - name: Commit JSONL trend record
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # 尋找今日 JSONL 趨勢記錄
+          TODAY=$(date '+%Y%m%d')
+          JSONL_FILE="docs/cruise-logs/backlog-water-${TODAY}.jsonl"
+
+          if [[ -f "$JSONL_FILE" ]]; then
+            git add "$JSONL_FILE"
+            if ! git diff --cached --quiet; then
+              git commit -m "chore: backlog-health 水位監控趨勢記錄 $(date '+%Y-%m-%d')"
+              git push
+              echo "[BACKLOG-MONITOR] JSONL 趨勢記錄已推送"
+            else
+              echo "[BACKLOG-MONITOR] 無新趨勢記錄需 commit"
+            fi
+          else
+            echo "[BACKLOG-MONITOR] 今日 JSONL 記錄未建立（可能 gh CLI 靜默降級），跳過 commit"
+          fi

--- a/scripts/check-backlog-health.sh
+++ b/scripts/check-backlog-health.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# scripts/check-backlog-health.sh
+# Story #944: 自動化 sprint-candidate 水位週期性監控機制
+#
+# 讀取 sprint-candidate 水位，低於閾值時輸出 [BACKLOG-REPLENISH-TRIGGER]
+# 可被 CI workflow 捕捉並觸發補充動作
+#
+# Usage:
+#   bash scripts/check-backlog-health.sh [options]
+#
+# Options:
+#   --threshold N        水位閾值（預設 10）    [AC4]
+#   --dry-run            使用模擬資料（gh CLI 失敗時的降級模式）
+#   --output-jsonl PATH  將結果追加寫入 JSONL 趨勢記錄  [NFR2]
+#   --repo OWNER/REPO    目標 repo（預設從 git remote 解析）
+#
+# Exit codes:
+#   0  正常（含 gh CLI 失敗靜默降級）[NFR1]
+#   0  水位不足（輸出 [BACKLOG-REPLENISH-TRIGGER]，供 CI 用 grep 捕捉）
+
+set -uo pipefail
+
+# ── 預設值 ────────────────────────────────────────────────────────────────
+
+THRESHOLD=10
+DRY_RUN=false
+OUTPUT_JSONL=""
+REPO=""
+
+# ── 參數解析 ──────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --threshold)   THRESHOLD="$2";    shift 2 ;;
+    --dry-run)     DRY_RUN=true;      shift   ;;
+    --output-jsonl) OUTPUT_JSONL="$2"; shift 2 ;;
+    --repo)        REPO="$2";         shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# ── Repo 偵測 ─────────────────────────────────────────────────────────────
+
+if [[ -z "$REPO" ]]; then
+  REPO=$(git remote get-url origin 2>/dev/null \
+    | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##; s#\.git$##') || REPO=""
+fi
+
+# ── sprint-candidate 水位取得 ─────────────────────────────────────────────
+
+CANDIDATE_COUNT=0
+GH_OK=false
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  # dry-run 模式：使用 0 作為模擬水位（用於測試 TRIGGER 輸出）
+  CANDIDATE_COUNT=0
+  GH_OK=true
+else
+  # NFR1：gh CLI 失敗靜默降級 — 整個區塊用 || true 防止 pipefail 終止
+  if command -v gh >/dev/null 2>&1; then
+    COUNT_RAW=$(gh issue list \
+      ${REPO:+-R "$REPO"} \
+      --label "sprint-candidate" \
+      --state open \
+      --json number \
+      --jq 'length' 2>/dev/null) || COUNT_RAW=""
+    if [[ -n "$COUNT_RAW" && "$COUNT_RAW" =~ ^[0-9]+$ ]]; then
+      CANDIDATE_COUNT="$COUNT_RAW"
+      GH_OK=true
+    fi
+  fi
+fi
+
+# NFR1：gh CLI 不可用時靜默離開（exit 0）
+if [[ "$GH_OK" == "false" && "$DRY_RUN" == "false" ]]; then
+  echo "[BACKLOG-HEALTH] WARNING: gh CLI unavailable or failed — skipping check (NFR1 silent degradation)"
+  exit 0
+fi
+
+# ── 閾值比對 ──────────────────────────────────────────────────────────────
+
+TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
+STATUS="ok"
+
+if [[ "$CANDIDATE_COUNT" -lt "$THRESHOLD" ]]; then
+  STATUS="low"
+  echo "[BACKLOG-REPLENISH-TRIGGER] sprint-candidate 水位不足：${CANDIDATE_COUNT} < ${THRESHOLD}（閾值）"
+else
+  echo "[BACKLOG-HEALTH] sprint-candidate 水位正常：${CANDIDATE_COUNT} >= ${THRESHOLD}（閾值）"
+fi
+
+# ── NFR2：JSONL 趨勢記錄 ──────────────────────────────────────────────────
+
+# 預設 JSONL 路徑（若未指定）
+if [[ -z "$OUTPUT_JSONL" ]]; then
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  OUTPUT_JSONL="${REPO_ROOT}/docs/cruise-logs/backlog-water-$(date '+%Y%m%d').jsonl"
+fi
+
+# 確保目錄存在
+JSONL_DIR="$(dirname "$OUTPUT_JSONL")"
+mkdir -p "$JSONL_DIR" 2>/dev/null || true
+
+ENTRY=$(printf '{"timestamp":"%s","sprint_candidate_count":%d,"threshold":%d,"status":"%s","repo":"%s"}\n' \
+  "$TIMESTAMP" "$CANDIDATE_COUNT" "$THRESHOLD" "$STATUS" "${REPO:-unknown}")
+
+# 寫入失敗靜默忽略（不阻塞主流程）
+echo "$ENTRY" >> "$OUTPUT_JSONL" 2>/dev/null || true
+
+# exit 0 — CI 以 grep [BACKLOG-REPLENISH-TRIGGER] 判斷狀態，不依賴 exit code
+exit 0

--- a/tests/test-check-backlog-health.sh
+++ b/tests/test-check-backlog-health.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# tests/test-check-backlog-health.sh
+# Story #944: 自動化 sprint-candidate 水位週期性監控機制
+# AC1: scripts/check-backlog-health.sh 存在，讀取 sprint-candidate 水位
+# AC2: 水位不足輸出 [BACKLOG-REPLENISH-TRIGGER]
+# AC4: 支援 --threshold 參數
+# NFR1: gh CLI 失敗靜默降級（exit 0）
+# NFR2: 結果寫入 JSONL
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-backlog-health.sh"
+PASS=0
+FAIL=0
+
+assert_pass() {
+  local desc="$1"; shift
+  local rc=0
+  "$@" >/dev/null 2>&1 || rc=$?
+  if [[ $rc -eq 0 ]]; then
+    echo "  [PASS] $desc"
+    PASS=$((PASS+1))
+  else
+    echo "  [FAIL] $desc (exit=$rc)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_output_contains() {
+  local desc="$1" needle="$2"; shift 2
+  local out
+  out=$("$@" 2>&1) || true
+  if echo "$out" | grep -q "$needle"; then
+    echo "  [PASS] $desc"
+    PASS=$((PASS+1))
+  else
+    echo "  [FAIL] $desc — expected '$needle'"
+    echo "         got: $(echo "$out" | head -2)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_file_exists() {
+  local desc="$1" f="$2"
+  if [[ -f "$f" ]]; then echo "  [PASS] $desc"; PASS=$((PASS+1))
+  else echo "  [FAIL] $desc — file not found: $f"; FAIL=$((FAIL+1)); fi
+}
+
+echo "--- AC1: 腳本存在且可執行 ---"
+assert_file_exists "check-backlog-health.sh 存在" "$SCRIPT"
+[[ -x "$SCRIPT" ]] && { echo "  [PASS] 腳本可執行"; PASS=$((PASS+1)); } || { echo "  [FAIL] 腳本不可執行"; FAIL=$((FAIL+1)); }
+
+echo "--- AC2: [BACKLOG-REPLENISH-TRIGGER] 輸出 (強制低水位) ---"
+assert_output_contains "低水位觸發 TRIGGER" "[BACKLOG-REPLENISH-TRIGGER]" \
+  bash "$SCRIPT" --threshold 99999 --dry-run
+
+echo "--- AC4: --threshold 覆蓋預設值 ---"
+# threshold=0 → 水位永遠達標，不輸出 TRIGGER
+out=$(bash "$SCRIPT" --threshold 0 --dry-run 2>&1) || true
+if echo "$out" | grep -q "\[BACKLOG-REPLENISH-TRIGGER\]"; then
+  echo "  [FAIL] threshold=0 不應觸發 TRIGGER"
+  FAIL=$((FAIL+1))
+else
+  echo "  [PASS] threshold=0 不觸發 TRIGGER"
+  PASS=$((PASS+1))
+fi
+
+echo "--- NFR1: gh CLI 失敗靜默降級 ---"
+# 模擬 gh CLI 不可用：建立假 gh 腳本讓它 exit 1（模擬 auth failure）
+TMPBIN=$(mktemp -d)
+cat > "$TMPBIN/gh" << 'FAKEGH'
+#!/usr/bin/env bash
+exit 1
+FAKEGH
+chmod +x "$TMPBIN/gh"
+rc=0
+PATH="$TMPBIN:$PATH" bash "$SCRIPT" 2>/dev/null || rc=$?
+rm -rf "$TMPBIN"
+if [[ $rc -eq 0 ]]; then
+  echo "  [PASS] gh CLI 失敗時 exit 0（靜默降級）"
+  PASS=$((PASS+1))
+else
+  echo "  [FAIL] gh CLI 失敗時 exit $rc（應為 0）"
+  FAIL=$((FAIL+1))
+fi
+
+echo "--- NFR2: JSONL 趨勢記錄 ---"
+TMPDIR_JSONL=$(mktemp -d)
+JSONL_OUT="$TMPDIR_JSONL/health.jsonl"
+bash "$SCRIPT" --threshold 0 --output-jsonl "$JSONL_OUT" --dry-run 2>/dev/null || true
+assert_file_exists "JSONL 記錄建立" "$JSONL_OUT"
+rm -rf "$TMPDIR_JSONL"
+
+echo ""
+echo "=== 結果: PASS=$PASS FAIL=$FAIL ==="
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- 新增 `scripts/check-backlog-health.sh`：讀取 sprint-candidate 水位，低於閾值輸出 `[BACKLOG-REPLENISH-TRIGGER]`
- 支援 `--threshold` 參數覆蓋預設值 10，gh CLI 失敗靜默降級（exit 0）
- 新增 `.github/workflows/backlog-health-monitor.yml`：週一/三/五 UTC 09:00 定期觸發
- 新增 `tests/test-check-backlog-health.sh`：TDD 全 PASS（6/6）

## AC Checklist
- [x] AC1: scripts/check-backlog-health.sh 存在且可執行
- [x] AC2: 水位不足輸出 [BACKLOG-REPLENISH-TRIGGER]
- [x] AC3: 整合至 CI workflow（backlog-health-monitor.yml，參考 complexity-trend.yml 設計）
- [x] AC4: --threshold 參數正常運作
- [x] NFR1: gh CLI 失敗靜默降級 exit 0
- [x] NFR2: 執行結果寫入 JSONL 趨勢記錄

## Test plan
- [x] bash tests/test-check-backlog-health.sh — PASS 6/6
- [x] bash scripts/validate-json.sh — PASS
- [x] bash scripts/validate-ci-versions.sh — PASS (all @v4)
