### PR TITLE
#968 worktree 平行執行時確保 branch 從乾淨 base 建立，防止 commit 交叉污染

### DIFF
--- a/skills/git-workflow/references/branch-setup.md
+++ b/skills/git-workflow/references/branch-setup.md
@@ -51,9 +51,20 @@ git check-ignore -q .worktrees
 
 ## 2.3 建立 Worktree + Feature Branch
 
+建立 worktree 時，應明確指定 base ref 以確保從乾淨狀態起點開始（#968）：
+
 ```bash
-git worktree add <worktree-path> -b <branch-name>
+# 準備：同步遠端 main
+git fetch origin main
+
+# 建立 worktree，明確指定 origin/main 作為 base
+git worktree add <worktree-path> -b <branch-name> origin/main
 ```
+
+**重要**：
+- 使用 `origin/main` 作為 base，而非本地 `main` 或 `.`（current HEAD）
+- 這確保 worktree 從遠端乾淨的 main 起點建立
+- 尤其在平行執行多個 worktree 時，此做法防止 commit 交叉污染（#968 Retro Action）
 
 ---
 

--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -58,6 +58,23 @@ Sprint 執行支援**雙軌派遣機制**：由環境變數 `SHIKIGAMI_MODEL_PRO
 | `docs/sprints/sprint-checkpoint.json` | Sprint 進度 checkpoint（coordinator-only） |
 </HARD-GATE>
 
+### Worktree Branch Base 隔離檢查（#968）
+
+<!-- #968 worktree 平行執行時確保 branch 從乾淨 base 建立 — Sprint 178 -->
+
+平行派遣 worktree subagent 前，必須確保所有 worktree branch 都從乾淨的 `origin/main` 起點建立，防止 commit 交叉污染（Sprint 177 Retro Action）。
+
+**主 session 派遣準備清單**：
+
+1. **執行全局 fetch**：`git fetch origin main`（一次性準備）
+2. **記錄 epoch commit**：`EPOCH_COMMIT=$(git rev-parse origin/main)` — 記錄派遣時刻的 main 版本
+3. **派遣各 Story subagent**，各自執行：
+   - 建立 worktree 時明確指定 base ref：`git worktree add <path> -b <branch> origin/main`
+   - 驗證初始 commit：`WORKTREE_HEAD=$(git rev-parse HEAD)` 應等於 EPOCH_COMMIT
+4. **平行完成後**：主 session 驗證所有 PR 的 commit 歷史無污染（PR review 時檢查）
+
+詳細流程見 `references/parallel-safety.md` **Worktree Branch Base 隔離檢查（#968）**
+
 ### 自動記憶體感知派遣（#712 / #722）
 
 派遣 subagent 前，**自動**執行 `scripts/memory-aware-dispatch.sh` 取得動態安全並行上限，無需人工決策：

--- a/skills/sprint-execution/references/parallel-safety.md
+++ b/skills/sprint-execution/references/parallel-safety.md
@@ -219,6 +219,71 @@ Sprint Execution 派遣 Story-Lifecycle subagent 時，使用 Claude Code Agent 
 > 每個 subagent 在獨立工作目錄操作，共用文件衝突風險大幅降低。
 > 但 PR merge 順序仍可能造成衝突，主 session 負責 merge conflict 解決。
 
+### Worktree Branch Base 隔離檢查（#968）
+
+<!-- #968 worktree 平行執行時確保 branch 從乾淨 base 建立 — Sprint 178 -->
+
+平行派遣 worktree subagent 時，必須確保每個 worktree 的 branch 都從乾淨的 `origin/main` 起點建立。防止 Sprint 177 中 #935 PR 混入 #954 commit 的問題（root cause：worktree branch 不是從乾淨的 main 建立）。
+
+#### 建立 Worktree 前的準備步驟
+
+派遣 Story-Lifecycle subagent 建立 worktree 前，執行以下準備步驟以確保 base 隔離：
+
+```
+步驟 1：同步遠端 main
+  git fetch origin main
+  |-- 取得最新遠端 main commit
+
+步驟 2：驗證本地 main 狀態
+  CURRENT_MAIN_COMMIT=$(git rev-parse origin/main)
+  |-- 記錄當前 origin/main 的 commit hash
+
+步驟 3：建立 worktree 並明確指定 base
+  git worktree add <worktree-path> -b <branch-name> origin/main
+  |-- 使用 origin/main 作為 base ref，確保從乾淨起點建立
+  |-- 禁止使用本地 main 或 HEAD（可能含有未推送變更）
+
+步驟 4：驗證 worktree 初始 commit
+  cd <worktree-path>
+  WORKTREE_COMMIT=$(git rev-parse HEAD)
+  |-- 確保 worktree HEAD == origin/main，無污染
+  |-- 若 WORKTREE_COMMIT != CURRENT_MAIN_COMMIT → 報錯 [BASE-ISOLATION-FAIL]
+```
+
+#### 快速參考：完整命令序列
+
+```bash
+# 準備：同步遠端並記錄 base commit
+git fetch origin main
+BASE_COMMIT=$(git rev-parse origin/main)
+
+# 建立隔離 worktree，明確指定 base
+BRANCH_NAME="sprint-${SPRINT_NUM}/${STORY_ID}-feature"
+WORKTREE_PATH=".claude/worktrees/${BRANCH_NAME}"
+
+git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" origin/main
+
+# 驗證初始狀態
+cd "${WORKTREE_PATH}"
+WORKTREE_HEAD=$(git rev-parse HEAD)
+if [[ "${WORKTREE_HEAD}" != "${BASE_COMMIT}" ]]; then
+  echo "[BASE-ISOLATION-FAIL] worktree HEAD (${WORKTREE_HEAD}) != origin/main (${BASE_COMMIT})"
+  exit 1
+fi
+echo "[BASE-ISOLATION-OK] worktree branch created from clean origin/main"
+```
+
+#### 平行派遣時的檢查
+
+多個 Story 平行派遣時，每個 subagent **獨立執行**上述準備步驟。主 session 派遣前：
+
+1. 執行 `git fetch origin main`（全局準備，一次性）
+2. 記錄 `origin/main` commit hash 作為 epoch
+3. 派遣各 Story subagent，各自在 worktree 中執行步驟 3-4
+4. 所有 subagent 完成後，驗證無 commit 混入（PR review 時檢查）
+
+**目標**：即使平行執行，每個 worktree 都基於同一乾淨 main epoch，避免版本漂移或 commit 交叉污染。
+
 ## 主 session 批次更新機制
 
 所有平行 subagent 完成後，**主 session 統一批次更新**：收集所有 PASS/FAIL/ESCALATE 結果 → 一次性讀取 `PROJECT_BOARD.md` 與 `sprint_N.md` → 依序套用狀態更新 → 單次 commit 提交。

--- a/tests/test-968-worktree-base-isolation.sh
+++ b/tests/test-968-worktree-base-isolation.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# tests/test-968-worktree-base-isolation.sh
+# Story #968 — worktree branch base isolation 隔離檢查與防污染測試
+#
+# ── 目的 ──────────────────────────────────────────────────────────────────
+#
+# 驗證平行 worktree 執行時，branch 正確從乾淨的 origin/main base 建立。
+# 防止 Sprint 177 #935 PR 混入 #954 commit 的問題重演。
+#
+# AC-1：parallel-safety.md 加入「建立 worktree 前先 fetch + 確認 base commit」步驟
+# AC-2：worktree 建立範例改為明確指定 base commit（origin/main 或可配置的 base ref）
+# AC-3：Sprint Execution 流程文件中加入 worktree branch isolation checklist
+#
+# ── 使用方式 ─────────────────────────────────────────────────────────────
+#   bash tests/test-968-worktree-base-isolation.sh
+# ─────────────────────────────────────────────────────────────────────────
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "  [PASS] $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  [FAIL] $1"; echo "    [DIAG] $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+echo "=== worktree branch base isolation 隔離檢查測試 (#968) ==="
+echo ""
+
+# ─── AC-1：parallel-safety.md 包含 fetch + base commit 檢查步驟 ────────
+echo "--- AC-1: parallel-safety.md 包含 base 同步檢查 ---"
+
+PARALLEL_SAFETY_REF="${REPO_ROOT}/skills/sprint-execution/references/parallel-safety.md"
+
+if [[ -f "${PARALLEL_SAFETY_REF}" ]]; then
+  pass "AC-1a: parallel-safety.md 存在"
+
+  # 檢查是否包含 fetch origin/main 或類似的 base 同步指令
+  if grep -q "git fetch\|fetch origin\|origin/main\|base.*commit\|clean.*base\|base branch" "${PARALLEL_SAFETY_REF}" 2>/dev/null; then
+    pass "AC-1b: parallel-safety.md 包含 base 同步檢查邏輯（fetch/origin-main）"
+  else
+    fail "AC-1b: parallel-safety.md 缺少 base 同步檢查" \
+      "未找到 git fetch、origin/main、或 base commit 驗證的相關說明"
+  fi
+
+  # 檢查是否提及 worktree 建立前的準備步驟
+  if grep -q "worktree.*建立前\|before.*worktree\|準備.*worktree\|worktree.*isolat" "${PARALLEL_SAFETY_REF}" 2>/dev/null; then
+    pass "AC-1c: parallel-safety.md 提及 worktree 建立前的準備流程"
+  else
+    fail "AC-1c: parallel-safety.md 缺少 worktree 建立前準備描述" \
+      "需要明確說明建立 worktree 前應執行的基礎檢查（fetch、base 驗證）"
+  fi
+else
+  fail "AC-1a: parallel-safety.md 不存在" \
+    "找不到 ${PARALLEL_SAFETY_REF}"
+fi
+
+echo ""
+
+# ─── AC-2：worktree 建立範例使用明確 base commit / origin/main ────────
+echo "--- AC-2: worktree 建立範例使用 origin/main base ---"
+
+# 檢查 parallel-safety.md 中是否有 worktree 建立範例
+if [[ -f "${PARALLEL_SAFETY_REF}" ]]; then
+  if grep -q "git worktree add" "${PARALLEL_SAFETY_REF}" 2>/dev/null; then
+    pass "AC-2a: parallel-safety.md 包含 git worktree add 範例"
+
+    # 檢查範例是否明確指定 base（origin/main 或 HEAD）
+    if grep "git worktree add" "${PARALLEL_SAFETY_REF}" | grep -q "origin/main\|HEAD\|@\|fetch" 2>/dev/null; then
+      pass "AC-2b: worktree add 範例明確指定 base ref（origin/main 或 HEAD）"
+    else
+      fail "AC-2b: worktree add 範例未明確指定 base" \
+        "範例應使用 'git worktree add <path> origin/main' 或類似明確 base 指定"
+    fi
+  else
+    fail "AC-2a: parallel-safety.md 缺少 git worktree add 範例" \
+      "應在 parallel-safety.md 中提供 worktree 建立的明確範例代碼"
+  fi
+fi
+
+echo ""
+
+# ─── AC-3：Sprint Execution 流程文件中加入 worktree isolation checklist ──
+echo "--- AC-3: Sprint Execution 流程包含 worktree isolation checklist ---"
+
+SPRINT_EXEC_SKILL="${REPO_ROOT}/skills/sprint-execution/SKILL.md"
+STORY_LIFECYCLE_PROMPT="${REPO_ROOT}/skills/sprint-execution/story-lifecycle-prompt.md"
+
+# 檢查 SKILL.md 或 story-lifecycle-prompt.md 是否提及 worktree base 隔離
+if [[ -f "${SPRINT_EXEC_SKILL}" ]]; then
+  if grep -q "worktree.*base\|base.*branch\|isolation.*check\|clean.*main\|origin/main" "${SPRINT_EXEC_SKILL}" 2>/dev/null; then
+    pass "AC-3a: sprint-execution/SKILL.md 包含 worktree base 隔離內容"
+  else
+    fail "AC-3a: sprint-execution/SKILL.md 缺少 worktree base 隔離說明" \
+      "應在 SKILL.md 中提及 worktree base 隔離檢查（fetch origin/main、branch from clean base）"
+  fi
+else
+  fail "AC-3a: sprint-execution/SKILL.md 不存在" \
+    "找不到 ${SPRINT_EXEC_SKILL}"
+fi
+
+# 檢查 story-lifecycle-prompt.md 是否提及 base 隔離流程
+if [[ -f "${STORY_LIFECYCLE_PROMPT}" ]]; then
+  if grep -q "fetch origin\|origin/main\|base.*commit\|worktree.*base\|clean.*base" "${STORY_LIFECYCLE_PROMPT}" 2>/dev/null; then
+    pass "AC-3b: story-lifecycle-prompt.md 包含 base 隔離流程說明"
+  else
+    # 不強制要求，因為隔離可能在 parallel-safety.md 或其他參考文件中
+    pass "AC-3b: story-lifecycle-prompt.md 不需強制提及（可在 parallel-safety.md 中統一說明）"
+  fi
+else
+  fail "AC-3b: story-lifecycle-prompt.md 不存在" \
+    "找不到 ${STORY_LIFECYCLE_PROMPT}"
+fi
+
+echo ""
+
+# ─── 額外驗證：確認相關技術文件的一致性 ──────────────────────────────────
+echo "--- 額外驗證：技術文件一致性 ---"
+
+# 檢查 git-workflow 中是否提及 base isolation
+GIT_WORKFLOW_REF="${REPO_ROOT}/skills/git-workflow/references/branch-setup.md"
+if [[ -f "${GIT_WORKFLOW_REF}" ]]; then
+  if grep -q "origin/main\|fetch\|base" "${GIT_WORKFLOW_REF}" 2>/dev/null; then
+    pass "AC-Extra-1: git-workflow/branch-setup.md 包含 base 相關內容"
+  else
+    fail "AC-Extra-1: git-workflow/branch-setup.md 缺少 base isolation 說明" \
+      "建議在 branch-setup.md 中提及 origin/main 作為 base"
+  fi
+else
+  pass "AC-Extra-1: git-workflow/branch-setup.md 不存在（非強制）"
+fi
+
+# 檢查 parallel-safety.md 中是否包含過時或錯誤的 worktree 建立方式
+if [[ -f "${PARALLEL_SAFETY_REF}" ]]; then
+  # 負向檢查：確保沒有建議直接使用當前 HEAD 而不檢查 origin/main
+  if grep "git worktree add" "${PARALLEL_SAFETY_REF}" | grep -q "^[^#]*git worktree add[^#]*$" 2>/dev/null; then
+    # 有 worktree add 指令，檢查是否避免了危險的做法
+    if ! grep "git worktree add" "${PARALLEL_SAFETY_REF}" | grep -q "\-\-detach\|\.\|\$\{PWD\}" 2>/dev/null; then
+      # 不包含危險的相對路徑或 PWD，這是好的
+      pass "AC-Extra-2: worktree add 指令不包含危險的相對參照"
+    fi
+  fi
+fi
+
+echo ""
+
+# ─── 統計結果 ────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+PASS_PCT=0
+if [[ $TOTAL -gt 0 ]]; then
+  PASS_PCT=$((PASS_COUNT * 100 / TOTAL))
+fi
+
+echo "=== 測試結果摘要 ==="
+echo "通過：$PASS_COUNT / $TOTAL（$PASS_PCT%）"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  echo "失敗：$FAIL_COUNT"
+  exit 1
+else
+  echo "失敗：0"
+  exit 0
+fi


### PR DESCRIPTION
## 摘要

強化 Parallel Dispatch / Worktree 建立流程，確保每個 worktree 的 branch 都從乾淨的 main（或正確 base）起點建立。

## 背景

Sprint 177 Retro Action：#935 PR 混入了 #954 的 commit，原因是 worktree branching 時 branch 起點不正確，導致兩個 Story 的 commit 歷史交叉。根本原因：worktree 建立時未確認正確的 base branch 狀態。

## 變更清單

- `skills/sprint-execution/references/parallel-safety.md` — 加入 Worktree Branch Base 隔離檢查（§4.2）
  - 建立 Worktree 前的準備步驟（fetch、epoch 記錄、base 驗證）
  - 快速參考：完整命令序列
  - 平行派遣時的檢查流程

- `skills/git-workflow/references/branch-setup.md` — 更新 worktree 建立範例（§2.3）
  - 明確指定 `origin/main` 作為 base ref
  - 說明重要性與預防措施

- `skills/sprint-execution/SKILL.md` — 加入 Worktree Branch Base 隔離檢查（§2.3）
  - 主 session 派遣準備清單
  - 參考詳細流程位置

- `tests/test-968-worktree-base-isolation.sh` — 新增自動化測試
  - AC-1：parallel-safety.md 包含 base 同步檢查
  - AC-2：worktree add 範例明確指定 origin/main
  - AC-3：Sprint Execution 流程包含 isolation checklist

## AC 驗證

- [x] AC-1：parallel-safety.md 加入「建立 worktree 前先 fetch + 確認 base commit」步驟
- [x] AC-2：worktree 建立指令範例改為明確指定 base commit（git worktree add <path> origin/main）
- [x] AC-3：Sprint Execution 流程文件中加入 worktree branch isolation checklist

## 測試計劃

- [x] 自動化測試通過：`bash tests/test-968-worktree-base-isolation.sh` → 9/9 通過（100%）
- [ ] 驗證 parallel-safety.md 文件完整性
- [ ] 檢查與其他 worktree 相關文件的一致性
- [ ] 確認範例代碼可執行（dry-run）

## 相關 Issue

- Closes #968
- Sprint 177 Retro Action（防止 #935/#954 commit 混入問題重演）