### PR TITLE
feat(#988): ADR-045 Phase 2 — L2 delivery-completion-check step subagent

### DIFF
--- a/scripts/state-machine/step-subagent-poc.sh
+++ b/scripts/state-machine/step-subagent-poc.sh
@@ -98,6 +98,96 @@ PROMPT_EOF
   echo "[PROMPT-GENERATED] ${output_file}"
 }
 
+generate_prompt_delivery_completion_check() {
+  local sprint_number="$1"
+  local story_id="${2:-STORY_ID}"
+  local branch="${3:-BRANCH_NAME}"
+  local output_file="${POC_OUTPUT_DIR}/prompt-delivery-completion-check.md"
+
+  mkdir -p "${POC_OUTPUT_DIR}"
+
+  # 讀取 prompt template（從 SKILL steps 目錄）
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local repo_root
+  repo_root="$(cd "${script_dir}/../.." && pwd)"
+  local template_file="${repo_root}/skills/sprint-execution/steps/delivery-completion-check.md"
+
+  if [[ -f "${template_file}" ]]; then
+    cp "${template_file}" "${output_file}"
+  else
+    # fallback：內嵌最小版本
+    cat > "${output_file}" <<'PROMPT_EOF'
+# Step Subagent: delivery-completion-check
+
+## 規則片段
+
+你是 Sprint Execution 的 delivery-completion-check 步驟 subagent。你的唯一任務是驗證 Story 交付的 PR 是否真實存在且合規。
+
+### 必須遵守的規則
+
+1. **禁止 git push**：不可執行任何 `git push` 指令，你是唯讀驗證者
+2. **禁止 gh pr create**：不可建立任何 PR，即使你認為缺少 PR 也絕對不可自行建立
+3. **禁止 gh pr merge**：不可合併任何 PR，merge 決策由主 session 執行
+4. **禁止代建 PR**：不可代替 Story-Lifecycle subagent 補建 PR，任何 PR 缺失必須回報 status=failed
+5. **禁止接受 doc-only 無需 PR 自圓其說**：doc-only 不是豁免理由，所有 Story 交付必須有 PR
+
+### 禁止工具清單
+
+- git push（任何形式）
+- gh pr create（任何形式）
+- gh pr merge（任何形式）
+- git commit（任何形式）
+- 任何寫入或修改檔案的操作
+
+### 唯一允許的工具
+
+- gh pr list：查詢 PR 清單
+- gh pr view：讀取 PR 詳情
+- git log：查閱 commit 歷史
+- cat：讀取本地檔案
+- 讀取 state machine 狀態檔
+
+## 輸入契約
+
+- Story ID：{story_id}
+- Branch name：{branch_name}
+- Claimed PR URL：{claimed_pr_url}
+- 結果輸出路徑：{result_file}
+
+## 輸出契約
+
+必須產出：
+- {result_file}（步驟結果 JSON，遵循 ADR-045 §3 格式）
+
+## 成功/失敗判定
+
+成功條件：
+- PR 存在（gh pr list 非空）
+- PR state = OPEN
+- PR baseRefName = main
+- claimed_pr_url（若非空）與實查 url 一致
+
+失敗條件：
+- PR 不存在（NO_PR_FOUND）
+- PR state != OPEN 或 baseRefName != main
+
+升級條件（escalate）：
+- claimed_pr_url 非空但與實查 PR URL 不符（PR_MISMATCH_SUSPECTED_FABRICATION）
+
+遇到失敗或升級時：寫入對應 JSON 並結束，不嘗試自行修復。
+PROMPT_EOF
+  fi
+
+  # 替換 placeholder
+  sed -i "s/{sprint_number}/${sprint_number}/g" "${output_file}"
+  sed -i "s/{story_id}/${story_id}/g" "${output_file}"
+  sed -i "s/{branch_name}/${branch}/g" "${output_file}"
+  sed -i "s|{result_file}|${POC_OUTPUT_DIR}/result-delivery-completion-check-${story_id}.json|g" "${output_file}"
+
+  echo "[PROMPT-GENERATED] ${output_file}"
+}
+
 generate_prompt() {
   local step_name="${1:?Usage: step-subagent-poc.sh generate-prompt <step_name> <sprint_number>}"
   local sprint_number="${2:?Usage: step-subagent-poc.sh generate-prompt <step_name> <sprint_number>}"
@@ -106,9 +196,12 @@ generate_prompt() {
     task-list-init)
       generate_prompt_task_list_init "${sprint_number}"
       ;;
+    delivery-completion-check)
+      generate_prompt_delivery_completion_check "${sprint_number}"
+      ;;
     *)
       echo "[ERROR] No prompt template for step: ${step_name}" >&2
-      echo "[INFO] Currently supported: task-list-init" >&2
+      echo "[INFO] Currently supported: task-list-init, delivery-completion-check" >&2
       return 1
       ;;
   esac
@@ -157,13 +250,102 @@ EOF
   echo "[RESULT] ${result_file}"
 }
 
+simulate_delivery_completion_check() {
+  local sprint_number="$1"
+  # 解析額外引數（--story-id / --branch / --claimed-pr-url / --output）
+  local story_id="STORY_ID"
+  local branch_name="BRANCH_NAME"
+  local claimed_pr_url=""
+  local result_file=""
+
+  shift || true
+  for arg in "$@"; do
+    case "${arg}" in
+      --story-id=*)   story_id="${arg#--story-id=}" ;;
+      --branch=*)     branch_name="${arg#--branch=}" ;;
+      --claimed-pr-url=*) claimed_pr_url="${arg#--claimed-pr-url=}" ;;
+      --output=*)     result_file="${arg#--output=}" ;;
+      *) ;;
+    esac
+  done
+
+  [[ -z "${result_file}" ]] && result_file="${POC_OUTPUT_DIR}/result-delivery-completion-check-${story_id}.json"
+
+  mkdir -p "${POC_OUTPUT_DIR}"
+
+  local start_ms end_ms duration_ms
+  start_ms=$(timestamp_ms)
+
+  # ── 核心驗證邏輯 ──
+  local status="completed"
+  local error_val="null"
+
+  # 1. 查詢 PR（使用 gh pr list，帶 --head branch filter）
+  local pr_json=""
+  local pr_list_exit=0
+  pr_json=$(gh pr list --head "${branch_name}" --json number,state,baseRefName,url 2>/dev/null) || pr_list_exit=$?
+
+  # 2. 判斷 PR 是否存在（空陣列或空字串）
+  local pr_count=0
+  if [[ -n "${pr_json}" ]] && echo "${pr_json}" | jq -e '.[0]' >/dev/null 2>&1; then
+    pr_count=$(echo "${pr_json}" | jq 'length' 2>/dev/null || echo "0")
+  fi
+
+  if [[ "${pr_count}" -eq 0 ]]; then
+    # TC2 情境：無 PR
+    status="failed"
+    error_val='"NO_PR_FOUND"'
+  else
+    # 取第一個 PR
+    local pr_url pr_state pr_base
+    pr_url=$(echo "${pr_json}"   | jq -r '.[0].url'         2>/dev/null || echo "")
+    pr_state=$(echo "${pr_json}" | jq -r '.[0].state'       2>/dev/null || echo "")
+    pr_base=$(echo "${pr_json}"  | jq -r '.[0].baseRefName' 2>/dev/null || echo "")
+
+    # 3. 狀態 / base 分支驗證
+    if [[ "${pr_state}" != "OPEN" || "${pr_base}" != "main" ]]; then
+      status="failed"
+      error_val="\"PR_NOT_OPEN_OR_WRONG_BASE\""
+    else
+      # 4. claimed_pr_url 比對（若非空）
+      if [[ -n "${claimed_pr_url}" && "${claimed_pr_url}" != "${pr_url}" ]]; then
+        # TC3 情境：URL 不符，疑似偽造
+        status="escalate"
+        error_val='"PR_MISMATCH_SUSPECTED_FABRICATION"'
+      fi
+      # 否則 status=completed
+    fi
+  fi
+
+  end_ms=$(timestamp_ms)
+  duration_ms=$((end_ms - start_ms))
+
+  # 產出結果 JSON
+  cat > "${result_file}" <<EOF
+{
+  "step_name": "delivery-completion-check",
+  "status": "${status}",
+  "output_artifacts": [],
+  "duration_ms": ${duration_ms},
+  "error": ${error_val}
+}
+EOF
+
+  echo "[SIMULATE-OK] delivery-completion-check status=${status} in ${duration_ms}ms"
+  echo "[RESULT] ${result_file}"
+}
+
 simulate() {
   local step_name="${1:?Usage: step-subagent-poc.sh simulate <step_name> <sprint_number>}"
   local sprint_number="${2:?Usage: step-subagent-poc.sh simulate <step_name> <sprint_number>}"
+  shift 2 || true
 
   case "${step_name}" in
     task-list-init)
       simulate_task_list_init "${sprint_number}"
+      ;;
+    delivery-completion-check)
+      simulate_delivery_completion_check "${sprint_number}" "$@"
       ;;
     *)
       echo "[ERROR] No simulation for step: ${step_name}" >&2
@@ -249,6 +431,100 @@ EOF
   echo "[RESULT] ${result_file}"
 }
 
+dispatch_delivery_completion_check() {
+  local story_id="$1"
+  local sprint_number="${2:-0}"
+  local branch_name="${3:-}"
+  local claimed_pr_url="${4:-}"
+  local result_file="${POC_OUTPUT_DIR}/result-delivery-completion-check-${story_id}.json"
+  local start_ms end_ms duration_ms
+
+  mkdir -p "${POC_OUTPUT_DIR}"
+
+  # model-route 記錄（AC-5）
+  echo "[MODEL-ROUTE] model-route step=delivery-completion-check tier=haiku reason=short-task-high-ratio"
+
+  # 1. 生成 prompt 模板
+  generate_prompt_delivery_completion_check "${sprint_number}" "${story_id}" "${branch_name}"
+  local prompt_file="${POC_OUTPUT_DIR}/prompt-delivery-completion-check.md"
+
+  start_ms=$(timestamp_ms)
+
+  # 2. 量測規則佔比
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local measure_script="${script_dir}/rule-ratio-measure.sh"
+  if [[ -x "${measure_script}" ]]; then
+    local ratio_result
+    ratio_result=$(bash "${measure_script}" "${prompt_file}" 2>/dev/null || echo '{"rule_tokens":0,"total_tokens":0,"ratio":0,"passed":false}')
+    local ratio_passed
+    ratio_passed=$(echo "${ratio_result}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['passed'])" 2>/dev/null || echo "False")
+    if [[ "${ratio_passed}" == "True" ]]; then
+      echo "[RULE-RATIO-PASS] 規則佔比達標（>= 10%）"
+    else
+      local ratio_val
+      ratio_val=$(echo "${ratio_result}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['ratio'])" 2>/dev/null || echo "0")
+      echo "[RULE-RATIO-WARN] 規則佔比 ${ratio_val} < 10%，建議增加規則內容" >&2
+    fi
+  fi
+
+  # 3. 更新 progress tracker（delivery-checks JSONL，per-date append-only）
+  local today
+  today=$(date '+%Y-%m-%d')
+  local checks_log
+  checks_log="${script_dir}/../../docs/cruise-logs/delivery-checks-${today}.jsonl"
+  mkdir -p "$(dirname "${checks_log}")"
+  local log_entry
+  log_entry="{\"ts\":\"$(timestamp)\",\"story_id\":\"${story_id}\",\"branch\":\"${branch_name}\",\"claimed_pr_url\":\"${claimed_pr_url}\",\"dispatch\":\"prepared\"}"
+  echo "${log_entry}" >> "${checks_log}"
+  echo "[DELIVERY-CHECKS-LOG] ${checks_log}"
+
+  # 4. 檢查 claude CLI 可用性
+  if command -v claude &>/dev/null; then
+    echo "[DISPATCH-MODE] claude CLI 可用，準備真實派遣 short-lived subagent (model: haiku)..."
+    echo "[DISPATCH-PROMPT] 使用 prompt: ${prompt_file}"
+    echo ""
+    echo "--- subagent prompt preview ---"
+    head -20 "${prompt_file}"
+    echo "--- (end of preview) ---"
+    echo ""
+    echo "[DISPATCH-INFO] 真實派遣需要在主 session 使用 Agent tool 執行以下 prompt："
+    echo "[DISPATCH-INFO] 請主 session 讀取 ${prompt_file} 並使用 Agent tool 派遣"
+    echo "[DISPATCH-INFO] 結果 JSON 應寫入 ${result_file}"
+    echo ""
+    echo "[DISPATCH-READY] prompt 已就緒，等待主 session 使用 Agent tool 派遣"
+  else
+    echo "[DISPATCH-FALLBACK] claude CLI 不可用，降級為 simulate 模式" >&2
+    simulate_delivery_completion_check "${sprint_number}" \
+      "--story-id=${story_id}" \
+      "--branch=${branch_name}" \
+      "--claimed-pr-url=${claimed_pr_url}" \
+      "--output=${result_file}"
+    return
+  fi
+
+  end_ms=$(timestamp_ms)
+  duration_ms=$((end_ms - start_ms))
+
+  # 5. 產出 dispatch 結果 JSON
+  cat > "${result_file}" <<EOF
+{
+  "step_name": "delivery-completion-check",
+  "status": "dispatch_ready",
+  "mode": "dispatch",
+  "model": "haiku",
+  "prompt_file": "${prompt_file}",
+  "output_artifacts": [],
+  "duration_ms": ${duration_ms},
+  "error": null,
+  "note": "Prompt generated and ready for Agent tool dispatch by main session"
+}
+EOF
+
+  echo "[DISPATCH-OK] delivery-completion-check dispatch preparation completed in ${duration_ms}ms"
+  echo "[RESULT] ${result_file}"
+}
+
 dispatch() {
   local step_name="${1:?Usage: step-subagent-poc.sh dispatch <step_name> <sprint_number>}"
   local sprint_number="${2:?Usage: step-subagent-poc.sh dispatch <step_name> <sprint_number>}"
@@ -257,9 +533,14 @@ dispatch() {
     task-list-init)
       dispatch_task_list_init "${sprint_number}"
       ;;
+    delivery-completion-check)
+      shift 2 || true
+      # dispatch_delivery_completion_check <story_id> [sprint] [branch] [claimed_pr_url]
+      dispatch_delivery_completion_check "${1:-STORY_ID}" "${sprint_number}" "${2:-}" "${3:-}"
+      ;;
     *)
       echo "[ERROR] No dispatch implementation for step: ${step_name}" >&2
-      echo "[INFO] Currently supported: task-list-init" >&2
+      echo "[INFO] Currently supported: task-list-init, delivery-completion-check" >&2
       return 1
       ;;
   esac

--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -436,6 +436,20 @@ Phase Checkpoint 讀取（#781 AC2，story-lifecycle-prompt.md §12.4）
   ├─ 多 PR 邊界：取 base=main + state=OPEN 的第一個（腳本自動處理）
   └─ 驗證完成後輸出 [POST-EXEC-PR-PASS] 或對應錯誤標記
         |
+        v（#988 AC-1：[MANDATORY] L2 delivery-completion-check step subagent — 僅在 L1 PASS 後執行）
+
+  **[MANDATORY] L2 delivery-completion-check Step Subagent**（L1 [POST-EXEC-PR-PASS] 通過後才執行）
+  ├─ **前置條件**：L1 inline bash 驗證已輸出 [POST-EXEC-PR-PASS]；若 L1 BLOCKED 則跳過此步
+  ├─ **派遣方式**：使用 step-subagent-poc.sh dispatch delivery-completion-check
+  │     bash scripts/state-machine/step-subagent-poc.sh dispatch delivery-completion-check \
+  │       <sprint_number> <story_id> <branch_name> <claimed_pr_url>
+  ├─ **model**：haiku（短任務 + 高規則佔比，model-route step=delivery-completion-check tier=haiku reason=short-task-high-ratio）
+  ├─ **結果三態處置**：
+  │  |-- status=completed → 繼續下一步
+  │  |-- status=failed    → Story=BLOCKED，記錄失敗原因，暫停等待人工介入
+  │  +-- status=escalate  → PR_MISMATCH_SUSPECTED_FABRICATION，立即升級 Architect，停止 Sprint
+  └─ **不得跳過**：即使 L1 已驗證通過，L2 仍為必要步驟（雙軌驗證）
+        |
         v
   Checkpoint 重讀流程定義（§3.1 / references/execution-flow-details.md）
   輸出 [CHECKPOINT-PASS] 或 [CHECKPOINT-FAIL]

--- a/skills/sprint-execution/references/step-subagent-contract.md
+++ b/skills/sprint-execution/references/step-subagent-contract.md
@@ -161,6 +161,33 @@ Token 估算規則（零依賴，純 bash）：
 | 輸出 artifact | `docs/sprints/sprint-{N}/task-list.md` |
 | 規則佔比 | 實測 44.78%（Sprint 180 prompt）|
 
+### delivery-completion-check
+
+<!-- ADR-045 Phase 2 落地 — Story #988 Sprint 181 -->
+
+| 項目 | 內容 |
+|------|------|
+| 步驟名稱 | `delivery-completion-check` |
+| ADR-045 Phase | Phase 2（L2 獨立驗證層） |
+| 對應 SKILL.md | §3 POST-EXECUTION 驗證流程 — L1 inline bash 通過後的 L2 驗證節點 |
+| Prompt 模板檔 | `skills/sprint-execution/steps/delivery-completion-check.md` |
+| 生成指令 | `step-subagent-poc.sh generate-prompt delivery-completion-check <sprint> [story_id] [branch]` |
+| 派遣指令 | `step-subagent-poc.sh dispatch delivery-completion-check <sprint> <story_id> <branch> <claimed_pr_url>` |
+| Model | haiku（固定，model-route step=delivery-completion-check tier=haiku reason=short-task-high-ratio）|
+| 輸出 artifact | 無（唯讀驗證，不產出檔案） |
+| 結果 JSON 路徑 | `docs/cruise-logs/delivery-checks-<date>.jsonl`（append-only per-date） |
+| 規則佔比 | 實測 44.07%（Sprint 181 prompt，>= 30% AC-2 要求） |
+| 三態輸出 | `completed` / `failed` (NO_PR_FOUND) / `escalate` (PR_MISMATCH_SUSPECTED_FABRICATION) |
+| 禁止工具 | git push, gh pr create, gh pr merge, git commit, 任何檔案修改 |
+| 允許工具 | gh pr list, gh pr view, git log, cat, 讀取 state machine |
+| 前置條件 | L1 [POST-EXEC-PR-PASS] 已輸出；若 L1 BLOCKED 則跳過 L2 |
+
+**Phase 2 落地決策摘要**（Sprint 181）：
+- L1（#989）已交付 main session inline bash 驗證（PR #991 merged）
+- L2（#988）新增獨立 step subagent，進一步防止 PR 偽造（#953 歷史案例）
+- 雙軌驗證：L1 快速 bash 過濾 + L2 短任務 haiku subagent 深度確認
+- Progress tracker 使用 per-date JSONL 檔案（`delivery-checks-<date>.jsonl`），避免 git conflict（多機器場景）
+
 ---
 
 ## 5. 擴充指引

--- a/skills/sprint-execution/steps/delivery-completion-check.md
+++ b/skills/sprint-execution/steps/delivery-completion-check.md
@@ -1,0 +1,100 @@
+# Step Subagent: delivery-completion-check
+
+<!-- ADR-045 Phase 2 — Story #988 -->
+<!-- model-route step=delivery-completion-check tier=haiku reason=short-task-high-ratio -->
+
+## 規則片段
+
+你是 Sprint Execution 的 delivery-completion-check 步驟 subagent。你的唯一任務是驗證 Story 交付的 PR 是否真實存在且合規。
+
+### 必須遵守的規則
+
+1. **禁止 git push**：不可執行任何 `git push` 指令，你是唯讀驗證者
+2. **禁止 gh pr create**：不可建立任何 PR，即使你認為缺少 PR 也絕對不可自行建立
+3. **禁止 gh pr merge**：不可合併任何 PR，merge 決策由主 session 執行
+4. **禁止代建 PR**：不可代替 Story-Lifecycle subagent 補建 PR，任何 PR 缺失必須回報 `status=failed`
+5. **禁止接受「doc-only 無需 PR」自圓其說**：doc-only 不是豁免理由，所有 Story 交付必須有 PR
+
+### 禁止工具清單（Hard Constraint — 不得使用以下任何工具）
+
+- `git push`（任何形式）
+- `gh pr create`（任何形式）
+- `gh pr merge`（任何形式）
+- `git commit`（任何形式）
+- 任何寫入或修改檔案的操作（Write、Edit、sed、awk 寫入模式等）
+
+### 唯一允許的工具
+
+- `gh pr list`：查詢 PR 清單
+- `gh pr view`：讀取 PR 詳情
+- `git log`：查閱 commit 歷史
+- `cat`：讀取本地檔案
+- 讀取 state machine 狀態檔
+
+### 三態輸出語意
+
+- `completed`：PR 存在、OPEN、base=main，且 claimed_pr_url 與實查一致
+- `failed`：PR 不存在（NO_PR_FOUND）或 PR 狀態不符合要求
+- `escalate`：claimed_pr_url 與實查 PR URL 不符，疑似偽造（PR_MISMATCH_SUSPECTED_FABRICATION）
+
+## 輸入契約
+
+- Story ID：{story_id}
+- Branch name：{branch_name}
+- Claimed PR URL：{claimed_pr_url}（由 Story-Lifecycle subagent 回傳的 PR URL）
+- 結果輸出路徑：{result_file}
+
+## 輸出契約
+
+必須產出：
+- {result_file}（步驟結果 JSON，遵循 ADR-045 §3 格式）
+
+結果 JSON 格式：
+
+```json
+{
+  "step_name": "delivery-completion-check",
+  "status": "completed | failed | escalate",
+  "output_artifacts": [],
+  "duration_ms": 1234,
+  "error": null
+}
+```
+
+錯誤碼說明：
+- `null`：成功
+- `"NO_PR_FOUND"`：gh pr list 回傳空，或 PR 不存在
+- `"PR_MISMATCH_SUSPECTED_FABRICATION"`：claimed_pr_url 與實查 URL 不符
+
+## 成功/失敗判定
+
+### 驗證步驟
+
+1. 執行 `gh pr list --head {branch_name} --json number,state,baseRefName,url`
+2. 若結果為空 → `status=failed, error="NO_PR_FOUND"`
+3. 若有結果 → 取第一個 PR，檢查：
+   - `state == "OPEN"` 且 `baseRefName == "main"`
+   - 若不符 → `status=failed`
+4. 若 `claimed_pr_url` 非空，比對 claimed_pr_url 與實查 url：
+   - 若不符 → `status=escalate, error="PR_MISMATCH_SUSPECTED_FABRICATION"`
+5. 所有檢查通過 → `status=completed, error=null`
+
+### 成功條件
+
+- PR 存在（gh pr list 非空）
+- PR state = OPEN
+- PR baseRefName = main
+- claimed_pr_url（若非空）與實查 url 一致
+
+### 失敗條件
+
+- PR 不存在（gh pr list 空回傳）
+- PR state != OPEN
+- PR baseRefName != main
+
+### 升級條件（escalate）
+
+- claimed_pr_url 非空，但與實查 PR URL 不符
+- 錯誤碼：`PR_MISMATCH_SUSPECTED_FABRICATION`
+
+遇到失敗或升級時：寫入對應 JSON 並結束，不嘗試自行修復，不建立 PR，不 push。

--- a/tests/test-delivery-completion-check.sh
+++ b/tests/test-delivery-completion-check.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# test-delivery-completion-check.sh — delivery-completion-check step subagent 測試（Story #988 AC-6）
+#
+# TC1: 正常 Story（mock gh 回傳 PR=OPEN, base=main）→ status=completed
+# TC2: #953 情境（mock gh 回傳空）→ status=failed, error="NO_PR_FOUND"
+# TC3: 偽造情境（claimed_pr_url 與實查不符）→ status=escalate, error="PR_MISMATCH_SUSPECTED_FABRICATION"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POC_SCRIPT="${SCRIPT_DIR}/scripts/state-machine/step-subagent-poc.sh"
+STATE_DIR=""
+PASS=0
+FAIL=0
+TOTAL=0
+
+# ── 測試工具函數 ──
+
+setup() {
+  STATE_DIR=$(mktemp -d)
+  export STATE_MACHINE_DIR="${STATE_DIR}"
+  export POC_OUTPUT_DIR="${STATE_DIR}/poc-output"
+  mkdir -p "${STATE_DIR}/poc-output"
+}
+
+teardown() {
+  if [[ -n "${STATE_DIR}" && -d "${STATE_DIR}" ]]; then
+    rm -rf "${STATE_DIR}"
+  fi
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "${expected}" == "${actual}" ]]; then
+    echo "  PASS: ${desc}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${desc} (expected='${expected}', actual='${actual}')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_file_exists() {
+  local desc="$1" filepath="$2"
+  TOTAL=$((TOTAL + 1))
+  if [[ -f "${filepath}" ]]; then
+    echo "  PASS: ${desc}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${desc} (file not found: ${filepath})"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_json_field() {
+  local desc="$1" filepath="$2" field="$3" expected="$4"
+  local actual
+  actual=$(jq -r "${field}" "${filepath}" 2>/dev/null || echo "JQ_ERROR")
+  TOTAL=$((TOTAL + 1))
+  if [[ "${expected}" == "${actual}" ]]; then
+    echo "  PASS: ${desc}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${desc} (expected='${expected}', actual='${actual}')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── TC1: 正常 Story（mock gh 回傳 PR=OPEN, base=main）→ status=completed ──
+
+test_tc1_normal_story() {
+  echo "TC1: 正常 Story（mock gh 回傳 PR=OPEN, base=main）→ status=completed"
+  setup
+
+  # 建立 fake gh binary（模擬 PR OPEN, base=main）
+  local TMPBIN
+  TMPBIN=$(mktemp -d)
+  trap "rm -rf ${TMPBIN}" RETURN
+
+  cat > "${TMPBIN}/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+# Fake gh — TC1: 回傳 PR OPEN, base=main
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  # 回傳 JSON 陣列（模擬 gh pr list --json 輸出）
+  cat <<'PRJSON'
+[{"number":123,"state":"OPEN","baseRefName":"main","url":"https://github.com/example/repo/pull/123"}]
+PRJSON
+  exit 0
+elif [[ "$1" == "pr" && "$2" == "view" ]]; then
+  cat <<'PRJSON'
+{"number":123,"state":"OPEN","baseRefName":"main","url":"https://github.com/example/repo/pull/123","title":"Fake PR title"}
+PRJSON
+  exit 0
+fi
+exit 0
+FAKEGH
+  chmod +x "${TMPBIN}/gh"
+
+  local result_file="${STATE_DIR}/poc-output/result-delivery-completion-check-999.json"
+
+  PATH="${TMPBIN}:${PATH}" bash "${POC_SCRIPT}" simulate delivery-completion-check 181 \
+    --story-id=999 \
+    --branch="feat/#999-fake-story" \
+    --claimed-pr-url="https://github.com/example/repo/pull/123" \
+    --output="${result_file}" \
+    2>/dev/null || true
+
+  assert_file_exists "TC1: result JSON created" "${result_file}"
+  assert_json_field "TC1: step_name is delivery-completion-check" "${result_file}" '.step_name' "delivery-completion-check"
+  assert_json_field "TC1: status is completed" "${result_file}" '.status' "completed"
+  assert_json_field "TC1: error is null" "${result_file}" '.error' "null"
+
+  teardown
+}
+
+# ── TC2: #953 情境（mock gh 回傳空）→ status=failed, error="NO_PR_FOUND" ──
+
+test_tc2_no_pr_found() {
+  echo "TC2: #953 情境（mock gh 回傳空）→ status=failed, error=NO_PR_FOUND"
+  setup
+
+  # 建立 fake gh binary（模擬 gh pr list 回傳空）
+  local TMPBIN
+  TMPBIN=$(mktemp -d)
+  trap "rm -rf ${TMPBIN}" RETURN
+
+  cat > "${TMPBIN}/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+# Fake gh — TC2: 模擬 #953 情境，gh pr list 回傳空 JSON 陣列
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  # 回傳空陣列（無 PR）
+  echo "[]"
+  exit 0
+elif [[ "$1" == "pr" && "$2" == "view" ]]; then
+  echo "no pull requests found for branch" >&2
+  exit 1
+fi
+exit 0
+FAKEGH
+  chmod +x "${TMPBIN}/gh"
+
+  local result_file="${STATE_DIR}/poc-output/result-delivery-completion-check-953.json"
+
+  PATH="${TMPBIN}:${PATH}" bash "${POC_SCRIPT}" simulate delivery-completion-check 181 \
+    --story-id=953 \
+    --branch="feat/#953-missing-pr" \
+    --claimed-pr-url="" \
+    --output="${result_file}" \
+    2>/dev/null || true
+
+  assert_file_exists "TC2: result JSON created" "${result_file}"
+  assert_json_field "TC2: step_name is delivery-completion-check" "${result_file}" '.step_name' "delivery-completion-check"
+  assert_json_field "TC2: status is failed" "${result_file}" '.status' "failed"
+  assert_json_field "TC2: error is NO_PR_FOUND" "${result_file}" '.error' "NO_PR_FOUND"
+
+  teardown
+}
+
+# ── TC3: 偽造情境（claimed_pr_url 與實查不符）→ status=escalate ──
+
+test_tc3_pr_mismatch() {
+  echo "TC3: 偽造情境（claimed_pr_url 與實查不符）→ status=escalate, error=PR_MISMATCH_SUSPECTED_FABRICATION"
+  setup
+
+  # 建立 fake gh binary（模擬 PR 存在但 URL 不符）
+  local TMPBIN
+  TMPBIN=$(mktemp -d)
+  trap "rm -rf ${TMPBIN}" RETURN
+
+  cat > "${TMPBIN}/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+# Fake gh — TC3: PR 存在但 URL 與 claimed 不符（偽造情境）
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  # 回傳真實 PR（URL 與 claimed_pr_url=#999 不同）
+  cat <<'PRJSON'
+[{"number":456,"state":"OPEN","baseRefName":"main","url":"https://github.com/example/repo/pull/456"}]
+PRJSON
+  exit 0
+elif [[ "$1" == "pr" && "$2" == "view" ]]; then
+  cat <<'PRJSON'
+{"number":456,"state":"OPEN","baseRefName":"main","url":"https://github.com/example/repo/pull/456","title":"Real PR title"}
+PRJSON
+  exit 0
+fi
+exit 0
+FAKEGH
+  chmod +x "${TMPBIN}/gh"
+
+  local result_file="${STATE_DIR}/poc-output/result-delivery-completion-check-000.json"
+
+  # claimed_pr_url 指向 #999 但實際查到的是 #456
+  PATH="${TMPBIN}:${PATH}" bash "${POC_SCRIPT}" simulate delivery-completion-check 181 \
+    --story-id=000 \
+    --branch="feat/#000-fabricated" \
+    --claimed-pr-url="https://github.com/example/repo/pull/999" \
+    --output="${result_file}" \
+    2>/dev/null || true
+
+  assert_file_exists "TC3: result JSON created" "${result_file}"
+  assert_json_field "TC3: step_name is delivery-completion-check" "${result_file}" '.step_name' "delivery-completion-check"
+  assert_json_field "TC3: status is escalate" "${result_file}" '.status' "escalate"
+  assert_json_field "TC3: error is PR_MISMATCH_SUSPECTED_FABRICATION" "${result_file}" '.error' "PR_MISMATCH_SUSPECTED_FABRICATION"
+
+  teardown
+}
+
+# ── 執行所有測試 ──
+
+echo "=== delivery-completion-check Step Subagent Tests (Story #988 AC-6) ==="
+echo ""
+
+test_tc1_normal_story
+echo ""
+test_tc2_no_pr_found
+echo ""
+test_tc3_pr_mismatch
+echo ""
+
+echo "=== Results: ${PASS}/${TOTAL} passed, ${FAIL} failed ==="
+
+if [[ ${FAIL} -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- 新增 `skills/sprint-execution/steps/delivery-completion-check.md`：L2 step subagent prompt template，遵循 step-subagent-contract.md §1 四區塊結構，規則佔比 44.07%（>= 30% AC-2 要求）
- 擴充 `scripts/state-machine/step-subagent-poc.sh`：新增 `generate_prompt_delivery_completion_check`、`simulate_delivery_completion_check`、`dispatch_delivery_completion_check` 三個函數；simulate 實作三態輸出（completed / failed / escalate）
- 修改 `skills/sprint-execution/SKILL.md` §3：在 L1 [POST-EXEC-PR-PASS] 後插入 L2 step subagent 派遣節點（AC-1）
- 更新 `skills/sprint-execution/references/step-subagent-contract.md` §4：新增 delivery-completion-check 條目，記錄 Phase 2 落地決策
- 新建 `tests/test-delivery-completion-check.sh`：TC1（正常 OPEN PR）、TC2（#953 情境 NO_PR_FOUND）、TC3（PR_MISMATCH_SUSPECTED_FABRICATION），使用 TMPBIN fake binary 模式，12/12 PASS

## Test plan

- [x] TC1: 正常 Story（mock gh 回傳 PR=OPEN, base=main）→ status=completed（PASS）
- [x] TC2: #953 情境（mock gh 回傳空陣列）→ status=failed, error=NO_PR_FOUND（PASS）
- [x] TC3: 偽造情境（claimed_pr_url 與實查不符）→ status=escalate, error=PR_MISMATCH_SUSPECTED_FABRICATION（PASS）
- [x] rule-ratio-measure.sh 自舉驗證：ratio=0.4407（>= 0.30 AC-2 要求）
- [x] model-route 記錄：step=delivery-completion-check tier=haiku reason=short-task-high-ratio（AC-5）
- [x] SKILL.md 插入點在 L1 POST-EXEC-PR-PASS 後、Checkpoint 前（AC-1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
