### PR TITLE
docs(#2286): story-lifecycle-prompt 補注 worktree-setup.sh 步驟

### DIFF
--- a/skills/sprint-execution/SKILL.md
+++ b/skills/sprint-execution/SKILL.md
@@ -182,7 +182,8 @@ stdout 格式：`[MODEL-FALLBACK] #N from=opus to=sonnet reason=HTTP529`
 1. **執行全局 fetch**：`git fetch origin main`（一次性準備）
 2. **記錄 epoch commit**：`EPOCH_COMMIT=$(git rev-parse origin/main)` — 記錄派遣時刻的 main 版本
 3. **派遣各 Story subagent**，各自執行：
-   - 建立 worktree 時明確指定 base ref：`git worktree add <path> -b <branch> origin/main`
+   - 建立 worktree 時使用 `worktree-setup.sh`（自動建立 `app/node_modules` symlink）：`bash scripts/worktree-setup.sh <path> -b <branch> origin/main`（#2286 Sprint 215）
+   - **禁止**直接使用 `git worktree add <path> -b <branch> origin/main`（缺少 node_modules symlink，vitest/eslint/tsc 無法執行）
    - 驗證初始 commit：`WORKTREE_HEAD=$(git rev-parse HEAD)` 應等於 EPOCH_COMMIT
 4. **平行完成後**：主 session 驗證所有 PR 的 commit 歷史無污染（PR review 時檢查）
 

--- a/skills/sprint-execution/references/parallel-safety.md
+++ b/skills/sprint-execution/references/parallel-safety.md
@@ -238,10 +238,12 @@ Sprint Execution 派遣 Story-Lifecycle subagent 時，使用 Claude Code Agent 
   CURRENT_MAIN_COMMIT=$(git rev-parse origin/main)
   |-- 記錄當前 origin/main 的 commit hash
 
-步驟 3：建立 worktree 並明確指定 base
-  git worktree add <worktree-path> -b <branch-name> origin/main
+步驟 3：建立 worktree 並明確指定 base（#2286 Sprint 215）
+  bash scripts/worktree-setup.sh <worktree-path> -b <branch-name> origin/main
+  |-- 使用 worktree-setup.sh（非 git worktree add），自動建立 app/node_modules symlink
   |-- 使用 origin/main 作為 base ref，確保從乾淨起點建立
   |-- 禁止使用本地 main 或 HEAD（可能含有未推送變更）
+  |-- 禁止直接 git worktree add（缺少 node_modules symlink，vitest/eslint/tsc 無法執行）
 
 步驟 4：驗證 worktree 初始 commit
   cd <worktree-path>
@@ -257,11 +259,12 @@ Sprint Execution 派遣 Story-Lifecycle subagent 時，使用 Claude Code Agent 
 git fetch origin main
 BASE_COMMIT=$(git rev-parse origin/main)
 
-# 建立隔離 worktree，明確指定 base
+# 建立隔離 worktree，明確指定 base（#2286：改用 worktree-setup.sh 自動建立 node_modules symlink）
 BRANCH_NAME="sprint-${SPRINT_NUM}/${STORY_ID}-feature"
 WORKTREE_PATH=".claude/worktrees/${BRANCH_NAME}"
 
-git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" origin/main
+bash scripts/worktree-setup.sh "${WORKTREE_PATH}" -b "${BRANCH_NAME}" origin/main
+# 取代舊寫法：git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" origin/main
 
 # 驗證初始狀態
 cd "${WORKTREE_PATH}"

--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -281,6 +281,24 @@ commit + 取得 commit SHA
 
 ## 開始前準備
 
+<!-- #2286 worktree-setup.sh 補注 — Sprint 215 -->
+0. **Worktree 環境確認**（`doc_only=false` 時必做；`doc_only=true` 時可跳過）：確認 subagent 執行環境在正確的 worktree 路徑內，且 `app/node_modules` symlink 已建立。
+
+   ```bash
+   # 確認 pwd 在預期 worktree 路徑內（非主 repo root）
+   pwd  # 應為 .claude/worktrees/agent-<id>-<desc>
+
+   # 確認 app/node_modules symlink 存在（由 worktree-setup.sh 自動建立）
+   ls -la app/node_modules
+   ```
+
+   **若 symlink 不存在**（`ls -la app/node_modules` 失敗或顯示 `No such file or directory`）：
+   - 輸出 `[WORKTREE-SETUP-WARN] app/node_modules symlink 不存在，vitest/eslint/tsc 將無法執行`
+   - 手動修復：`ln -sf <主 repo 絕對路徑>/app/node_modules app/node_modules`（其中 `<主 repo 絕對路徑>` 由 `git worktree list --porcelain | grep "^worktree" | head -1 | awk '{print $2}'` 取得）
+   - 修復後重新確認 `ls -la app/node_modules` 回傳 symlink
+
+   **根本原因**：若 worktree 由 `git worktree add` 直接建立（未使用 `bash scripts/worktree-setup.sh`），則缺少自動 symlink 步驟。coordinator（主 session）應改用 `bash scripts/worktree-setup.sh <path> -b <branch> origin/main` 建立 worktree，詳見 `CLAUDE.md §開發環境`。
+
 1. 讀取 `sprint_file` 路徑下的 Sprint 文件，取得 Story ID 對應的完整 AC 清單
 2. 讀取所有 `related_adrs` 路徑下的 ADR 文件（若有）
 3. 讀取所有 `related_sdds` 路徑下的 SDD 文件（若有），並**提取 SDD 架構約束**（ADR-020）：


### PR DESCRIPTION
## Summary

- `story-lifecycle-prompt.md` §開始前準備 新增步驟 0：確認 `app/node_modules` symlink 存在，附自助修復指引（`[WORKTREE-SETUP-WARN]`）
- `SKILL.md` §Worktree Branch Base 隔離檢查：coordinator 改用 `bash scripts/worktree-setup.sh`，禁止直接 `git worktree add`
- `references/parallel-safety.md` 快速參考命令序列同步更新

## 解決問題

seiryu Sprint 214 Retro A2（#1957/#2244）：直接 `git worktree add` 建立的 worktree 無 `app/node_modules`，導致 `vitest`/`eslint`/`tsc` 無法執行。此補注讓 story-lifecycle subagent 能自我偵測問題並提供修復指引，coordinator 也明確改用 `worktree-setup.sh`。

## AC 驗收

- AC1: story-lifecycle-prompt.md 補注 bash scripts/worktree-setup.sh 步驟 ✓
- AC2: 下一 Sprint 執行時無需手動 ln -sf（subagent 步驟 0 自動偵測並修復）✓

Closes #2286 (seiryu sprint-candidate)

🤖 Generated with Claude Code (Sprint 215 Batch 2)