### PR TITLE
chore: bump version v0.118.1 → v0.119.0 + README/CHANGELOG 更新

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,12 +8,12 @@
     {
       "name": "shikigami",
       "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-      "version": "0.118.1",
+      "version": "0.119.0",
       "source": "./",
       "author": {
         "name": "KCTW"
       }
     }
   ],
-  "version": "0.118.1"
+  "version": "0.119.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shikigami",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
-  "version": "0.118.1",
+  "version": "0.119.0",
   "author": {
     "name": "KCTW"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **專案名稱**：Shikigami（式神）
 - **性質**：Claude Code Plugin — AI Agent Scrum Team 框架
-- **目前版本**：v0.118.1
+- **目前版本**：v0.119.0
 - **授權**：MIT
 - **Repository**：https://github.com/KCTW/shikigami
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 式神 Shikigami — AI Agent Scrum Team 框架
 
-![Version](https://img.shields.io/badge/version-v0.118.1-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-v0.119.0-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)
 ![Sprints](https://img.shields.io/badge/sprints-175%2B-orange?style=flat-square)
 ![Skills](https://img.shields.io/badge/skills-31-purple?style=flat-square)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 
 **為你的 AI 開發工具注入 8 個專業角色，涵蓋 Discovery → Definition → Delivery 全產品生命週期。**
 
+### 🆕 v0.119.0 更新（Sprint 183）
+
+| 新功能 | 說明 |
+|--------|------|
+| **Issue 建立安全封裝** | `scripts/gh-issue-create.sh`：強制 `--body-file` 模式，防止特殊字元截斷（紅線 #13 強化） |
+| **禁用軟性字樣清單** | Architect / QA prompt 新增 8 條禁用詞表（考慮、適當、合理…），PO Round 1 自動自檢 |
+| **Agent fallback 驗證** | `dispatch-with-fallback.sh` + ADR-046：偵測 HTTP 429 / 5xx / Policy Refusal，自動切換模型 |
+| **ADR 歸檔政策** | `audit-adr-references.sh`（ACTIVE / DOCS-ONLY / DORMANT / SUPERSEDED 分類）+ ADR-009 已歸檔 |
+| **L-size 自動 Refinement** | 排程模式下 L-size sprint-candidate 觀察期達標後，Cruise Patrol 自動觸發 Architect 拆解 |
+
 ```
 /plugin marketplace add KCTW/shikigami
 /plugin install shikigami

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 | 版本 | 主題 | Sprint | 交付內容 |
 |------|------|--------|----------|
+| **v0.119.0** | **流程安全強化 + ADR 歸檔 + Cruise 智能化** | 183 | **#1001** `gh-issue-create.sh` 強制 `--body-file`；**#1002** Architect/QA 禁用軟性字樣清單（8 條）；**#1003** `dispatch-with-fallback.sh` + ADR-046 Agent fallback 驗證；**D5** ADR 歸檔政策 + `audit-adr-references.sh` + ADR-009 歸檔；**#1005** Cruise Patrol L-size sprint-candidate 自動觸發 Refinement（Architect 拆解 → S/M sub-stories） |
 | v0.1–0.9 | 核心建立與穩定化 | 1–24 | 25 Skills + 8 Agents 基礎架構、CI Pipeline、Hard Gate 機制、dispel 解咒模式、schedule/shoot 自動化、parallel-dispatch、使用者文件 |
 | v0.13–0.29 | 多平台 + 自動化閉環 | 25–50 | OpenCode 平台整合、排程四條流程、版號同步腳本、環境可攜性方案、diagram Skill（drawio MCP 整合） |
 | v0.30–0.41 | Design 體系 + 方法論強化 | 51–73 | UIUX Agent + Figma 整合管線 + Vision Critic、QA 雙階段審查強化、模型分層策略、Gemini CLI / Cursor 平台整合 |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "shikigami",
-  "version": "0.118.1",
+  "version": "0.119.0",
   "description": "AI Agent Scrum Team：8 個專業角色 × 自治協作 × Discovery → Delivery 全週期覆蓋",
   "author": "KCTW",
   "homepage": "https://github.com/KCTW/shikigami",


### PR DESCRIPTION
## Summary

- Version bump: v0.118.1 → v0.119.0（Sprint 183 新功能交付後的 minor bump）
- README 加入 "🆕 v0.119.0 更新" 表格（5 個新功能摘要）
- CHANGELOG 補上 v0.119.0 一行

## 更新的檔案

| 檔案 | 變更 |
|------|------|
| `.claude-plugin/plugin.json` | version 0.118.1 → 0.119.0 |
| `.claude-plugin/marketplace.json` | version 0.118.1 → 0.119.0（2 處）|
| `gemini-extension.json` | version 0.118.1 → 0.119.0 |
| `CLAUDE.md` | 版本標記更新 |
| `README.md` | badge + 🆕 What's New 表格 |
| `docs/CHANGELOG.md` | 新增 v0.119.0 一行 |

## Sprint 183 功能清單

- #1001 `gh-issue-create.sh` 強制 `--body-file` 模式
- #1002 Architect / QA 禁用軟性字樣清單（8 條）
- #1003 `dispatch-with-fallback.sh` + ADR-046 Agent fallback 驗證
- D5 ADR 歸檔政策 + `audit-adr-references.sh` + ADR-009 歸檔
- #1005 Cruise Patrol L-size sprint-candidate 自動觸發 Refinement

🤖 Generated with [Claude Code](https://claude.com/claude-code)