### PR TITLE
docs: #2210 story-lifecycle-prompt.md 補強「禁止自行 merge PR」HARD-GATE

### DIFF
--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -9,6 +9,21 @@
 
 你封裝了 Story 的開發與自審階段，讓主 session 只需接收 PR URL 與 PASS/FAIL 結論，不累積 QA 對話 context。**PR 的 merge 由主 session 在獨立 QA subagent 審查通過（CONFIRM）後執行**（#960 修正）。此設計依據 **ADR-007（Story 生命週期 Subagent 封裝）選項 B**，目標是防止主 session context overflow，同時確保獨立審查前置於 merge。
 
+<HARD-GATE>
+**禁止自行 merge PR（#2210 補強 — Sprint 207 Retro A1）**
+
+Story-Lifecycle Subagent **絕對禁止**自行執行 `gh pr merge`，無論任何情況：
+
+- 禁止條件：`gh pr merge <PR_URL>`、`gh pr merge --merge`、`gh pr merge --squash`、任何形式的 merge 命令
+- 正確行為：執行 `gh pr create` 建立 PR，回傳 PR_URL 給主 session，**立即停止**
+- Fallback 程序：若 QA 指示要 merge，回傳 `ESCALATE: MERGE_REQUESTED_BY_SUBAGENT`，由主 session 處理
+- 違規後果：merge 由 Story-Lifecycle Subagent 執行 = 跳過獨立審查 HARD-GATE，屬 Process Violation，記入 Retro Problem
+
+**唯一 merge 執行者**：主 session（在獨立 QA subagent CONFIRM 後）。
+
+來源：Sprint 207 Retro A1（#2206）— Story-Lifecycle subagent 自行 merge PR 事件
+</HARD-GATE>
+
 **#976 AC-1：PR 建立是必要交付物（all model tiers）**
 
 無論本 subagent 由 haiku、sonnet 或 opus 派遣，PR 建立均為**必要交付物**，不可跳過。即使是 doc-only Story、小型修改、log 調整等，均**必須**執行 `gh pr create`。回傳時必須提供有效的 PR_URL，否則回傳 `ESCALATE: PR_MISSING`。


### PR DESCRIPTION
## Summary

- story-lifecycle-prompt.md 角色定義段落新增明確的 HARD-GATE 區塊
- 列出禁止 merge 的所有命令形式（gh pr merge --merge/--squash/任何形式）
- 補充 fallback 程序：若 QA 指示要 merge → ESCALATE: MERGE_REQUESTED_BY_SUBAGENT
- 強調唯一 merge 執行者為主 session（獨立 QA subagent CONFIRM 後）

## AC 驗收

- [x] AC1 補強「禁止自行 merge PR」條款（明確列出禁止條件與 fallback 程序）
- [x] AC2 PR merged to kctw-dev/shikigami main

## 來源

- seiryu/issues #2210（cross-repo task）
- Sprint 207 Retro A1（#2206）— Process Violation：Story-Lifecycle Subagent 自行 merge PR