### PR TITLE
feat: sprint pipeline skill — 端到端 artifact 驗證閘控執行

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Version](https://img.shields.io/badge/version-v0.119.0-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)
 ![Sprints](https://img.shields.io/badge/sprints-175%2B-orange?style=flat-square)
-![Skills](https://img.shields.io/badge/skills-31-purple?style=flat-square)
+![Skills](https://img.shields.io/badge/skills-32-purple?style=flat-square)
 
 **為你的 AI 開發工具注入 8 個專業角色，涵蓋 Discovery → Definition → Delivery 全產品生命週期。**
 
@@ -186,7 +186,7 @@ Architect：ADR-002 狀態 → Accepted
 **重點：它們互相制衡，不是 8 個獨立助手。**
 
 <details>
-<summary>完整 31 個 Skills 列表</summary>
+<summary>完整 32 個 Skills 列表</summary>
 
 **Discovery（產品探索）**
 
@@ -207,6 +207,7 @@ Architect：ADR-002 狀態 → Accepted
 
 | Skill | 說明 |
 |---|---|
+| **sprint** | 端到端 Sprint pipeline：Planning → Execution → Review，每階段 artifact 驗證，失敗即 HALT |
 | **sprint-execution** | 執行 Sprint Stories、功能實作、處理 Sprint Backlog |
 | **sprint-review** | Sprint 結束時進行回顧與驗收、評估 Sprint 成果 |
 | **architecture-decision** | 技術決策、架構審查、技術選型、ADR 撰寫 |

--- a/skills/sprint/SKILL.md
+++ b/skills/sprint/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: sprint
+description: "Use when running a complete sprint lifecycle end-to-end, or when someone says 'run sprint', 'start sprint', 'full sprint', 'go'. Chains planning → execution → review as isolated Agent sessions with artifact verification between stages."
+---
+
+# Sprint Pipeline — 端到端 Sprint 執行
+
+## 概述
+
+一個指令跑完整個 Sprint 生命週期。每個階段是**獨立的 Agent session**，完成後驗證 artifact 存在，才進入下一階段。
+
+**關鍵原則：沒有 artifact，視同沒有執行。**
+
+---
+
+## 觸發語法
+
+```
+/sprint          — 自動偵測目前狀態，從需要的階段開始
+/sprint plan     — 只跑 Planning
+/sprint exec     — 只跑 Execution（假設 Planning 已完成）
+/sprint review   — 只跑 Review（假設 Execution 已完成）
+```
+
+---
+
+## Step 0：狀態偵測
+
+執行前先偵測目前 Sprint 狀態，決定從哪個階段開始：
+
+```bash
+# 取得最新 Sprint 編號
+SPRINT_N=$(ls docs/sprints/sprint_*.md 2>/dev/null | grep -oE 'sprint_([0-9]+)' | grep -oE '[0-9]+' | sort -n | tail -1)
+TODAY=$(date '+%Y-%m-%d')
+```
+
+| 狀態 | 判斷條件 | 從哪開始 |
+|------|---------|---------|
+| 無 Sprint | `docs/sprints/sprint_N.md` 不存在 | Planning |
+| Planning 完成 | sprint doc 存在，但無 `status: in-sprint` 的 open issues | Execution |
+| Execution 進行中 | 有 `status: in-sprint` 的 open issues | Execution（繼續） |
+| Execution 完成 | 所有 in-sprint stories 已有 PR，無 retro doc | Review |
+| Sprint 完成 | retro doc 存在 | 輸出完成訊息，停止 |
+
+```bash
+# 偵測 Planning 狀態
+SPRINT_DOC="docs/sprints/sprint_${SPRINT_N}.md"
+PLANNING_DONE=$(test -f "$SPRINT_DOC" && echo "yes" || echo "no")
+
+# 偵測 Execution 狀態（有無 in-sprint open stories）
+IN_SPRINT_COUNT=$(gh issue list --label "status: in-sprint" --state open --json number 2>/dev/null | jq length 2>/dev/null || echo "0")
+
+# 偵測 Review 狀態（有無 retro doc）
+RETRO_DOC=$(ls docs/meetings/*retro* 2>/dev/null | grep "$(date '+%Y-%m')" | tail -1)
+REVIEW_DONE=$([ -n "$RETRO_DOC" ] && echo "yes" || echo "no")
+```
+
+---
+
+## Stage 1：Sprint Planning
+
+**跳過條件**：`docs/sprints/sprint_N.md` 已存在且有效
+
+**輸出開始標記**：
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[1/3] 🗓 Sprint Planning
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**執行**：派遣 sprint-planning Agent（<!-- Claude Code -->invoke shikigami:sprint-planning<!-- /Claude Code --><!-- OpenCode -->使用 sprint-planning skill<!-- /OpenCode -->）
+
+**Artifact 驗證**（Planning 結束後立即執行）：
+
+```bash
+# 驗證 1：sprint doc 存在
+test -f "docs/sprints/sprint_${SPRINT_N}.md" \
+  || PIPELINE_HALT "Stage 1" "docs/sprints/sprint_${SPRINT_N}.md 未產出"
+
+# 驗證 2：planning 會議紀錄存在
+ls docs/meetings/*sprint*planning* 2>/dev/null | grep -q "." \
+  || PIPELINE_HALT "Stage 1" "Sprint Planning 會議紀錄未產出"
+
+# 驗證 3：有 in-sprint stories
+IN_SPRINT=$(gh issue list --label "status: in-sprint" --state open --json number | jq length)
+[ "$IN_SPRINT" -gt 0 ] \
+  || PIPELINE_HALT "Stage 1" "無 in-sprint stories（Sprint Backlog 為空）"
+```
+
+**成功輸出**：
+```
+✅ docs/sprints/sprint_N.md 已建立
+✅ Sprint Planning 會議紀錄已建立
+✅ Sprint Backlog: N 個 stories
+```
+
+---
+
+## Stage 2：Sprint Execution
+
+**跳過條件**：所有 `status: in-sprint` stories 已有對應 PR（`IN_SPRINT_COUNT = 0`）
+
+**輸出開始標記**：
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[2/3] ⚙️ Sprint Execution
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**取得 Story 清單**：
+
+```bash
+STORIES=$(gh issue list --label "status: in-sprint" --state open --json number,title --jq '.[] | "\(.number) \(.title)"')
+```
+
+**逐 Story 執行**：對每個 story，派遣獨立的 sprint-execution Agent：
+
+```
+→ Story #1001「Feature A」：派遣執行 agent...
+```
+
+（<!-- Claude Code -->invoke shikigami:sprint-execution<!-- /Claude Code --><!-- OpenCode -->使用 sprint-execution skill<!-- /OpenCode -->）
+
+**每個 Story 的 Artifact 驗證**：
+
+```bash
+# 驗證：該 story 有對應 PR（open 或 merged 均可）
+PR_COUNT=$(gh pr list --search "Closes #${STORY_N} OR close #${STORY_N}" --state all --json number | jq length)
+[ "$PR_COUNT" -gt 0 ] \
+  || PIPELINE_HALT "Stage 2" "Story #${STORY_N} 無對應 PR（執行可能未完成）"
+```
+
+**每個 Story 成功輸出**：
+```
+✅ Story #1001: PR #88 已開啟
+```
+
+**所有 Stories 完成後**：
+```
+✅ Sprint Execution 完成：N 個 stories，N 個 PRs
+```
+
+---
+
+## Stage 3：Sprint Review
+
+**跳過條件**：retro doc 已存在（本月內）
+
+**輸出開始標記**：
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[3/3] 📋 Sprint Review
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**執行**：派遣 sprint-review Agent（<!-- Claude Code -->invoke shikigami:sprint-review<!-- /Claude Code --><!-- OpenCode -->使用 sprint-review skill<!-- /OpenCode -->）
+
+**Artifact 驗證**（Review 結束後立即執行）：
+
+```bash
+# 驗證 1：retro 會議紀錄存在
+RETRO=$(ls docs/meetings/*retro* 2>/dev/null | tail -1)
+[ -n "$RETRO" ] \
+  || PIPELINE_HALT "Stage 3" "Retro 會議紀錄未產出"
+
+# 驗證 2：review 會議紀錄存在
+REVIEW=$(ls docs/meetings/*review* 2>/dev/null | tail -1)
+[ -n "$REVIEW" ] \
+  || PIPELINE_HALT "Stage 3" "Sprint Review 會議紀錄未產出"
+```
+
+**成功輸出**：
+```
+✅ Sprint Review 會議紀錄已建立
+✅ Retro 會議紀錄已建立
+✅ Action Items 已轉為 GitHub Issues
+```
+
+---
+
+## 完成
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Sprint N 完成 ✅
+Planning → Execution (N stories) → Review 全部通過
+下一步：說「/sprint」開始 Sprint N+1
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## PIPELINE-HALT 機制
+
+<HARD-GATE>
+任何 Stage 的 Artifact 驗證失敗，必須立即 HALT，禁止繼續執行下一 Stage。
+</HARD-GATE>
+
+HALT 時輸出：
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[PIPELINE-HALT] Stage: Sprint Planning
+原因：docs/sprints/sprint_N.md 未產出
+行動：手動檢查後，執行 /sprint exec 從下一階段繼續
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**HALT 後禁止自動重試**。等待使用者介入後，用指定語法繼續（`/sprint exec`、`/sprint review`）。
+
+---
+
+## project_level 行為
+
+| project_level | 行為 |
+|---|---|
+| `low` | 全自動，三個 Stage 連續執行，不停頓 |
+| `medium` | Stage 1 結束後停頓，顯示 Sprint Backlog 清單，等使用者確認後繼續 |
+| `high` | 每個 Stage 前均需使用者確認 |
+
+---
+
+## 與其他 Skill 的關係
+
+| Skill | 角色 |
+|---|---|
+| `sprint-planning` | Stage 1 的執行體，被 pipeline 派遣 |
+| `sprint-execution` | Stage 2 的執行體，被 pipeline 逐 story 派遣 |
+| `sprint-review` | Stage 3 的執行體，被 pipeline 派遣 |
+| `cruise` | 背景排程版本，適合全自動無人值守 |
+| `sprint`（本 skill） | 前景 pipeline，適合人機協作或夥伴操作 |

--- a/tests/test-sprint-pipeline-skill.sh
+++ b/tests/test-sprint-pipeline-skill.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# tests/test-sprint-pipeline-skill.sh
+# Sprint Pipeline Skill 結構驗證測試
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="$REPO_ROOT/skills/sprint/SKILL.md"
+
+PASS=0; FAIL=0
+ok()   { echo "✅ $1"; PASS=$((PASS+1)); }
+fail() { echo "❌ $1"; FAIL=$((FAIL+1)); }
+
+echo "=== Sprint Pipeline Skill 測試 ==="
+
+# AC1: SKILL.md 存在
+test -f "$SKILL" && ok "SKILL.md 存在" || fail "SKILL.md 不存在"
+
+# AC2: frontmatter name 正確
+grep -q '^name: sprint$' "$SKILL" && ok "name: sprint" || fail "name 欄位錯誤"
+
+# AC3: description 包含 end-to-end 語意
+grep -qi "end.to.end\|端到端\|full sprint\|complete sprint" "$SKILL" \
+  && ok "description 含端到端語意" || fail "description 缺端到端語意"
+
+# AC4: 三個階段定義存在
+grep -q "Stage 1" "$SKILL" && ok "Stage 1 定義存在" || fail "Stage 1 缺失"
+grep -q "Stage 2" "$SKILL" && ok "Stage 2 定義存在" || fail "Stage 2 缺失"
+grep -q "Stage 3" "$SKILL" && ok "Stage 3 定義存在" || fail "Stage 3 缺失"
+
+# AC5: 三個 Stage 對應正確的 skill 派遣
+grep -q "sprint-planning" "$SKILL" && ok "Stage 1 派遣 sprint-planning" || fail "Stage 1 缺 sprint-planning 派遣"
+grep -q "sprint-execution" "$SKILL" && ok "Stage 2 派遣 sprint-execution" || fail "Stage 2 缺 sprint-execution 派遣"
+grep -q "sprint-review"    "$SKILL" && ok "Stage 3 派遣 sprint-review"    || fail "Stage 3 缺 sprint-review 派遣"
+
+# AC6: Artifact 驗證存在（每個 stage）
+ARTIFACT_CHECKS=$(grep -c "PIPELINE_HALT\|HALT" "$SKILL" 2>/dev/null || echo 0)
+[ "$ARTIFACT_CHECKS" -ge 3 ] \
+  && ok "Artifact 驗證點 >= 3 個（實際: ${ARTIFACT_CHECKS}）" \
+  || fail "Artifact 驗證點不足（需 >= 3，實際: ${ARTIFACT_CHECKS}）"
+
+# AC7: HARD-GATE 存在
+grep -q '<HARD-GATE>' "$SKILL" && ok "HARD-GATE 存在" || fail "HARD-GATE 缺失"
+
+# AC8: PIPELINE-HALT 定義
+grep -q 'PIPELINE-HALT' "$SKILL" && ok "PIPELINE-HALT 機制定義存在" || fail "PIPELINE-HALT 機制缺失"
+
+# AC9: 禁止自動重試的明確說明
+grep -qi "禁止.*重試\|不.*重試" "$SKILL" && ok "HALT 後禁止自動重試" || fail "未明確禁止 HALT 後重試"
+
+# AC10: 狀態偵測機制（Step 0）
+grep -q "Step 0\|狀態偵測" "$SKILL" && ok "Step 0 狀態偵測存在" || fail "Step 0 狀態偵測缺失"
+
+# AC11: 可從指定 Stage 繼續（resume）
+grep -qE "/sprint plan|/sprint exec|/sprint review" "$SKILL" \
+  && ok "支援從指定 Stage 繼續" || fail "缺乏 resume 語法"
+
+# AC12: project_level 行為差異定義
+grep -q "project_level" "$SKILL" && ok "project_level 行為定義存在" || fail "project_level 行為缺失"
+
+# AC13: 與 cruise 的差異說明
+grep -qi "cruise" "$SKILL" && ok "與 cruise 的差異有說明" || fail "缺 cruise 對比說明"
+
+# AC14: 進度輸出格式定義（使用者可讀）
+grep -qE "\[1/3\]|\[2/3\]|\[3/3\]" "$SKILL" && ok "進度格式 [N/3] 定義存在" || fail "進度格式缺失"
+
+# AC15: README 已更新 skill 數量
+README="$REPO_ROOT/README.md"
+grep -q "skills-32" "$README" && ok "README badge 已更新為 32" || fail "README badge 未更新（仍是 31）"
+grep -q "sprint.*端到端\|端到端.*Sprint" "$README" && ok "README skills 清單含 sprint" || fail "README skills 清單未加 sprint"
+
+# 總結
+echo ""
+echo "=== 結果：PASS ${PASS} / FAIL ${FAIL} / TOTAL $((PASS+FAIL)) ==="
+[ "$FAIL" -eq 0 ] && echo "✅ 全部通過" || { echo "❌ 有失敗項目"; exit 1; }


### PR DESCRIPTION
## Summary

- 新增 `skills/sprint/SKILL.md`：端到端 Sprint Pipeline，一個指令跑完 Planning → Execution → Review
- 每個 Stage 是獨立 Agent session（不是同一 session 角色扮演）
- 每個 Stage 完成後驗證 artifact 存在，失敗即 PIPELINE-HALT，不繼續
- 解決夥伴（非專家）使用時無法驗證流程是否真的跑完的問題

## 核心設計

| | cruise | sprint（本 PR）|
|---|---|---|
| 觸發 | cron 背景 | 使用者主動 |
| 可見性 | 看 log | 即時進度 |
| 驗證 | 無 | Artifact 驗證閘控 |
| HALT | 靜默繼續 | 明確 HALT + 報錯 |

## Test plan

- [x] `bash tests/test-sprint-pipeline-skill.sh` → 20/20 PASS
- [x] `bash scripts/validate-skills.sh` → 32 個 Skill 全部通過
- [x] `bash scripts/validate-json.sh`、`validate-version.sh` 失敗為 pre-existing（stash 前後相同）

🤖 Generated with [Claude Code](https://claude.com/claude-code)