### PR TITLE
feat: sprint skill 強制 Compliance Audit — 讓夥伴看到流程有沒有跑完

### DIFF
--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -778,3 +778,47 @@ Sprint Execution 支援 Live Log Streaming，讓使用者在另一個 terminal �
 Developer 在 Refinement 中負責提供技術實作面的輸入，協助 Architect（Refinement Chair）識別實作風險與依賴，確保 Story 進入 Sprint 後不因技術細節阻塞開發。Developer 在 Refinement 中為**諮詢（Consulted）**角色，不主持、不輸出正式報告。
 
 > 詳見 `references/developer-refinement.md`（職責說明表、Refinement 輸出定義）
+
+---
+
+## 11. Compliance Audit（強制輸出）
+
+<HARD-GATE>
+每個 Story 的 Story-Lifecycle subagent 結束前，以及所有 Stories 完成後的主 session 彙總，都必須輸出 [COMPLIANCE-AUDIT] 區塊。不得省略。
+</HARD-GATE>
+
+### 11.1 Story 層級 Audit（每個 Story 結束時）
+
+Story-Lifecycle subagent 完成後，回傳摘要必須包含：
+
+```
+[COMPLIANCE-AUDIT] sprint-execution Story #N
+✅ TDD Red    — 失敗測試已寫（N 個 tests）
+✅ TDD Green  — 最小實作通過
+✅ TDD Refactor — 重構完成（N commits）
+✅ Spec Compliance Review — 通過（N 個 AC 全部覆蓋）
+✅ Code Quality Review    — 通過
+⏭ Security Review        — 跳過（非外部輸入 Story）
+✅ PR 建立   — PR #N 已開啟
+
+Artifact: PR #N ✅ / 未開啟 ❌
+```
+
+### 11.2 Sprint Execution 彙總 Audit（所有 Stories 完成後）
+
+主 session 在所有 Stories 執行完畢後輸出：
+
+```
+[COMPLIANCE-AUDIT] sprint-execution Sprint N 彙總
+Stories 完成：N 個
+✅ #XXX「Story Title」→ PR #N
+✅ #XXX「Story Title」→ PR #N
+❌ #XXX「Story Title」→ 失敗（原因）
+
+整體結果：N/N 通過 ✅ / 有失敗項目 ❌
+```
+
+**符號規則**：
+- `✅` 已執行且 artifact 可驗證
+- `⏭` 跳過，必須附上原因
+- `❌` 應執行但失敗，必須附上原因

--- a/skills/sprint-planning/SKILL.md
+++ b/skills/sprint-planning/SKILL.md
@@ -215,3 +215,33 @@ Sprint Planning 流程中的業務規則以 SBE 範例作為 ground truth，格�
 - `docs/definition/sbe-examples/SBE_TO_TEST_RULES.md`：SBE → 測試案例轉換規則
 - `docs/definition/sbe-examples/sprint-lifecycle/sprint_planning_scheduled_mode.sbe.md`：§3.1 排程模式 HARD-GATE
 - `docs/definition/sbe-examples/sprint-lifecycle/sprint_planning_refinement_gate.sbe.md`：§9.2 Refinement 觸發條件
+
+---
+
+## 11. Compliance Audit（強制輸出）
+
+<HARD-GATE>
+Sprint Planning 結束前必須輸出 [COMPLIANCE-AUDIT] 區塊。無論步驟是否完整執行，都不得省略此輸出。
+</HARD-GATE>
+
+Sprint Planning 完成（或中止）前，**最後一個動作**必須是輸出以下格式的 Compliance Audit：
+
+```
+[COMPLIANCE-AUDIT] sprint-planning Sprint N
+✅ PO Round 1    — N 個 Stories 選入（#XXX, #XXX, ...）
+✅ Architect     — 技術評估表已輸出
+✅ QA            — AC 驗收表已確認
+✅ PO Round 2    — docs/sprints/sprint_N.md 已建立
+✅ commit + push — 完成
+⏭ 健康檢查      — 跳過（快思模式）
+⏭ Token 記錄    — 跳過（快思模式）
+
+Artifact: docs/sprints/sprint_N.md ✅
+```
+
+**符號規則**：
+- `✅` 已執行且有對應 artifact 或可驗證結果
+- `⏭` 跳過，必須附上原因（快思模式 / 排程模式 / 條件不符）
+- `❌` 應執行但未執行或失敗，必須附上原因
+
+每個列出的項目對應 §2 流程 Checklist 的一個主要步驟。**不得合併、不得省略**。

--- a/skills/sprint-review/SKILL.md
+++ b/skills/sprint-review/SKILL.md
@@ -420,3 +420,34 @@ commit + push 完成後清理同步 signal：`rm -f docs/sprints/.review-signal-
     # 範例：kctw-dev/shikigami/sprint-129-done-next-action
     # agent compact 後看到此 Task 即知道要繼續 Sprint Planning 或 Cruise
   ```
+
+---
+
+## 8. Compliance Audit（強制輸出）
+
+<HARD-GATE>
+Sprint Review 結束前必須輸出 [COMPLIANCE-AUDIT] 區塊。無論步驟是否完整執行，都不得省略此輸出。
+</HARD-GATE>
+
+Sprint Review 完成（或中止）前，**最後一個動作**必須是輸出以下格式的 Compliance Audit：
+
+```
+[COMPLIANCE-AUDIT] sprint-review Sprint N
+✅ Demo / 驗收        — N 個 Stories 驗收通過
+✅ Retrospective      — What Went Well / What Didn't / Actions 完整
+✅ Action Items       — N 個 Actions → GitHub Issues #XXX, #XXX
+✅ Sprint Review 紀錄 — docs/meetings/YYYY-MM-DD-sprint-N-review.md 已建立
+✅ Retro 紀錄         — docs/meetings/YYYY-MM-DD-sprint-N-retro.md 已建立
+✅ Metrics 更新       — docs/km/Metrics_Log.md 已更新
+✅ commit + push      — 完成
+⏭ 歸檔觸發           — 跳過（未達歸檔條件）
+
+Artifacts:
+  Sprint Review: docs/meetings/YYYY-MM-DD-sprint-N-review.md ✅
+  Retro:         docs/meetings/YYYY-MM-DD-sprint-N-retro.md  ✅
+```
+
+**符號規則**：
+- `✅` 已執行且有對應 artifact 或可驗證結果
+- `⏭` 跳過，必須附上原因
+- `❌` 應執行但未執行或失敗，必須附上原因

--- a/tests/test-compliance-audit.sh
+++ b/tests/test-compliance-audit.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# tests/test-compliance-audit.sh
+# 驗證三個 sprint skill 的 Compliance Audit 定義
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0; FAIL=0
+ok()   { echo "✅ $1"; PASS=$((PASS+1)); }
+fail() { echo "❌ $1"; FAIL=$((FAIL+1)); }
+
+echo "=== Compliance Audit 定義測試 ==="
+
+for SKILL in sprint-planning sprint-execution sprint-review; do
+  FILE="$REPO_ROOT/skills/$SKILL/SKILL.md"
+  echo ""
+  echo "--- $SKILL ---"
+
+  # AC1: Compliance Audit 節存在
+  grep -q "Compliance Audit" "$FILE" \
+    && ok "$SKILL: Compliance Audit 節存在" \
+    || fail "$SKILL: 缺少 Compliance Audit 節"
+
+  # AC2: HARD-GATE 存在（確保強制執行）
+  GATE_COUNT=$(grep -c '<HARD-GATE>' "$FILE" 2>/dev/null || echo 0)
+  [ "$GATE_COUNT" -ge 1 ] \
+    && ok "$SKILL: 含 HARD-GATE（共 ${GATE_COUNT} 個）" \
+    || fail "$SKILL: 缺少 HARD-GATE"
+
+  # AC3: [COMPLIANCE-AUDIT] 輸出標記存在
+  grep -q '\[COMPLIANCE-AUDIT\]' "$FILE" \
+    && ok "$SKILL: [COMPLIANCE-AUDIT] 輸出標記存在" \
+    || fail "$SKILL: 缺少 [COMPLIANCE-AUDIT] 輸出標記"
+
+  # AC4: ✅ 和 ⏭ 符號規則有定義
+  grep -q '✅' "$FILE" && grep -q '⏭' "$FILE" \
+    && ok "$SKILL: ✅ / ⏭ 符號定義存在" \
+    || fail "$SKILL: 缺少符號定義"
+
+  # AC5: ❌ 符號有定義（失敗情況）
+  grep -q '❌' "$FILE" \
+    && ok "$SKILL: ❌ 失敗符號定義存在" \
+    || fail "$SKILL: 缺少 ❌ 失敗符號定義"
+
+  # AC6: Artifact 驗證欄位（planning/review 需有 docs/ 路徑，execution 需有 PR）
+  case "$SKILL" in
+    sprint-planning)
+      grep -q 'docs/sprints/sprint_N' "$FILE" \
+        && ok "$SKILL: Artifact 含 sprint doc 路徑" \
+        || fail "$SKILL: Artifact 缺 sprint doc 路徑"
+      ;;
+    sprint-execution)
+      grep -q 'PR #N' "$FILE" \
+        && ok "$SKILL: Artifact 含 PR 驗證" \
+        || fail "$SKILL: Artifact 缺 PR 驗證"
+      ;;
+    sprint-review)
+      grep -q 'docs/meetings' "$FILE" \
+        && ok "$SKILL: Artifact 含 meeting doc 路徑" \
+        || fail "$SKILL: Artifact 缺 meeting doc 路徑"
+      ;;
+  esac
+
+  # AC7: 「最後一個動作」或等效強制語言
+  grep -qE "最後一個動作|結束前.*必須|必須輸出" "$FILE" \
+    && ok "$SKILL: 有強制輸出語言" \
+    || fail "$SKILL: 缺強制輸出語言"
+
+done
+
+echo ""
+echo "=== 結果：PASS ${PASS} / FAIL ${FAIL} / TOTAL $((PASS+FAIL)) ==="
+[ "$FAIL" -eq 0 ] && echo "✅ 全部通過" || { echo "❌ 有失敗項目"; exit 1; }


### PR DESCRIPTION
## Summary

- 三個核心 sprint skill 各加一個強制 `[COMPLIANCE-AUDIT]` 輸出區塊
- 解決問題：夥伴（非專家用戶）無法確認 Claude 是否真的跑完了所有步驟

## 設計

每個 skill 結束前，最後一個動作必須輸出：

```
[COMPLIANCE-AUDIT] sprint-planning Sprint N
✅ PO Round 1    — 3 個 Stories 選入（#1001, #1002, #1003）
✅ Architect     — 技術評估表已輸出
✅ QA            — AC 驗收表已確認
✅ PO Round 2    — docs/sprints/sprint_184.md 已建立
✅ commit + push — 完成
⏭ 健康檢查      — 跳過（快思模式）

Artifact: docs/sprints/sprint_184.md ✅
```

夥伴看到 `❌` 就知道有步驟沒跑到，不需要了解 skill 的內部結構。

## 變更

| Skill | 新增 |
|---|---|
| sprint-planning | §11 Compliance Audit + HARD-GATE |
| sprint-execution | §11.1 Story 層級 Audit + §11.2 Sprint 彙總 Audit + HARD-GATE |
| sprint-review | §8 Compliance Audit + HARD-GATE |

## Test plan

- [x] `bash tests/test-compliance-audit.sh` → 21/21 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)