### PR TITLE
feat(#1005): 排程模式 L-size sprint-candidate 自動觸發 Refinement

### DIFF
--- a/skills/cruise/references/po-patrol.md
+++ b/skills/cruise/references/po-patrol.md
@@ -334,11 +334,74 @@ project_level=${PROJECT_LEVEL}，請確認是否轉送。
     # 交付物已明確，不標記 awaiting-reply，依 Size 直接分流
     log action: "deliverable-${DELIVERABLE_TYPE} #<issue.number>"
 
+  # ── Step 3.7：L-size sprint-candidate → 自動觸發 Refinement（#1005）──
+  # L-size Story 在排程模式（SHIKIGAMI_SCHEDULED=true）下無法進入 Sprint Backlog
+  # （sprint-planning §3.1 HARD-GATE），若無自動出口將永遠卡住。
+  # 正確回應是由巡邏自動觸發 Refinement 拆解為 S/M sub-stories。
+  #
+  # 觸發條件（全部成立）：
+  #   1. Issue 帶有 sprint-candidate label
+  #   2. Issue 帶有 size:L label
+  #   3. updatedAt >= 24h（觀察期 — 避免剛加入就立刻拆解）
+  #   4. 未帶有 needs-refinement label（避免重複觸發）
+  #   5. 未帶有 stakeholder label（安全邊界）
+  if "sprint-candidate" in issue.labels AND "size:L" in issue.labels:
+    if "needs-refinement" in issue.labels OR "stakeholder" in issue.labels:
+      # 已觸發或安全邊界 → 跳過
+      continue
+
+    AGE_HOURS = (now - issue.updatedAt) in hours
+    if AGE_HOURS < 24:
+      # 觀察期未滿 → 記錄，繼續等待
+      log action: "l-size-candidate-observing #<issue.number>: ${AGE_HOURS}h < 24h"
+      continue
+
+    # ── 觸發 Refinement ──
+
+    # 1. 更新 label：加 needs-refinement，移除 sprint-candidate
+    #    （移除 sprint-candidate 避免計入 Sprint Planning 觸發閾值，防止 L story 搶進 Sprint）
+    gh issue edit ${issue.number} -R ${OWNER_REPO} \
+      --add-label "needs-refinement" \
+      --remove-label "sprint-candidate"
+
+    # 2. 留言通知（使用 --body-file，CLAUDE.md 紅線 13）
+    printf '%s\n' \
+      "## [巡邏狀態：L-size Refinement 觸發]" "" \
+      "此 Story 評估為 **L size**，排程模式下無法直接進入 Sprint Backlog（sprint-planning §3.1 HARD-GATE）。" "" \
+      "系統自動觸發 Refinement 評估：" \
+      "- Architect 將分析此 Story 的複雜度與依賴" \
+      "- 嘗試拆解為 S/M sub-stories（加 \`sprint-candidate\` + \`size:S\`/\`size:M\` label）" \
+      "- 本 Story 拆解完成後關閉或加 \`refined\` label" "" \
+      "- 觸發時間：$(date '+%Y-%m-%dT%H:%M:%S')" \
+      "- Session: ${SESSION_ID}" \
+      "- Story 年齡：${AGE_HOURS}h（觀察期閾值 >= 24h）" \
+      > /tmp/l-refine-comment-${issue.number}.txt
+    gh issue comment ${issue.number} -R ${OWNER_REPO} \
+      --body-file /tmp/l-refine-comment-${issue.number}.txt
+
+    # 3. 依 project_level 決定是否自動執行 Refinement（Architect 拆解）
+    if [[ "$PROJECT_LEVEL" == "low" ]]; then
+      # low：直接派遣 Architect subagent 執行拆解
+      # 詳見 skills/sprint-planning/references/architect-prompt.md §L-size Patrol Refinement
+      # <HARD-GATE>
+      # project_level=low 時，L-size sprint-candidate 觀察期達標後必須立即派遣 Architect 執行 Patrol Refinement，禁止詢問使用者確認。
+      # </HARD-GATE>
+      L_SIZE_REFINEMENT_NEEDED += issue.number
+      log action: "l-size-refinement-trigger #<issue.number> (project_level=low, age=${AGE_HOURS}h)"
+    elif [[ "$PROJECT_LEVEL" == "medium" ]]; then
+      # medium：已留言通知，等使用者確認後手動觸發 Refinement
+      log action: "l-size-refinement-notify #<issue.number> (project_level=medium, age=${AGE_HOURS}h)"
+    else:  # high
+      # high：只記錄，不自動觸發
+      log action: "l-size-refinement-marked #<issue.number> (project_level=high, age=${AGE_HOURS}h)"
+    fi
+    continue  # 此 Issue 已移出 sprint-candidate 流程，不進入 Step 4
+
   # ── Step 4：判斷 Size 決定 auto-shoot 或 sprint-candidate ──
   if Size=S（單檔修改、修復方向明確、無需跨模組）:
     ACTIONABLE_ISSUES += issue.number
     log action: "auto-shoot #<issue.number>"
-  else:  # Size=M+
+  else:  # Size=M+（不含已被 Step 3.7 攔截的 size:L）
     gh issue edit issue.number -R ${OWNER_REPO} --add-label sprint-candidate
     SPRINT_CANDIDATES += issue.number
     log action: "sprint-candidate #<issue.number>"
@@ -346,6 +409,7 @@ project_level=${PROJECT_LEVEL}，請確認是否轉送。
 # 回傳結果（#346：close 與 auto-shoot 分開回傳）
 # close_issues: PO 已直接 close 的 Issue（不走 shoot）
 # actionable_issues: 供主 loop invoke shikigami:shoot 派遣（必須走完整 shoot 流程）
+# l_size_refinement_needed: project_level=low 時，需由主 loop 派遣 Architect 執行 Patrol Refinement
 
 # ── Step 5：Sprint Planning 觸發（#352：PO 直接執行，不經主 loop）──
 # <HARD-GATE>
@@ -630,9 +694,11 @@ SPRINT_FILE=$(ls ${REPO_PATH}/docs/sprints/sprint_*.md 2>/dev/null | sort -V | t
   "threshold_days": <THRESHOLD_DAYS>,
   "project_level": "<PROJECT_LEVEL>",
   "summary": "掃描 <X> 個 open issues，發現 <Y> 個逾期，<Z> 個無回應",
-  "actions": ["triage #<N1>", "auto-shoot #<N2>", "sprint-candidate #<N3>", "awaiting-reply #<N4>", "pending #<N5>", "close #<N6>", "close-pending-approval #<N7>", "auto-close #<N8>", "waiting #<N9>: Xh elapsed", "skipped #<N10>: stakeholder-issue"],
+  "actions": ["triage #<N1>", "auto-shoot #<N2>", "sprint-candidate #<N3>", "awaiting-reply #<N4>", "pending #<N5>", "close #<N6>", "close-pending-approval #<N7>", "auto-close #<N8>", "waiting #<N9>: Xh elapsed", "skipped #<N10>: stakeholder-issue", "l-size-refinement-trigger #<N11> (project_level=low, age=Xh)", "l-size-refinement-notify #<N12> (project_level=medium, age=Xh)", "l-size-refinement-marked #<N13> (project_level=high, age=Xh)", "l-size-candidate-observing #<N14>: Xh < 24h"],
   "actionable_issues": [<issue_numbers>],
-  "sprint_candidates": [<issue_numbers>]
+  "sprint_candidates": [<issue_numbers>],
+  "l_size_refinement_triggered": [<issue_numbers>],
+  "l_size_observing": [<issue_numbers>]
 }
 ```
 
@@ -683,6 +749,10 @@ SPRINT_FILE=$(ls ${REPO_PATH}/docs/sprints/sprint_*.md 2>/dev/null | sort -V | t
 | `"auto-close"` | `awaiting-reply`/`pending` 超過 2h 未回應，自動關閉（AC-4） |
 | `"waiting"` | `awaiting-reply`/`pending` 未超時，維持等待（AC-1 全覆蓋） |
 | `"skipped"` | Stakeholder Issue 跳過（含 reason） |
+| `"l-size-refinement-trigger"` | L-size sprint-candidate 觀察期達標（age >= 24h），project_level=low → 派遣 Architect 執行 Patrol Refinement（#1005） |
+| `"l-size-refinement-notify"` | L-size sprint-candidate 觀察期達標，project_level=medium → 留言通知，等使用者確認（#1005） |
+| `"l-size-refinement-marked"` | L-size sprint-candidate 觀察期達標，project_level=high → 只記錄，不自動觸發（#1005） |
+| `"l-size-candidate-observing"` | L-size sprint-candidate 觀察期未滿（age < 24h），暫不觸發（#1005） |
 
 # ── Step 5.6：Backlog 健康度檢查與信號消費（#698）──
 

--- a/skills/sprint-planning/references/architect-prompt.md
+++ b/skills/sprint-planning/references/architect-prompt.md
@@ -494,10 +494,13 @@ Architect 在擔任 Refinement Chair 時，必須對每個 M/L Story 逐一回�
 
 ### 排程模式與 Refinement 的互動
 
-| 執行模式 | Refinement 行為 |
+| 執行路徑 | Refinement 行為 |
 |---------|----------------|
-| **排程模式**（`SHIKIGAMI_SCHEDULED=true`） | **完全跳過 Refinement**。排程模式僅允許 S-size Story，S-size 預設豁免 Refinement。 |
-| **手動模式**（非排程） | 依觸發條件執行 Refinement，M/L size 必須，S size 預設豁免（豁免例外見上方）。 |
+| **排程 Sprint Planning**（`SHIKIGAMI_SCHEDULED=true`） | Sprint Planning 本身**完全跳過 Refinement**。排程模式僅允許 S-size Story，S-size 預設豁免 Refinement。 |
+| **手動 Sprint Planning**（非排程） | 依觸發條件執行 Refinement，M/L size 必須，S size 預設豁免（豁免例外見上方）。 |
+| **Cruise Patrol 偵測 L-size sprint-candidate**（#1005） | Patrol 自動觸發「**L-size Patrol Refinement**」（見下方），由 Architect subagent 執行拆解，不經 Sprint Planning 流程。 |
+
+> **設計理由（#1005）**：Cruise 巡邏模式下，L-size Story 被標為 sprint-candidate 後因排程 Sprint Planning HARD-GATE 永遠無法進入 Sprint，正確出路是由 Patrol 偵測並自動啟動 Refinement，Architect 拆解為 S/M sub-stories 後讓下輪 Patrol 自動選入。
 
 **跨 Type 依賴的特殊處置**：
 
@@ -505,6 +508,136 @@ Architect 在擔任 Refinement Chair 時，必須對每個 M/L Story 逐一回�
 |------|---------|
 | SRE 工作量不可忽略（需要獨立設計、建置或審查） | 拆分為獨立 INFRA Story，Contract Owner 由 SRE 擔任 |
 | SRE 工作量極小（設定調整、參數修改等） | 在 FEATURE Contract 中附加 Infra Prerequisites Checklist，由 SRE 簽核後合併在 FEATURE Story 中執行 |
+
+---
+
+## L-size Patrol Refinement（#1005）
+
+<!-- #1005 排程模式 L-size sprint-candidate 自動 Refinement — Sprint 183 -->
+
+Cruise Patrol 偵測到 L-size sprint-candidate 觀察期達標（`updatedAt >= 24h`，`project_level=low`）時，派遣 Architect subagent 執行本流程（詳見 `skills/cruise/references/po-patrol.md` Step 3.7）。
+
+### 觸發前提
+
+| 項目 | 條件 |
+|------|------|
+| Issue label | `sprint-candidate` + `size:L` + `needs-refinement` |
+| 未帶有 | `stakeholder` label |
+| 觸發方 | Cruise Patrol PO subagent（project_level=low） |
+
+### Architect 執行步驟
+
+Architect subagent 在接到 Patrol Refinement 指令後，對指定 Issue 執行以下步驟：
+
+**Step A — 讀取 Story**
+
+```bash
+gh issue view ${ISSUE_NUMBER} -R ${OWNER_REPO} --json title,body,labels,comments
+```
+
+**Step B — 複雜度分析**
+
+依照標準 Refinement 依賴分析 Checklist（Q1–Q5，見上方），對此 L-size Story 進行評估：
+
+| 問題 | 評估目的 |
+|------|---------|
+| Q1 前置依賴 | 拆解後 sub-stories 是否有執行順序約束？ |
+| Q2 後置依賴 | 原 L story 是否為他處前置條件？拆解後需通知依賴方 |
+| Q3 跨模組 | 哪些模組/檔案需要修改，是否可分離為獨立 sub-stories？ |
+| Q5 Sprint 內完成性 | 每個 sub-story 是否可在一個 Sprint 內完成（S=1pt / M=2pt）？ |
+
+**Step C — 拆解決策**
+
+| 評估結果 | 處置 |
+|---------|------|
+| **可拆解**：Story 可分離為 2–4 個 S/M sub-stories，各自獨立可測試 | 執行 Step D（建立 sub-issues）→ Step E（關閉原 Story） |
+| **不可拆解**：Story 本身整體性強（如單一資料庫遷移），無法有意義分割 | 執行 Step F（NOT_READY 標記），留言說明 |
+| **需補充資訊**：原 Story AC 不足，無法判斷拆解方向 | 執行 Step G（awaitning-reply），留言請 PO 補充 |
+
+**Step D — 建立 sub-issues（僅可拆解情況）**
+
+```bash
+# 每個 sub-story 建立 Issue（使用 --body-file，CLAUDE.md 紅線 13）
+printf '%s\n' \
+  "## 背景" "" \
+  "此 sub-story 由 L-size Story #${PARENT_NUMBER} 拆解而來（Patrol Refinement #1005）。" "" \
+  "## User Story" "" \
+  "${SUB_STORY_DESCRIPTION}" "" \
+  "## Acceptance Criteria" "" \
+  "- AC1: ${SUB_AC_1}" \
+  "- AC2: ${SUB_AC_2}" "" \
+  "## 非功能性需求" "" \
+  "NFR1: ${SUB_NFR}" "" \
+  "---" "" \
+  "**Parent Story**: #${PARENT_NUMBER}" \
+  > /tmp/sub-story-${i}.txt
+
+bash scripts/gh-issue-create.sh \
+  --title "${SUB_STORY_TITLE}" \
+  --body-file /tmp/sub-story-${i}.txt \
+  --label "type: backlog-item,status: backlog,sprint-candidate,size:${SUB_SIZE}" \
+  --repo "${OWNER_REPO}"
+```
+
+**Step E — 關閉原 L Story（僅可拆解情況）**
+
+```bash
+printf '%s\n' \
+  "## [Patrol Refinement 完成]" "" \
+  "此 L-size Story 已由 Patrol Refinement（#1005）拆解為以下 sub-stories：" "" \
+  "${SUB_STORY_LINKS}" "" \
+  "Sub-stories 已加入 sprint-candidate，將在下輪 Patrol 自動選入 Sprint。" "" \
+  "- 執行時間：$(date '+%Y-%m-%dT%H:%M:%S')" \
+  "- Session: ${SESSION_ID}" \
+  > /tmp/close-comment.txt
+gh issue comment ${ISSUE_NUMBER} -R ${OWNER_REPO} --body-file /tmp/close-comment.txt
+gh issue close ${ISSUE_NUMBER} -R ${OWNER_REPO}
+```
+
+**Step F — NOT_READY 標記（不可拆解情況）**
+
+```bash
+# 移除 needs-refinement（已評估），加 pending label
+gh issue edit ${ISSUE_NUMBER} -R ${OWNER_REPO} \
+  --remove-label "needs-refinement" \
+  --add-label "pending"
+
+printf '%s\n' \
+  "## [Patrol Refinement：不可拆解]" "" \
+  "Architect 評估此 L-size Story 無法有意義拆解（原因：${REASON}）。" "" \
+  "建議：在手動模式下由 PO + Architect 共同評估，或調整 Story 範圍。" "" \
+  "此 Issue 已標記 \`pending\`，等待人工確認。" \
+  > /tmp/not-ready-comment.txt
+gh issue comment ${ISSUE_NUMBER} -R ${OWNER_REPO} --body-file /tmp/not-ready-comment.txt
+```
+
+**Step G — awaiting-reply（需補充資訊情況）**
+
+```bash
+gh issue edit ${ISSUE_NUMBER} -R ${OWNER_REPO} \
+  --remove-label "needs-refinement" \
+  --add-label "awaiting-reply"
+
+printf '%s\n' \
+  "## [Patrol Refinement：需補充資訊]" "" \
+  "Architect 無法根據現有 AC 判斷拆解方向，需要以下補充：" "" \
+  "- ${MISSING_INFO}" "" \
+  "請 PO 補充後移除 \`awaiting-reply\` label，系統將在下輪 Patrol 重新評估。" \
+  > /tmp/awaiting-comment.txt
+gh issue comment ${ISSUE_NUMBER} -R ${OWNER_REPO} --body-file /tmp/awaiting-comment.txt
+```
+
+### 結果輸出格式
+
+```json
+{
+  "type": "l-size-patrol-refinement",
+  "issue": ${ISSUE_NUMBER},
+  "decision": "split | not-splittable | needs-info",
+  "sub_issues": [<created_issue_numbers>],
+  "reason": "<簡短說明>"
+}
+```
 
 ---
 

--- a/tests/test-1005-l-size-refinement.sh
+++ b/tests/test-1005-l-size-refinement.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# tests/test-1005-l-size-refinement.sh
+# #1005：排程模式 L-size sprint-candidate 自動觸發 Refinement
+#
+# 覆蓋 AC：
+#   AC1 — po-patrol.md 含 Step 3.7 L-size 偵測區段
+#   AC2 — 觸發條件：sprint-candidate + size:L + age >= 24h + 無 needs-refinement
+#   AC3 — 觀察期保護：age < 24h → l-size-candidate-observing
+#   AC4 — 冪等性：已有 needs-refinement label → 跳過
+#   AC5 — project_level 分流：low/medium/high 各有不同 action log
+#   AC6 — needs-refinement label 替換 sprint-candidate label
+#   AC7 — --body-file 模式（CLAUDE.md 紅線 13）
+#   AC8 — 結果 JSON 含 l_size_refinement_triggered 與 l_size_observing 欄位
+#   AC9 — architect-prompt.md 含 L-size Patrol Refinement 章節
+#   AC10 — 排程模式互動表更新（patrol 觸發路徑）
+#   AC11 — Architect 執行步驟（Step A–G）完整定義
+#   AC12 — Architect sub-issue 使用 gh-issue-create.sh（CLAUDE.md 紅線 13）
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PATROL="$REPO_ROOT/skills/cruise/references/po-patrol.md"
+ARCHITECT="$REPO_ROOT/skills/sprint-planning/references/architect-prompt.md"
+
+pass() { echo "[PASS] $1"; PASS=$((PASS+1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+# ---------------------------------------------------------------------------
+# AC1：po-patrol.md 含 Step 3.7 L-size 偵測區段
+# ---------------------------------------------------------------------------
+[[ -f "$PATROL" ]] && pass "AC1.0 po-patrol.md 存在" \
+  || { fail "AC1.0 po-patrol.md 缺失"; exit 1; }
+
+if grep -q "Step 3.7" "$PATROL"; then
+  pass "AC1.1 po-patrol.md 含 Step 3.7 區段標記"
+else
+  fail "AC1.1 po-patrol.md 缺 Step 3.7 區段"
+fi
+
+if grep -q "L-size sprint-candidate" "$PATROL" && grep -q "1005" "$PATROL"; then
+  pass "AC1.2 Step 3.7 含 L-size sprint-candidate + issue 引用"
+else
+  fail "AC1.2 Step 3.7 缺 L-size sprint-candidate 或 #1005 引用"
+fi
+
+# ---------------------------------------------------------------------------
+# AC2：觸發條件完整性
+# ---------------------------------------------------------------------------
+STEP37_CONTENT=$(awk '/Step 3.7/,/Step 4/' "$PATROL")
+
+for cond in "sprint-candidate" "size:L" "needs-refinement" "AGE_HOURS" "24"; do
+  if printf '%s' "$STEP37_CONTENT" | grep -q "$cond"; then
+    pass "AC2 Step 3.7 含觸發條件：$cond"
+  else
+    fail "AC2 Step 3.7 缺觸發條件：$cond"
+  fi
+done
+
+# stakeholder 安全邊界
+if printf '%s' "$STEP37_CONTENT" | grep -q "stakeholder"; then
+  pass "AC2 Step 3.7 含 stakeholder 安全邊界"
+else
+  fail "AC2 Step 3.7 缺 stakeholder 安全邊界"
+fi
+
+# ---------------------------------------------------------------------------
+# AC3：觀察期保護（age < 24h → l-size-candidate-observing）
+# ---------------------------------------------------------------------------
+if grep -q "l-size-candidate-observing" "$PATROL"; then
+  pass "AC3.1 po-patrol.md 含 l-size-candidate-observing action"
+else
+  fail "AC3.1 po-patrol.md 缺 l-size-candidate-observing action"
+fi
+
+if printf '%s' "$STEP37_CONTENT" | grep -q "AGE_HOURS < 24"; then
+  pass "AC3.2 Step 3.7 觀察期條件為 < 24"
+else
+  fail "AC3.2 Step 3.7 觀察期條件缺 AGE_HOURS < 24"
+fi
+
+# ---------------------------------------------------------------------------
+# AC4：冪等性（already has needs-refinement → skip）
+# ---------------------------------------------------------------------------
+if printf '%s' "$STEP37_CONTENT" | grep -q "needs-refinement.*continue\|needs-refinement.*OR.*stakeholder\|stakeholder.*needs-refinement"; then
+  pass "AC4 Step 3.7 含 needs-refinement 冪等保護"
+else
+  # alternative pattern
+  if printf '%s' "$STEP37_CONTENT" | grep -q "needs-refinement" && \
+     printf '%s' "$STEP37_CONTENT" | grep -q "continue"; then
+    pass "AC4 Step 3.7 含 needs-refinement + continue（冪等保護）"
+  else
+    fail "AC4 Step 3.7 缺 needs-refinement 冪等保護"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# AC5：project_level 分流 log actions
+# ---------------------------------------------------------------------------
+for level in low medium high; do
+  if grep -q "l-size-refinement.*${level}\|${level}.*l-size-refinement" "$PATROL"; then
+    pass "AC5 po-patrol.md 含 project_level=${level} 的 l-size-refinement log"
+  else
+    fail "AC5 po-patrol.md 缺 project_level=${level} 的 l-size-refinement log"
+  fi
+done
+
+# low 必有 HARD-GATE
+if grep -q "HARD-GATE" "$PATROL" && grep -A5 "HARD-GATE" "$PATROL" | grep -q "L-size\|l-size\|Patrol Refinement"; then
+  pass "AC5 low 路徑含 HARD-GATE 強制標記"
+else
+  fail "AC5 low 路徑缺 HARD-GATE"
+fi
+
+# ---------------------------------------------------------------------------
+# AC6：needs-refinement 替換 sprint-candidate
+# ---------------------------------------------------------------------------
+if printf '%s' "$STEP37_CONTENT" | grep -q "add-label.*needs-refinement\|add.*needs-refinement"; then
+  pass "AC6.1 Step 3.7 加 needs-refinement label"
+else
+  fail "AC6.1 Step 3.7 未加 needs-refinement label"
+fi
+
+if printf '%s' "$STEP37_CONTENT" | grep -q "remove-label.*sprint-candidate\|remove.*sprint-candidate"; then
+  pass "AC6.2 Step 3.7 移除 sprint-candidate label"
+else
+  fail "AC6.2 Step 3.7 未移除 sprint-candidate label"
+fi
+
+# ---------------------------------------------------------------------------
+# AC7：留言使用 --body-file（CLAUDE.md 紅線 13）
+# ---------------------------------------------------------------------------
+if printf '%s' "$STEP37_CONTENT" | grep -q "body-file"; then
+  pass "AC7 Step 3.7 留言使用 --body-file 模式"
+else
+  fail "AC7 Step 3.7 留言未使用 --body-file（違反 CLAUDE.md 紅線 13）"
+fi
+
+# ---------------------------------------------------------------------------
+# AC8：結果 JSON 含新欄位
+# ---------------------------------------------------------------------------
+if grep -q "l_size_refinement_triggered" "$PATROL"; then
+  pass "AC8.1 po-patrol.md 結果 JSON 含 l_size_refinement_triggered"
+else
+  fail "AC8.1 po-patrol.md 結果 JSON 缺 l_size_refinement_triggered"
+fi
+
+if grep -q "l_size_observing" "$PATROL"; then
+  pass "AC8.2 po-patrol.md 結果 JSON 含 l_size_observing"
+else
+  fail "AC8.2 po-patrol.md 結果 JSON 缺 l_size_observing"
+fi
+
+# actions 說明表包含新類型
+if grep -q "l-size-refinement-trigger.*actions\|actions.*l-size-refinement-trigger\|l-size-refinement-trigger.*說明\|l-size.*Patrol Refinement" "$PATROL"; then
+  pass "AC8.3 actions 說明表含 l-size-refinement-trigger 類型"
+else
+  # check the table separately
+  if grep -q '"l-size-refinement-trigger"' "$PATROL"; then
+    pass "AC8.3 actions 說明表含 l-size-refinement-trigger 類型"
+  else
+    fail "AC8.3 actions 說明表缺 l-size-refinement-trigger 類型"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# AC9：architect-prompt.md 含 L-size Patrol Refinement 章節
+# ---------------------------------------------------------------------------
+[[ -f "$ARCHITECT" ]] && pass "AC9.0 architect-prompt.md 存在" \
+  || { fail "AC9.0 architect-prompt.md 缺失"; exit 1; }
+
+if grep -q "L-size Patrol Refinement" "$ARCHITECT"; then
+  pass "AC9.1 architect-prompt.md 含 L-size Patrol Refinement 章節"
+else
+  fail "AC9.1 architect-prompt.md 缺 L-size Patrol Refinement 章節"
+fi
+
+if grep -q "1005" "$ARCHITECT"; then
+  pass "AC9.2 architect-prompt.md 含 #1005 引用"
+else
+  fail "AC9.2 architect-prompt.md 缺 #1005 引用"
+fi
+
+# ---------------------------------------------------------------------------
+# AC10：排程模式互動表更新
+# ---------------------------------------------------------------------------
+if grep -q "Cruise Patrol" "$ARCHITECT" && grep -q "L-size Patrol Refinement\|Patrol Refinement" "$ARCHITECT"; then
+  pass "AC10 排程模式互動表包含 Cruise Patrol 觸發路徑"
+else
+  fail "AC10 排程模式互動表缺 Cruise Patrol 觸發路徑"
+fi
+
+# 舊表述應改為只針對 Sprint Planning
+if grep -q "排程 Sprint Planning\|排程模式.*Sprint Planning" "$ARCHITECT"; then
+  pass "AC10 排程模式互動表有區分「Sprint Planning」vs「Patrol」兩種路徑"
+else
+  fail "AC10 排程模式互動表未區分兩種路徑"
+fi
+
+# ---------------------------------------------------------------------------
+# AC11：Architect 執行步驟（Step A–G）完整
+# ---------------------------------------------------------------------------
+for step in "Step A" "Step B" "Step C" "Step D" "Step E" "Step F" "Step G"; do
+  if grep -q "$step" "$ARCHITECT"; then
+    pass "AC11 architect-prompt.md 含 $step"
+  else
+    fail "AC11 architect-prompt.md 缺 $step"
+  fi
+done
+
+# 決策結果三路（grep -E 用 | 不用 \|）
+if grep -qE "split|可拆解" "$ARCHITECT"; then
+  pass "AC11 Architect 決策含 split/可拆解"
+else
+  fail "AC11 Architect 決策缺 split/可拆解"
+fi
+if grep -qE "not-splittable|不可拆解" "$ARCHITECT"; then
+  pass "AC11 Architect 決策含 not-splittable/不可拆解"
+else
+  fail "AC11 Architect 決策缺 not-splittable/不可拆解"
+fi
+if grep -qE "needs-info|需補充" "$ARCHITECT"; then
+  pass "AC11 Architect 決策含 needs-info/需補充"
+else
+  fail "AC11 Architect 決策缺 needs-info/需補充"
+fi
+
+# ---------------------------------------------------------------------------
+# AC12：sub-issue 使用 gh-issue-create.sh（CLAUDE.md 紅線 13）
+# ---------------------------------------------------------------------------
+if grep -q "gh-issue-create.sh" "$ARCHITECT"; then
+  pass "AC12 L-size Patrol Refinement 使用 gh-issue-create.sh 建立 sub-issues"
+else
+  fail "AC12 L-size Patrol Refinement 未使用 gh-issue-create.sh（違反 CLAUDE.md 紅線 13）"
+fi
+
+# ---------------------------------------------------------------------------
+# 結算
+# ---------------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo "Test Result: PASS=$PASS  FAIL=$FAIL"
+echo "=========================================="
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- **問題**：L-size sprint-candidate 在排程模式因 `§3.1 HARD-GATE` 永遠無法進入 Sprint，又不會被送去 Refinement，導致 story 永遠卡住（具體案例：kctw-dev/seiryu #1583）
- **修正根本**：排程模式下，L-size Story 被排除是因為「太大、需設計」，正確回應是**拆解**，而非**忽略**

## Changes

### `skills/cruise/references/po-patrol.md`
- 新增 **Step 3.7**（在 Step 3.5 與 Step 4 之間）：
  - 觸發條件：`sprint-candidate` + `size:L` + `updatedAt >= 24h`（觀察期防止立即拆解）
  - 冪等：已有 `needs-refinement` 或 `stakeholder` label → 跳過
  - 行動：加 `needs-refinement`、移除 `sprint-candidate`、留言通知（`--body-file`）
  - `project_level=low` → 直接派遣 Architect；`medium` → 留言等確認；`high` → 只記錄
  - HARD-GATE：low 模式下禁止詢問確認
- 結果 JSON 加入 `l_size_refinement_triggered` / `l_size_observing` 欄位
- actions 說明表加入 4 種新 action 類型

### `skills/sprint-planning/references/architect-prompt.md`
- 新增 **§L-size Patrol Refinement**：Architect 執行步驟 A–G
  - Step A 讀取 Story → Step B 複雜度分析 → Step C 決策（可拆/不可拆/需補充）
  - Step D 建立 sub-issues（使用 `gh-issue-create.sh`，紅線 13）
  - Step E 關閉原 L story / Step F NOT_READY 標記 / Step G awaiting-reply
- 更新「排程模式與 Refinement 的互動」表：區分 Sprint Planning 路徑 vs Cruise Patrol 路徑

### `tests/test-1005-l-size-refinement.sh`（新建）
- 38 tests，全通過

## Test plan

- [x] `bash tests/test-1005-l-size-refinement.sh` → 38/38 PASS
- [x] 觸發條件完整性驗證（sprint-candidate + size:L + age >= 24h）
- [x] 冪等性保護（needs-refinement 已存在 → 跳過）
- [x] project_level 三路分流（low/medium/high）
- [x] HARD-GATE 存在（low 模式禁止詢問）
- [x] --body-file 模式合規（CLAUDE.md 紅線 13）
- [x] Architect Step A–G 完整定義

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)