### PR TITLE
docs(#2287): Sprint Planning pre-implementation check 落地

### DIFF
--- a/skills/sprint-execution/story-lifecycle-prompt.md
+++ b/skills/sprint-execution/story-lifecycle-prompt.md
@@ -340,6 +340,25 @@ commit + 取得 commit SHA
    - **doc-only 路徑**：同樣必須執行三問，不因 doc_only=true 而豁免
    - **不取代 Spec Compliance self-review**：三問是前置檢查，不替代 §5 Spec Compliance 審查
 
+7.5 **Pre-Implementation Check（#2287 Sprint 215 Retro A2）**：在 TDD 開始前，確認 Story 功能是否已在過去 Sprint 中實作。**僅在 `doc_only=false` 且 `story_type ∈ {FEATURE, INTEGRATION, INFRA}` 時執行**；doc-only、RESEARCH、DESIGN 路徑豁免。
+
+   ```
+   步驟：
+   1. 搜尋 closed PRs / Issues（關鍵字來自 Story title 與主要 AC 函式名）：
+        gh pr list --search "<關鍵字>" --state merged --limit 10 --repo <OWNER_REPO>
+        gh issue list --search "<關鍵字>" --state closed --limit 10 --repo <OWNER_REPO>
+   2. grep 現有程式碼（AC 提到的主要函式/Component 名稱）：
+        grep -rn "<功能關鍵字>" app/  （或 scripts/）
+   3. 判斷結果 → 輸出 tag：
+        |-- 完整實作（所有 AC 已覆蓋）→ [PRE-IMPL-DONE] 回傳主 session，由主 session 重新界定 Story 範圍（改為 AC verification，doc_only=true）
+        |-- 部分實作（部分 AC 已覆蓋）→ [PRE-IMPL-PARTIAL] 輸出 AC gap 清單，繼續開發剩餘部分
+        +-- 未實作（未找到相關實作）→ [PRE-IMPL-CLEAR] 繼續正常 TDD 流程
+   ```
+
+   **[PRE-IMPL-DONE] 處理**：subagent 輸出 `[PRE-IMPL-DONE] 功能已完整實作於 PR#NNN / commit SHA`，回傳 ESCALATE: ALREADY_IMPLEMENTED 至主 session。**禁止**自行重新實作已存在的功能。
+
+   **gh 指令失敗降級**：若 `gh` 不可用，跳過步驟 1，僅執行步驟 2（grep），輸出 `[PRE-IMPL-SEARCH-DEGRADED]`。
+
 8. **Knowledge Ingestion via MCP（步驟 7.5，ADR-017）**：觸發條件：三問 (2) 含 API 相關 `[UNCERTAIN]` 項目，或 AC 含 API 文件 URL。完整執行邏輯（MCP 查詢、WebFetch fallback、ADR-006 防護）請 Read `skills/sprint-execution/SKILL.md §2.8`（ADR-017 實作細節）。CI=true 時跳過（輸出 `[KNOWLEDGE-INGESTION-SKIPPED: CI_ENV]`）。
 
 <!-- US-216 Knowledge Ingestion via MCP — Sprint 81, ADR-017 -->

--- a/skills/sprint-planning/references/architect-prompt.md
+++ b/skills/sprint-planning/references/architect-prompt.md
@@ -45,6 +45,40 @@ bash scripts/check-adr-conflict.sh docs/adr
 
 ---
 
+## Pre-Implementation Check（#2287 Sprint 215 Retro A2）
+
+<!-- #2287 Sprint Planning pre-implementation check — Sprint 215 -->
+
+**Architect 技術評估開始前**，對 PO 選取的每個 Story 執行 pre-implementation check：確認「此 Story 是否在過去 Sprint 中已部分或完整實作」。
+
+### Pre-Implementation Check 步驟
+
+```
+對每個 PO 選取的 Story：
+  1. 搜尋 closed + merged PRs / Issues：
+       gh pr list --search "<Story title keywords>" --state merged --limit 10
+       gh issue list --search "<Story title keywords>" --state closed --limit 10
+  2. 檢查現有程式碼路徑（grep Story AC 的關鍵函式/Component 名稱）
+  3. 判斷結果：
+       |-- 完整實作（AC 已全部覆蓋）→ [PRE-IMPL-DONE] Story 改為「AC verification Story」（doc_only=true）
+       |-- 部分實作（部分 AC 已覆蓋）→ [PRE-IMPL-PARTIAL] 標注已實作的 AC gap，PO 重新範圍界定
+       +-- 未實作 → [PRE-IMPL-CLEAR] 繼續正常技術評估流程
+```
+
+**輸出要求**：技術評估表格新增 `Pre-Impl` 欄位：
+
+| 值 | 意義 |
+|----|------|
+| `CLEAR` | 未找到既有實作，可正常開發 |
+| `PARTIAL: <說明>` | 部分已實作，標注 AC gap |
+| `DONE` | 完整已實作，改為 AC verification |
+
+**PO 決策觸發**（AC2）：
+- `[PRE-IMPL-DONE]` → PO 在 Sprint Planning 文件標注「已實作，改為 AC verification Story」，估點下修（≤ 0.25pt）
+- `[PRE-IMPL-PARTIAL]` → PO 重新評估 Story 範圍，僅列入 AC gap 部分
+
+---
+
 ## 技術評估
 
 對 PO 選取的每個 Story 進行技術可行性評估，給出 T-shirt size 估算（S/M/L），並檢查需要 ADR 的 Story 是否已有對應的 Accepted ADR。若涉及 API 互動的 Story，必須產出 API 契約（參閱 [Architect 角色決策指引 §7](../architect/SKILL.md)）。若發現 Hard Gate 問題，該 Story 退回 Backlog。詳細決策標準（估點策略、ADR 需求判斷、平行分群策略、API 契約產出）請參閱 [Architect 角色決策指引](../architect/SKILL.md)。
@@ -54,11 +88,11 @@ bash scripts/check-adr-conflict.sh docs/adr
 ```markdown
 ## 技術評估結果
 
-| Story | T-shirt | ADR 需求 | API 契約 | Related SDDs | 說明 |
-|-------|---------|---------|---------|-------------|------|
-| US-#N | M | 無需 ADR | **有**（見下方契約定義） | SDD-000 §3, SDD-001 §2 | {說明} |
-| US-#M | S | 無需 ADR | **無**（需補充，阻擋開發） | SDD-000 §5 | {說明} |
-| US-#K | S | 無需 ADR | **不適用** | — | doc-only，無架構涉及 |
+| Story | T-shirt | Pre-Impl | ADR 需求 | API 契約 | Related SDDs | 說明 |
+|-------|---------|----------|---------|---------|-------------|------|
+| US-#N | M | CLEAR | 無需 ADR | **有**（見下方契約定義） | SDD-000 §3, SDD-001 §2 | {說明} |
+| US-#M | S | PARTIAL: AC3 已覆蓋 | 無需 ADR | **無**（需補充，阻擋開發） | SDD-000 §5 | {說明} |
+| US-#K | S | CLEAR | 無需 ADR | **不適用** | — | doc-only，無架構涉及 |
 ```
 
 **API 契約欄位說明**：


### PR DESCRIPTION
## Summary

- `architect-prompt.md` 新增 §Pre-Implementation Check 區塊：Architect 技術評估前先確認 Story 是否已在過去 Sprint 實作（AC1）；表格新增 `Pre-Impl` 欄位輸出 CLEAR/PARTIAL/DONE
- `story-lifecycle-prompt.md` §開始前準備 步驟 7.5 補注：TDD 開始前執行 pre-implementation check，防止 story-lifecycle subagent 重複實作已存在的功能（AC3）
- PO 決策觸發：DONE → Story 改為 AC verification（估點下修），PARTIAL → 重新評估範圍（AC2）

## 解決問題

Sprint 214 Retro A2（#2287）：#2269 在 Sprint Planning 時未確認是否已實作，導致派工重複作業。此補注讓 Architect 和 story-lifecycle subagent 在開始前先確認功能是否已存在。

## AC 驗收

- AC1: Architect 技術評估階段新增 pre-implementation check ✓
- AC2: 已實作 → AC verification Story；部分實作 → AC gap 標注 ✓
- AC3: story-lifecycle-prompt.md §開始前準備 步驟 7.5 補注 pre-implementation check ✓

Closes #2287 (seiryu sprint-candidate)

🤖 Generated with Claude Code (Sprint 215 Batch 2, sequential after #2286)