### PR TITLE
feat(#940): validate-skill-deps.sh

### DIFF
--- a/scripts/validate-skill-deps.sh
+++ b/scripts/validate-skill-deps.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Skill Dependency Declaration Consistency Validator
+# Scans all Skills for reference declarations and validates path existence
+
+set -u
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_DIR="${PROJECT_ROOT}/skills"
+
+echo "Scanning Skill dependencies in ${SKILLS_DIR}..."
+
+# Temporary file to collect violations
+VIOLATIONS_FILE=$(mktemp)
+trap "rm -f $VIOLATIONS_FILE" EXIT
+
+# Iterate through each skill directory
+for skill_dir in "${SKILLS_DIR}"/*; do
+  [ -d "$skill_dir" ] || continue
+
+  skill_name=$(basename "$skill_dir")
+  skill_file="${skill_dir}/SKILL.md"
+
+  # Skip if no SKILL.md file
+  [ -f "$skill_file" ] || continue
+
+  # Extract all markdown link references using grep
+  # Pattern: [anything](./references/something.md)
+  # Use perl-compatible grep to handle complex patterns safely
+  grep -oP '\]\(\./references/[^)]+' "$skill_file" 2>/dev/null | while read -r match; do
+    # Remove the leading ]( to get just the path
+    ref_path="${match#\]\(}"
+
+    [ -z "$ref_path" ] && continue
+
+    full_ref_path="${skill_dir}${ref_path#.}"
+
+    # Check if the referenced file exists
+    if [ ! -f "$full_ref_path" ]; then
+      echo "${skill_name}: ${ref_path}" >> "$VIOLATIONS_FILE"
+    fi
+  done
+done
+
+# Count violations from the file
+violation_count=0
+if [ -f "$VIOLATIONS_FILE" ] && [ -s "$VIOLATIONS_FILE" ]; then
+  cat "$VIOLATIONS_FILE"
+  violation_count=$(wc -l < "$VIOLATIONS_FILE")
+fi
+
+# Exit with appropriate code
+if [ "$violation_count" -eq 0 ]; then
+  echo "Skill dependency validation: OK"
+  exit 0
+else
+  echo "Found $violation_count broken reference(s)"
+  exit 1
+fi

--- a/tests/test-validate-skill-deps.sh
+++ b/tests/test-validate-skill-deps.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Test suite for validate-skill-deps.sh
+# Tests skill dependency validation script
+
+set -u
+
+PASS=0
+FAIL=0
+
+PROJECT_ROOT="/home/kevin/workspace/00.shikigami-dev"
+SCRIPT_PATH="${PROJECT_ROOT}/scripts/validate-skill-deps.sh"
+
+# TC1: Normal case - no broken references (should exit 0)
+test_no_broken_references() {
+  echo "TC1: Testing normal case (no broken references)..."
+
+  if bash "$SCRIPT_PATH" > /tmp/tc1-output.txt 2>&1; then
+    exit_code=0
+    if grep -q "Skill dependency validation: OK" /tmp/tc1-output.txt; then
+      echo "  [PASS] No broken references found (exit code 0)"
+      PASS=$((PASS+1))
+    else
+      echo "  [FAIL] Expected 'OK' message not found"
+      FAIL=$((FAIL+1))
+    fi
+  else
+    echo "  [FAIL] Script exited with non-zero code when no violations expected"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# TC2: Create broken reference and verify detection
+test_broken_reference_detection() {
+  echo "TC2: Testing broken reference detection..."
+
+  # Create a temporary test skill with broken reference
+  TEST_SKILL_DIR="${PROJECT_ROOT}/skills/test-broken-skill"
+  mkdir -p "${TEST_SKILL_DIR}/references"
+
+  cat > "${TEST_SKILL_DIR}/SKILL.md" << 'EOF'
+---
+name: test-broken-skill
+description: Test skill with broken reference
+---
+
+# Test Skill
+
+This skill references [non-existent file](./references/does-not-exist.md)
+EOF
+
+  if bash "$SCRIPT_PATH" 2>&1 | grep -q "test-broken-skill.*does-not-exist.md"; then
+    echo "  [PASS] Broken reference detected correctly"
+    PASS=$((PASS+1))
+  else
+    echo "  [FAIL] Failed to detect broken reference"
+    FAIL=$((FAIL+1))
+  fi
+
+  # Cleanup
+  rm -rf "${TEST_SKILL_DIR}"
+}
+
+# TC3: Verify execution time < 5 seconds
+test_execution_time() {
+  echo "TC3: Testing execution time < 5s..."
+
+  start_time=$(date +%s%N)
+  bash "$SCRIPT_PATH" > /dev/null 2>&1
+  end_time=$(date +%s%N)
+
+  # Calculate elapsed time in milliseconds
+  elapsed_ms=$(( (end_time - start_time) / 1000000 ))
+  elapsed_s=$(( elapsed_ms / 1000 ))
+
+  if [ "$elapsed_s" -lt 5 ]; then
+    echo "  [PASS] Execution completed in ${elapsed_s}s (< 5s)"
+    PASS=$((PASS+1))
+  else
+    echo "  [FAIL] Execution took ${elapsed_s}s (>= 5s)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# Run tests
+echo "====== Running Skill Dependency Validation Tests ======"
+test_no_broken_references
+test_broken_reference_detection
+test_execution_time
+
+echo ""
+echo "====== Test Results ======"
+echo "PASS=$PASS FAIL=$FAIL Total=$((PASS+FAIL))"
+
+if [ "$FAIL" -eq 0 ]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
## Summary
實作 Story #940 — Skill 依賴宣告一致性驗證腳本

## 變更內容

### 1. scripts/validate-skill-deps.sh
- 掃描所有 31 個 Skill 的 SKILL.md 檔案
- 偵測 Markdown 連結中的相對路徑引用 `[text](./references/...)`
- 驗證每個引用的檔案是否實際存在於硬碟上
- 不存在的引用輸出違規格式：`<skill-path>: <broken-reference>`
- 無違規 → exit 0；有違規 → exit 1

### 2. tests/test-validate-skill-deps.sh
- TC1：正常情境（無違規）→ exit 0 且輸出 "OK" 訊息
- TC2：故意建立壞 reference → 正確偵測並輸出違規
- TC3：執行時間驗證 < 5s（實測 0.x 秒）

## AC 達成度

- **AC-1**：✓ 建立 scripts/validate-skill-deps.sh，支援 Markdown 相對路徑引用
- **AC-2**：✓ 路徑存在性檢查（使用 `[ -f ]`）
- **AC-3**：✓ 違規報告格式 `<skill-path>: <broken-reference>`
- **NFR-1**：✓ 覆蓋率 31 個 Skill 全掃
- **NFR-2**：✓ 執行時間 < 5s

## 測試結果

```
====== Running Skill Dependency Validation Tests ======
TC1: Testing normal case (no broken references)...
  [PASS] No broken references found (exit code 0)
TC2: Testing broken reference detection...
  [PASS] Broken reference detected correctly
TC3: Testing execution time < 5s...
  [PASS] Execution completed in 0s (< 5s)

====== Test Results ======
PASS=3 FAIL=0 Total=3
```

## 技術細節

- 使用 `grep -oP` 提取 Markdown 連結模式
- Perl-compatible regex 便於複雜模式匹配
- 每個 Skill 獨立檢查，避免全局變數問題
- 臨時檔案管理確保違規計數正確
